### PR TITLE
Vec*Mask tests

### DIFF
--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -367,7 +367,8 @@ pub struct Vec2Mask(u32, u32);
 pub type Vec2b = Vec2Mask;
 
 impl Vec2Mask {
-    pub(crate) fn new(x: bool, y: bool) -> Self {
+    #[inline]
+    pub fn new(x: bool, y: bool) -> Self {
         const MASK: [u32; 2] = [0, 0xff_ff_ff_ff];
         Self(MASK[x as usize], MASK[y as usize])
     }

--- a/src/f32/vec3_f32.rs
+++ b/src/f32/vec3_f32.rs
@@ -370,7 +370,8 @@ impl Distribution<Vec3> for Standard {
 pub struct Vec3Mask(u32, u32, u32);
 
 impl Vec3Mask {
-    pub(crate) fn new(x: bool, y: bool, z: bool) -> Self {
+    #[inline]
+    pub fn new(x: bool, y: bool, z: bool) -> Self {
         const MASK: [u32; 2] = [0, 0xff_ff_ff_ff];
         Self(MASK[x as usize], MASK[y as usize], MASK[z as usize])
     }

--- a/src/f32/vec3_sse2.rs
+++ b/src/f32/vec3_sse2.rs
@@ -496,6 +496,19 @@ pub struct Vec3Mask(__m128);
 
 impl Vec3Mask {
     #[inline]
+    pub fn new(x: bool, y: bool, z: bool) -> Self {
+        const MASK: [u32; 2] = [0, 0xff_ff_ff_ff];
+        unsafe {
+            Self(_mm_set_ps(
+                f32::from_bits(MASK[z as usize]),
+                f32::from_bits(MASK[z as usize]),
+                f32::from_bits(MASK[y as usize]),
+                f32::from_bits(MASK[x as usize]),
+            ))
+        }
+    }
+
+    #[inline]
     #[deprecated(since = "0.7.1", note = "please use `bitmask` instead")]
     pub fn mask(self) -> u32 {
         self.bitmask()

--- a/src/f32/vec4_f32.rs
+++ b/src/f32/vec4_f32.rs
@@ -562,7 +562,8 @@ pub struct Vec4Mask(u32, u32, u32, u32);
 
 impl Vec4Mask {
     /// Creates a new `Vec4Mask`.
-    pub(crate) fn new(x: bool, y: bool, z: bool, w: bool) -> Self {
+    #[inline]
+    pub fn new(x: bool, y: bool, z: bool, w: bool) -> Self {
         const MASK: [u32; 2] = [0, 0xff_ff_ff_ff];
         Self(
             MASK[x as usize],

--- a/src/f32/vec4_sse2.rs
+++ b/src/f32/vec4_sse2.rs
@@ -604,6 +604,20 @@ impl Distribution<Vec4> for Standard {
 pub struct Vec4Mask(__m128);
 
 impl Vec4Mask {
+    /// Creates a new `Vec4Mask`.
+    #[inline]
+    pub fn new(x: bool, y: bool, z: bool, w: bool) -> Self {
+        const MASK: [u32; 2] = [0, 0xff_ff_ff_ff];
+        unsafe {
+            Self(_mm_set_ps(
+                f32::from_bits(MASK[w as usize]),
+                f32::from_bits(MASK[z as usize]),
+                f32::from_bits(MASK[y as usize]),
+                f32::from_bits(MASK[x as usize]),
+            ))
+        }
+    }
+
     #[inline]
     #[deprecated(since = "0.7.1", note = "please use `bitmask` instead")]
     pub fn mask(self) -> u32 {

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -193,6 +193,52 @@ fn test_vec2b() {
     assert!(b.cmpeq(Vec2::splat(1.0)).all());
 }
 
+#[test]
+fn test_vec2mask_bitmask() {
+    assert_eq!(Vec2Mask::new(false, false).bitmask(), 0b00);
+    assert_eq!(Vec2Mask::new(true, false).bitmask(),  0b01);
+    assert_eq!(Vec2Mask::new(false, true).bitmask(),  0b10);
+    assert_eq!(Vec2Mask::new(true, true).bitmask(),   0b11);
+}
+
+#[test]
+fn test_vec2mask_any() {
+    assert_eq!(Vec2Mask::new(false, false).any(), false);
+    assert_eq!(Vec2Mask::new(true, false).any(), true);
+    assert_eq!(Vec2Mask::new(false, true).any(), true);
+    assert_eq!(Vec2Mask::new(true, true).any(), true);
+}
+
+#[test]
+fn test_vec2mask_all() {
+    assert_eq!(Vec2Mask::new(false, false).all(), false);
+    assert_eq!(Vec2Mask::new(true, false).all(), false);
+    assert_eq!(Vec2Mask::new(false, true).all(), false);
+    assert_eq!(Vec2Mask::new(true, true).all(), true);
+}
+
+#[test]
+fn test_vec2mask_select() {
+    let a = Vec2::new(1.0, 2.0);
+    let b = Vec2::new(3.0, 4.0);
+    assert_eq!(
+        Vec2Mask::new(true, true).select(a, b),
+        Vec2::new(1.0, 2.0),
+    );
+    assert_eq!(
+        Vec2Mask::new(true, false).select(a, b),
+        Vec2::new(1.0, 4.0),
+    );
+    assert_eq!(
+        Vec2Mask::new(false, true).select(a, b),
+        Vec2::new(3.0, 2.0),
+    );
+    assert_eq!(
+        Vec2Mask::new(false, false).select(a, b),
+        Vec2::new(3.0, 4.0),
+    );
+}
+
 #[cfg(feature = "rand")]
 #[test]
 fn test_vec2_rand() {

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -223,6 +223,54 @@ fn test_vec3b() {
     assert!(b.cmpeq(Vec3::splat(1.0)).all());
 }
 
+#[test]
+fn test_vec3mask_bitmask() {
+    assert_eq!(Vec3Mask::new(false, false, false).bitmask(), 0b000);
+    assert_eq!(Vec3Mask::new(true, false, false).bitmask(),  0b001);
+    assert_eq!(Vec3Mask::new(false, true, true).bitmask(),   0b110);
+    assert_eq!(Vec3Mask::new(false, true, false).bitmask(),  0b010);
+    assert_eq!(Vec3Mask::new(true, false, true).bitmask(),   0b101);
+    assert_eq!(Vec3Mask::new(true, true, true).bitmask(),    0b111);
+}
+
+#[test]
+fn test_vec3mask_any() {
+    assert_eq!(Vec3Mask::new(false, false, false).any(), false);
+    assert_eq!(Vec3Mask::new(true, false, false).any(), true);
+    assert_eq!(Vec3Mask::new(false, true, false).any(), true);
+    assert_eq!(Vec3Mask::new(false, false, true).any(), true);
+}
+
+#[test]
+fn test_vec3mask_all() {
+    assert_eq!(Vec3Mask::new(true, true, true).all(), true);
+    assert_eq!(Vec3Mask::new(false, true, true).all(), false);
+    assert_eq!(Vec3Mask::new(true, false, true).all(), false);
+    assert_eq!(Vec3Mask::new(true, true, false).all(), false);
+}
+
+#[test]
+fn test_vec3mask_select() {
+    let a = Vec3::new(1.0, 2.0, 3.0);
+    let b = Vec3::new(4.0, 5.0, 6.0);
+    assert_eq!(
+        Vec3Mask::new(true, true, true).select(a, b),
+        Vec3::new(1.0, 2.0, 3.0),
+    );
+    assert_eq!(
+        Vec3Mask::new(true, false, true).select(a, b),
+        Vec3::new(1.0, 5.0, 3.0),
+    );
+    assert_eq!(
+        Vec3Mask::new(false, true, false).select(a, b),
+        Vec3::new(4.0, 2.0, 6.0),
+    );
+    assert_eq!(
+        Vec3Mask::new(false, false, false).select(a, b),
+        Vec3::new(4.0, 5.0, 6.0),
+    );
+}
+
 #[cfg(feature = "rand")]
 #[test]
 fn test_vec3_rand() {

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -257,6 +257,56 @@ fn test_vec4_sign() {
 //     assert_eq!(vec4(4.0, 4.0, 4.0, 4.0), a.dup_w());
 // }
 
+#[test]
+fn test_vec4mask_bitmask() {
+    assert_eq!(Vec4Mask::new(false, false, false, false).bitmask(), 0b0000);
+    assert_eq!(Vec4Mask::new(false, false, true, true).bitmask(),   0b1100);
+    assert_eq!(Vec4Mask::new(true, true, false, false).bitmask(),   0b0011);
+    assert_eq!(Vec4Mask::new(false, true, false, true).bitmask(),   0b1010);
+    assert_eq!(Vec4Mask::new(true, false, true, false).bitmask(),   0b0101);
+    assert_eq!(Vec4Mask::new(true, true, true, true).bitmask(),     0b1111);
+}
+
+#[test]
+fn test_vec4mask_any() {
+    assert_eq!(Vec4Mask::new(false, false, false, false).any(), false);
+    assert_eq!(Vec4Mask::new(true, false, false, false).any(), true);
+    assert_eq!(Vec4Mask::new(false, true, false, false).any(), true);
+    assert_eq!(Vec4Mask::new(false, false, true, false).any(), true);
+    assert_eq!(Vec4Mask::new(false, false, false, true).any(), true);
+}
+
+#[test]
+fn test_vec4mask_all() {
+    assert_eq!(Vec4Mask::new(true, true, true, true).all(), true);
+    assert_eq!(Vec4Mask::new(false, true, true, true).all(), false);
+    assert_eq!(Vec4Mask::new(true, false, true, true).all(), false);
+    assert_eq!(Vec4Mask::new(true, true, false, true).all(), false);
+    assert_eq!(Vec4Mask::new(true, true, true, false).all(), false);
+}
+
+#[test]
+fn test_vec4mask_select() {
+    let a = Vec4::new(1.0, 2.0, 3.0, 4.0);
+    let b = Vec4::new(5.0, 6.0, 7.0, 8.0);
+    assert_eq!(
+        Vec4Mask::new(true, true, true, true).select(a, b),
+        Vec4::new(1.0, 2.0, 3.0, 4.0),
+    );
+    assert_eq!(
+        Vec4Mask::new(true, false, true, false).select(a, b),
+        Vec4::new(1.0, 6.0, 3.0, 8.0),
+    );
+    assert_eq!(
+        Vec4Mask::new(false, true, false, true).select(a, b),
+        Vec4::new(5.0, 2.0, 7.0, 4.0),
+    );
+    assert_eq!(
+        Vec4Mask::new(false, false, false, false).select(a, b),
+        Vec4::new(5.0, 6.0, 7.0, 8.0),
+    );
+}
+
 #[cfg(feature = "serde")]
 #[test]
 fn test_vec4_serde() {


### PR DESCRIPTION
Added tests for the methods on `Vec4Mask`, `Vec3Mask`, and `Vec2Mask`.