### PR TITLE
Fix Mat4::look_at_lh/rh

### DIFF
--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -390,7 +390,7 @@ impl Mat4 {
     fn look_to_lh(eye: Vec3, dir: Vec3, up: Vec3) -> Self {
         let f = dir.normalize();
         let s = up.cross(f).normalize();
-        let u = f.cross(s).normalize();
+        let u = f.cross(s);
         let (fx, fy, fz) = f.into();
         let (sx, sy, sz) = s.into();
         let (ux, uy, uz) = u.into();

--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -389,17 +389,17 @@ impl Mat4 {
     // TODO: make public at some point
     fn look_to_lh(eye: Vec3, dir: Vec3, up: Vec3) -> Self {
         let f = dir.normalize();
+        let s = up.cross(f).normalize();
+        let u = f.cross(s).normalize();
         let (fx, fy, fz) = f.into();
-        let s = f.cross(up);
         let (sx, sy, sz) = s.into();
-        let u = s.cross(f);
         let (ux, uy, uz) = u.into();
-        Self {
-            x_axis: Vec4::new(sx, ux, -fx, 0.0),
-            y_axis: Vec4::new(sy, uy, -fy, 0.0),
-            z_axis: Vec4::new(sz, uz, -fz, 0.0),
-            w_axis: Vec4::new(-s.dot(eye), -u.dot(eye), f.dot(eye), 1.0),
-        }
+        Mat4::new(
+            Vec4::new(sx, ux, fx, 0.0),
+            Vec4::new(sy, uy, fy, 0.0),
+            Vec4::new(sz, uz, fz, 0.0),
+            Vec4::new(-s.dot(eye), -u.dot(eye), -f.dot(eye), 1.0),
+        )
     }
 
     #[inline]

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -249,8 +249,8 @@ fn test_mat4_look_at() {
     let lh = Mat4::look_at_lh(eye, center, up);
     let rh = Mat4::look_at_rh(eye, center, up);
     let point = Vec3::new(1.0, 0.0, 0.0);
-    assert_ulps_eq!(lh.transform_point3(point), Vec3::new(0.0, 1.0, -5.0));
-    assert_ulps_eq!(rh.transform_point3(point), Vec3::new(0.0, 1.0, 5.0));
+    assert_ulps_eq!(lh.transform_point3(point), Vec3::new(0.0, 1.0, 5.0));
+    assert_ulps_eq!(rh.transform_point3(point), Vec3::new(0.0, 1.0, -5.0));
 }
 
 #[test]


### PR DESCRIPTION
The `Mat4::look_at_lh` implementation was a broken with lacking normalization, doing the cross products in the wrong order and some flips. 

I'm not 100% sure if this is correct but with these fixes it matches the behavior of `glm::look_at_rh` and also the implementation in DirectXMath `XMMatrixLookToLH`, though I've only in practice tested the right-handed version as that is what we use.