### PR TITLE
Mat4::from_scale(Vec3): Do not assert any zero scale component, only on all zero

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/*.rs.bk
 Cargo.lock
 Session.vim
+.cargo-ok

--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -273,7 +273,7 @@ impl Mat4 {
 
     #[inline]
     pub fn from_scale(scale: Vec3) -> Self {
-        glam_assert!(scale.cmpne(Vec3::zero()).all());
+        glam_assert!(scale.cmpne(Vec3::zero()).any()); // Do not panic as long as any component is non-zero
         let (x, y, z) = scale.into();
         Self {
             x_axis: Vec4::new(x, 0.0, 0.0, 0.0),


### PR DESCRIPTION
I think default panic on any zero scale component is too opiniated.
It can be valid to squash along an axis, e.g for UI.
For the Z special case, from_scale(Vec2) could be defined, with scale.z = 0 or 1.

P.S: Feel free to merge without history
(Triggered by iced/wgpu:hidpi-support)