### PR TITLE
Implement Mat2, Mat3 & Mat4 serialization

### DIFF
--- a/src/f32/glam_serde.rs
+++ b/src/f32/glam_serde.rs
@@ -116,10 +116,9 @@ impl Serialize for Mat4 {
     where
         S: Serializer,
     {
-        let f: &[f32; 16] = self.as_ref();
         let mut state = serializer.serialize_tuple_struct("Mat4", 16)?;
-        for i in 0..16 {
-            state.serialize_field(&f[i])?;
+        for f in self.as_ref() {
+            state.serialize_field(f)?;
         }
         state.end()
     }

--- a/src/f32/glam_serde.rs
+++ b/src/f32/glam_serde.rs
@@ -1,4 +1,4 @@
-use crate::{Quat, Vec2, Vec3, Vec4};
+use crate::{Quat, Vec2, Vec3, Vec4, Mat2, Mat3, Mat4};
 
 use serde::{
     de::{self, Deserialize, Deserializer, SeqAccess, Visitor},
@@ -69,6 +69,62 @@ impl Serialize for Quat {
         state.end()
     }
 }
+
+#[cfg(feature = "serde")]
+impl Serialize for Mat2 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let f: &[f32; 4] = self.as_ref();
+        let mut state = serializer.serialize_tuple_struct("Mat2", 4)?;
+        state.serialize_field(&f[0])?;
+        state.serialize_field(&f[1])?;
+        state.serialize_field(&f[2])?;
+        state.serialize_field(&f[3])?;
+        state.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Mat3 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let (m00, m01, m02) = self.x_axis.into();
+        let (m10, m11, m12) = self.y_axis.into();
+        let (m20, m21, m22) = self.z_axis.into();
+
+        let mut state = serializer.serialize_tuple_struct("Mat3", 9)?;
+        state.serialize_field(&m00)?;
+        state.serialize_field(&m01)?;
+        state.serialize_field(&m02)?;
+        state.serialize_field(&m10)?;
+        state.serialize_field(&m11)?;
+        state.serialize_field(&m12)?;
+        state.serialize_field(&m20)?;
+        state.serialize_field(&m21)?;
+        state.serialize_field(&m22)?;
+        state.end()
+    }
+}
+
+#[cfg(feature = "serde")]
+impl Serialize for Mat4 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let f: &[f32; 16] = self.as_ref();
+        let mut state = serializer.serialize_tuple_struct("Mat4", 16)?;
+        for i in 0..16 {
+            state.serialize_field(&f[i])?;
+        }
+        state.end()
+    }
+}
+
 impl<'de> Deserialize<'de> for Vec2 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -217,5 +273,116 @@ impl<'de> Deserialize<'de> for Quat {
         }
 
         deserializer.deserialize_tuple_struct("Quat", 4, QuatVisitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for Mat2 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Mat2Visitor;
+
+        // TODO: Not sure why this line is reported as uncovered
+        #[cfg_attr(tarpaulin, skip)]
+        impl<'de> Visitor<'de> for Mat2Visitor {
+            type Value = Mat2;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Mat2")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Mat2, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let mut f = { [0.0; 4] };
+                for i in 0..4 {
+                    f[i] = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(i, &self))?;
+                }
+                let x = Vec2::new(f[0], f[1]);
+                let y = Vec2::new(f[2], f[3]);
+                Ok(Mat2::new(x, y))
+            }
+        }
+
+        deserializer.deserialize_tuple_struct("Mat2", 4, Mat2Visitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for Mat3 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Mat3Visitor;
+
+        // TODO: Not sure why this line is reported as uncovered
+        #[cfg_attr(tarpaulin, skip)]
+        impl<'de> Visitor<'de> for Mat3Visitor {
+            type Value = Mat3;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Mat3")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Mat3, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let mut f = { [0.0; 9] };
+                for i in 0..9 {
+                    f[i] = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(i, &self))?;
+                }
+                let x = Vec3::new(f[0], f[1], f[2]);
+                let y = Vec3::new(f[3], f[4], f[5]);
+                let z = Vec3::new(f[6], f[7], f[8]);
+                Ok(Mat3::new(x, y, z))
+            }
+        }
+
+        deserializer.deserialize_tuple_struct("Mat3", 9, Mat3Visitor)
+    }
+}
+
+impl<'de> Deserialize<'de> for Mat4 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct Mat4Visitor;
+
+        // TODO: Not sure why this line is reported as uncovered
+        #[cfg_attr(tarpaulin, skip)]
+        impl<'de> Visitor<'de> for Mat4Visitor {
+            type Value = Mat4;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("struct Mat4")
+            }
+
+            fn visit_seq<V>(self, mut seq: V) -> Result<Mat4, V::Error>
+            where
+                V: SeqAccess<'de>,
+            {
+                let mut f = { [0.0; 16] };
+                for i in 0..16 {
+                    f[i] = seq
+                        .next_element()?
+                        .ok_or_else(|| de::Error::invalid_length(i, &self))?;
+                }
+                let x = Vec4::new(f[0], f[1], f[2], f[3]);
+                let y = Vec4::new(f[4], f[5], f[6], f[7]);
+                let z = Vec4::new(f[8], f[9], f[10], f[11]);
+                let w = Vec4::new(f[12], f[13], f[14], f[15]);
+                Ok(Mat4::new(x, y, z, w))
+            }
+        }
+
+        deserializer.deserialize_tuple_struct("Mat4", 16, Mat4Visitor)
     }
 }

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -134,3 +134,25 @@ fn test_mat2_ops() {
     assert_ulps_eq!(Mat2::from([[1.0, 2.0], [3.0, 4.0]]), m0 * Mat2::identity());
     assert_ulps_eq!(Mat2::from([[1.0, 2.0], [3.0, 4.0]]), Mat2::identity() * m0);
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_mat2_serde() {
+    let a = Mat2::new(vec2(1.0, 2.0), vec2(3.0, 4.0));
+    let serialized = serde_json::to_string(&a).unwrap();
+    assert_eq!(serialized, "[1.0,2.0,3.0,4.0]");
+    let deserialized = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(a, deserialized);
+    let deserialized = serde_json::from_str::<Mat2>("[]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat2>("[1.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat2>("[1.0,2.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat2>("[1.0,2.0,3.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat2>("[1.0,2.0,3.0,4.0,5.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat2>("[[1.0,2.0],[3.0,4.0]]");
+    assert!(deserialized.is_err());
+}

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -189,3 +189,29 @@ fn test_mat3_ops() {
     assert_ulps_eq!(m0, m0 * Mat3::identity());
     assert_ulps_eq!(m0, Mat3::identity() * m0);
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_mat3_serde() {
+    let a = Mat3::new(
+        vec3(1.0, 2.0, 3.0),
+        vec3(4.0, 5.0, 6.0),
+        vec3(7.0, 8.0, 9.0),
+    );
+    let serialized = serde_json::to_string(&a).unwrap();
+    assert_eq!(serialized, "[1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0]");
+    let deserialized = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(a, deserialized);
+    let deserialized = serde_json::from_str::<Mat3>("[]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat3>("[1.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat3>("[1.0,2.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat3>("[1.0,2.0,3.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat3>("[1.0,2.0,3.0,4.0,5.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat3>("[[1.0,2.0,3.0],[4.0,5.0,6.0],[7.0,8.0,9.0]]");
+    assert!(deserialized.is_err());
+}

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -269,3 +269,37 @@ fn test_mat4_ops() {
     assert_ulps_eq!(m0, m0 * Mat4::identity());
     assert_ulps_eq!(m0, Mat4::identity() * m0);
 }
+
+#[cfg(feature = "serde")]
+#[test]
+fn test_mat4_serde() {
+    let a = Mat4::new(
+        vec4(1.0, 2.0, 3.0, 4.0),
+        vec4(5.0, 6.0, 7.0, 8.0),
+        vec4(9.0, 10.0, 11.0, 12.0),
+        vec4(13.0, 14.0, 15.0, 16.0),
+    );
+    let serialized = serde_json::to_string(&a).unwrap();
+    assert_eq!(
+        serialized,
+        "[1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0,10.0,11.0,12.0,13.0,14.0,15.0,16.0]"
+    );
+    let deserialized = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(a, deserialized);
+    let deserialized = serde_json::from_str::<Mat4>("[]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat4>("[1.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat4>("[1.0,2.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat4>("[1.0,2.0,3.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat4>("[1.0,2.0,3.0,4.0,5.0]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat4>("[[1.0,2.0,3.0],[4.0,5.0,6.0],[7.0,8.0,9.0]]");
+    assert!(deserialized.is_err());
+    let deserialized = serde_json::from_str::<Mat4>(
+        "[[1.0,2.0,3.0,4.0],[5.0,6.0,7.0,8.0],[9.0,10.0,11.0,12.0][13.0,14.0,15.0,16.0]]",
+    );
+    assert!(deserialized.is_err());
+}


### PR DESCRIPTION
Fixes #17.

This explicitly implements serialization and deserialization of the matrix types and does it as flat tuples, which is the same approach `nalgebra-glm` has.

Brought over the tests that @bitshifter did on his branch https://github.com/bitshifter/glam-rs/commit/ae35ffc7a793f517288369d685e6e1117c96f2af as well but adapted them to the flat tuple serialization