### PR TITLE
Fix _ps_const_ty macro compile on non-x86

### DIFF
--- a/src/f32/funcs.rs
+++ b/src/f32/funcs.rs
@@ -8,6 +8,7 @@ use super::x86_utils::UnionCast;
 
 macro_rules! _ps_const_ty {
     ($name:ident, $field:ident, $x:expr) => {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         const $name: UnionCast = UnionCast {
             $field: [$x, $x, $x, $x],
         };


### PR DESCRIPTION
Was building for `wasm32-unknown-unknown` when I ran into this, but should be a fail on any non-x86 target. But easy fix!