### PR TITLE
Add cargo-deny GitHub CI action

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,8 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: EmbarkStudios/cargo-deny-action@v0

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,20 @@
+[bans]
+multiple-versions = "deny"
+deny = []
+skip = [
+    # criterion uses old 0.3, glam uses 0.4
+    { name = "rand_xoshiro", version = "=0.3" },
+    # serde_json uses old 0.2 instead of 1.0
+    { name = "ryu", version = "=0.2" },
+]
+
+[licenses]
+unlicensed = "deny"
+allow = [
+    "Apache-2.0",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+    "MPL-2.0",
+]


### PR DESCRIPTION
To verify all dependencies are using permissible licenses and that there are no duplicate versions of dependencies.

For a small crate like this it is likely not super useful, but hoping it could help a bit and is easy to set up and use.

For more info: 
https://github.com/EmbarkStudios/cargo-deny
https://github.com/EmbarkStudios/cargo-deny-action