### PR TITLE
Update rand 0.7 & criterion 0.4 and disable OS random number generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ rand = { version = "0.7", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
-criterion = "0.2"
+criterion = "0.3"
 rand_xoshiro = "0.4"
 serde_json = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,12 +34,12 @@ transform-types = []
 # TODO: make this dev only
 approx = { version = "0.3", optional = true, default-features = false }
 mint = { version = "0.5", optional = true, default-features = false  }
-rand = { version = "0.6", optional = true }
+rand = { version = "0.7", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
 [dev-dependencies]
 criterion = "0.2"
-rand_xoshiro = "0.1"
+rand_xoshiro = "0.4"
 serde_json = "1.0"
 
 [[bench]]

--- a/tests/angle.rs
+++ b/tests/angle.rs
@@ -1,6 +1,10 @@
 use approx::assert_ulps_eq;
 use glam::f32::{deg, rad, Angle};
 use std::f32::consts;
+#[cfg(feature = "rand")]
+use rand::{Rng, SeedableRng};
+#[cfg(feature = "rand")]
+use rand_xoshiro::Xoshiro256Plus;
 
 #[test]
 fn test_angle() {
@@ -47,8 +51,7 @@ fn test_angle() {
 #[cfg(feature = "rand")]
 #[test]
 fn test_angle_rnd() {
-    use rand::Rng;
-    let mut rng = rand::thread_rng();
+    let mut rng = Xoshiro256Plus::seed_from_u64(0);
     let a: Angle = rng.gen();
     assert!(a >= rad(0.0));
     assert!(a < rad(std::f32::consts::PI * 2.0));


### PR DESCRIPTION
Disabled default features on `rand` to avoid pulling in things that are not needed, such as the OS random number generator in `getrandom`. 

Want to be able to build for `wasm32-unknown-unknown` without having this pulled in because if called it will just panic (as there is no OS).

Unfortunately I think in practice due to `criterion` using `rand` with all features it will enable all features here also even though `criterion` is just a dev-dependency. But that is a separate cargo issue for now.

And good to use latest `rand` 0.7 anyway with minimal features.

And I do agree with #6 that ideally both `rand` and `approx` should be disabled by default. 