### PR TITLE
Add #[repr(C)] to a few types that were missing it. 

### DIFF
--- a/src/f32/mat2.rs
+++ b/src/f32/mat2.rs
@@ -30,6 +30,7 @@ pub fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
 
 /// A 2x2 column major matrix.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[repr(C)]
 pub struct Mat2(pub(crate) Vec4);
 
 impl Default for Mat2 {

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -59,6 +59,7 @@ fn quat_to_axes(rotation: Quat) -> (Vec3, Vec3, Vec3) {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[repr(C)]
 pub struct Mat3 {
     pub(crate) x_axis: Vec3,
     pub(crate) y_axis: Vec3,

--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -60,6 +60,7 @@ fn quat_to_axes(rotation: Quat) -> (Vec4, Vec4, Vec4) {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[repr(C)]
 pub struct Mat4 {
     pub(crate) x_axis: Vec4,
     pub(crate) y_axis: Vec4,

--- a/src/f32/transform.rs
+++ b/src/f32/transform.rs
@@ -8,6 +8,7 @@ use rand::{
 };
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[repr(C)]
 pub struct TransformSRT {
     pub scale: Vec3,
     pub rotation: Quat,
@@ -26,6 +27,7 @@ impl Default for TransformSRT {
 }
 
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
+#[repr(C)]
 pub struct TransformRT {
     pub rotation: Quat,
     pub translation: Vec3,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,10 @@ SIMD support can be disabled entirely using the `scalar-math` feature. This
 feature will also disable SIMD alignment meaning most types will use native
 `f32` alignment of 4 bytes.
 
+All the main `glam` types are tagged with #[repr(C)], so they are possible
+to expose as struct members to C interfaces if desired. Be mindful of Vec3's
+extra float though.
+
 ## Accessing internal data
 
 The SIMD types that `glam` builds on are opaque and their contents are not


### PR DESCRIPTION
Also adds a small comment in the docs.