### PR TITLE
Added Mat4::to_scale_rotation_translation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ rust:
 # cache: cargo
 
 env:
-  - CARGO_FEATURES="mint rand serde debug-glam-assert"
-  - CARGO_FEATURES="mint rand serde scalar-math debug-glam-assert"
+  - CARGO_FEATURES="mint rand serde debug-glam-assert transform-types"
+  - CARGO_FEATURES="mint rand serde scalar-math debug-glam-assert transform-types"
 
 matrix:
   allow_failures:
@@ -31,7 +31,7 @@ script:
   - cargo clean
   - cargo build --features "$CARGO_FEATURES"
   - cargo test --features "$CARGO_FEATURES"
-  - cargo bench --features "$CARGO_FEATURES transform-types" --no-run
+  - cargo bench --features "$CARGO_FEATURES" --no-run
 
 after_success: |
   if [[ "$TRAVIS_RUST_VERSION" == nightly ]]; then

--- a/src/f32/mat2.rs
+++ b/src/f32/mat2.rs
@@ -150,31 +150,29 @@ impl Mat2 {
         Vec2::new(x, y)
     }
 
-    #[allow(dead_code)]
-    #[inline]
-    pub(crate) fn col(&self, index: usize) -> Vec2 {
-        match index {
-            0 => self.x_axis(),
-            1 => self.y_axis(),
-            _ => panic!(
-                "index out of bounds: the len is 2 but the index is {}",
-                index
-            ),
-        }
-    }
+    // #[inline]
+    // pub(crate) fn col(&self, index: usize) -> Vec2 {
+    //     match index {
+    //         0 => self.x_axis(),
+    //         1 => self.y_axis(),
+    //         _ => panic!(
+    //             "index out of bounds: the len is 2 but the index is {}",
+    //             index
+    //         ),
+    //     }
+    // }
 
-    #[allow(dead_code)]
-    #[inline]
-    pub(crate) fn col_mut(&mut self, index: usize) -> &mut Vec2 {
-        match index {
-            0 => unsafe { &mut *(self.0.as_mut().as_mut_ptr() as *mut Vec2) },
-            1 => unsafe { &mut *(self.0.as_mut()[2..].as_mut_ptr() as *mut Vec2) },
-            _ => panic!(
-                "index out of bounds: the len is 2 but the index is {}",
-                index
-            ),
-        }
-    }
+    // #[inline]
+    // pub(crate) fn col_mut(&mut self, index: usize) -> &mut Vec2 {
+    //     match index {
+    //         0 => unsafe { &mut *(self.0.as_mut().as_mut_ptr() as *mut Vec2) },
+    //         1 => unsafe { &mut *(self.0.as_mut()[2..].as_mut_ptr() as *mut Vec2) },
+    //         _ => panic!(
+    //             "index out of bounds: the len is 2 but the index is {}",
+    //             index
+    //         ),
+    //     }
+    // }
 
     /// Returns the transpose of `self`.
     #[inline]

--- a/src/f32/mat2.rs
+++ b/src/f32/mat2.rs
@@ -150,6 +150,32 @@ impl Mat2 {
         Vec2::new(x, y)
     }
 
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn col(&self, index: usize) -> Vec2 {
+        match index {
+            0 => self.x_axis(),
+            1 => self.y_axis(),
+            _ => panic!(
+                "index out of bounds: the len is 2 but the index is {}",
+                index
+            ),
+        }
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn col_mut(&mut self, index: usize) -> &mut Vec2 {
+        match index {
+            0 => unsafe { &mut *(self.0.as_mut().as_mut_ptr() as *mut Vec2) },
+            1 => unsafe { &mut *(self.0.as_mut()[2..].as_mut_ptr() as *mut Vec2) },
+            _ => panic!(
+                "index out of bounds: the len is 2 but the index is {}",
+                index
+            ),
+        }
+    }
+
     /// Returns the transpose of `self`.
     #[inline]
     pub fn transpose(&self) -> Self {

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -281,6 +281,34 @@ impl Mat3 {
         self.z_axis
     }
 
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn col(&self, index: usize) -> Vec3 {
+        match index {
+            0 => self.x_axis,
+            1 => self.y_axis,
+            2 => self.z_axis,
+            _ => panic!(
+                "index out of bounds: the len is 3 but the index is {}",
+                index
+            ),
+        }
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn col_mut(&mut self, index: usize) -> &mut Vec3 {
+        match index {
+            0 => &mut self.x_axis,
+            1 => &mut self.y_axis,
+            2 => &mut self.z_axis,
+            _ => panic!(
+                "index out of bounds: the len is 3 but the index is {}",
+                index
+            ),
+        }
+    }
+
     /// Returns the transpose of `self`.
     #[inline]
     pub fn transpose(&self) -> Self {

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -281,33 +281,31 @@ impl Mat3 {
         self.z_axis
     }
 
-    #[allow(dead_code)]
-    #[inline]
-    pub(crate) fn col(&self, index: usize) -> Vec3 {
-        match index {
-            0 => self.x_axis,
-            1 => self.y_axis,
-            2 => self.z_axis,
-            _ => panic!(
-                "index out of bounds: the len is 3 but the index is {}",
-                index
-            ),
-        }
-    }
+    // #[inline]
+    // pub(crate) fn col(&self, index: usize) -> Vec3 {
+    //     match index {
+    //         0 => self.x_axis,
+    //         1 => self.y_axis,
+    //         2 => self.z_axis,
+    //         _ => panic!(
+    //             "index out of bounds: the len is 3 but the index is {}",
+    //             index
+    //         ),
+    //     }
+    // }
 
-    #[allow(dead_code)]
-    #[inline]
-    pub(crate) fn col_mut(&mut self, index: usize) -> &mut Vec3 {
-        match index {
-            0 => &mut self.x_axis,
-            1 => &mut self.y_axis,
-            2 => &mut self.z_axis,
-            _ => panic!(
-                "index out of bounds: the len is 3 but the index is {}",
-                index
-            ),
-        }
-    }
+    // #[inline]
+    // pub(crate) fn col_mut(&mut self, index: usize) -> &mut Vec3 {
+    //     match index {
+    //         0 => &mut self.x_axis,
+    //         1 => &mut self.y_axis,
+    //         2 => &mut self.z_axis,
+    //         _ => panic!(
+    //             "index out of bounds: the len is 3 but the index is {}",
+    //             index
+    //         ),
+    //     }
+    // }
 
     /// Returns the transpose of `self`.
     #[inline]

--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -194,8 +194,91 @@ impl Mat4 {
 
     /// Returns a scale, rotation and translation extracted from the Mat4.
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
+        // const EPSILON: f32 = 0.0001;
+        // const CANONICAL_BASIS: [[f32; 3]; 3] = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
+        // let rank = |[x, y, z]: [f32; 3]| -> (usize, usize, usize) {
+        //     if x < y {
+        //         if y < z {
+        //             (2, 1, 0)
+        //         } else {
+        //             if x < z {
+        //                 (1, 2, 0)
+        //             } else {
+        //                 (1, 0, 2)
+        //             }
+        //         }
+        //     } else {
+        //         if x < z {
+        //             (2, 0, 1)
+        //         } else {
+        //             if y < z {
+        //                 (0, 2, 1)
+        //             } else {
+        //                 (0, 1, 2)
+        //             }
+        //         }
+        //     }
+        // };
+
+        // let mut basis = Mat3::from_cols(
+        //     self.x_axis.truncate(),
+        //     self.y_axis.truncate(),
+        //     self.z_axis.truncate(),
+        // );
+
+        // let mut scales = [
+        //     self.x_axis.length(),
+        //     self.y_axis.length(),
+        //     self.z_axis.length(),
+        // ];
+
+        // let (a, b, c) = rank(scales);
+
+        // if scales[a] < EPSILON {
+        //     *basis.col_mut(a) = CANONICAL_BASIS[a].into();
+        // } else {
+        //     let basis_a = basis.col_mut(a);
+        //     *basis_a = basis_a.normalize();
+        // }
+
+        // if scales[b] < EPSILON {
+        //     let basis_a = basis.col(a);
+        //     let abs_basis_a = basis_a.abs();
+        //     let (_, _, cc) = rank(abs_basis_a.into());
+        //     *basis.col_mut(b) = basis_a.cross(CANONICAL_BASIS[cc].into());
+        // } else {
+        //     let basis_b = basis.col_mut(b);
+        //     *basis_b = basis_b.normalize();
+        // }
+
+        // if scales[c] < EPSILON {
+        //     *basis.col_mut(c) = basis.col(a).cross(basis.col(b));
+        // } else {
+        //     let basis_c = basis.col_mut(c);
+        //     *basis_c = basis_c.normalize();
+        // }
+
+        // // TODO: det of basis matrix
+        // let det = basis.determinant();
+        // // glam_assert!(det != 0.0);
+
+        // if det < 0.0 {
+        //     scales[a] = -scales[a];
+        //     *basis.col_mut(a) = -basis.col(a);
+        //     // TODO: check for error
+        //     // det = -det;
+        // }
+
+        // // det = det - 1.0;
+        // // det = det * det;
+
+        // let scale = scales.into();
+        // let translation = self.w_axis.truncate();
+        // let rotation = Quat::from_rotation_mat3(&basis);
+        // (scale, rotation, translation)
+
         let det = self.determinant();
-        glam_assert!(det != 0.0);
+        glam_assert!(deg != 0.0);
 
         let scale = Vec3::new(
             self.x_axis.length() * det.signum(),
@@ -362,6 +445,36 @@ impl Mat4 {
     #[inline]
     pub fn w_axis(&self) -> Vec4 {
         self.w_axis
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn col(&self, index: usize) -> Vec4 {
+        match index {
+            0 => self.x_axis,
+            1 => self.y_axis,
+            2 => self.z_axis,
+            3 => self.w_axis,
+            _ => panic!(
+                "index out of bounds: the len is 4 but the index is {}",
+                index
+            ),
+        }
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    pub(crate) fn col_mut(&mut self, index: usize) -> &mut Vec4 {
+        match index {
+            0 => &mut self.x_axis,
+            1 => &mut self.y_axis,
+            2 => &mut self.z_axis,
+            3 => &mut self.w_axis,
+            _ => panic!(
+                "index out of bounds: the len is 4 but the index is {}",
+                index
+            ),
+        }
     }
 
     /// Returns the transpose of `self`.

--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -196,7 +196,7 @@ impl Mat4 {
     /// be a 4x4 homogeneous transformation matrix otherwise the output will be invalid.
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
         let det = self.determinant();
-        glam_assert!(deg != 0.0);
+        glam_assert!(det != 0.0);
 
         let scale = Vec3::new(
             self.x_axis.length() * det.signum(),

--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -192,91 +192,9 @@ impl Mat4 {
         }
     }
 
-    /// Returns a scale, rotation and translation extracted from the Mat4.
+    /// Extracts `scale`, `rotation` and `translation` from `self`. The input matrix is expected to
+    /// be a 4x4 homogeneous transformation matrix otherwise the output will be invalid.
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
-        // const EPSILON: f32 = 0.0001;
-        // const CANONICAL_BASIS: [[f32; 3]; 3] = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
-        // let rank = |[x, y, z]: [f32; 3]| -> (usize, usize, usize) {
-        //     if x < y {
-        //         if y < z {
-        //             (2, 1, 0)
-        //         } else {
-        //             if x < z {
-        //                 (1, 2, 0)
-        //             } else {
-        //                 (1, 0, 2)
-        //             }
-        //         }
-        //     } else {
-        //         if x < z {
-        //             (2, 0, 1)
-        //         } else {
-        //             if y < z {
-        //                 (0, 2, 1)
-        //             } else {
-        //                 (0, 1, 2)
-        //             }
-        //         }
-        //     }
-        // };
-
-        // let mut basis = Mat3::from_cols(
-        //     self.x_axis.truncate(),
-        //     self.y_axis.truncate(),
-        //     self.z_axis.truncate(),
-        // );
-
-        // let mut scales = [
-        //     self.x_axis.length(),
-        //     self.y_axis.length(),
-        //     self.z_axis.length(),
-        // ];
-
-        // let (a, b, c) = rank(scales);
-
-        // if scales[a] < EPSILON {
-        //     *basis.col_mut(a) = CANONICAL_BASIS[a].into();
-        // } else {
-        //     let basis_a = basis.col_mut(a);
-        //     *basis_a = basis_a.normalize();
-        // }
-
-        // if scales[b] < EPSILON {
-        //     let basis_a = basis.col(a);
-        //     let abs_basis_a = basis_a.abs();
-        //     let (_, _, cc) = rank(abs_basis_a.into());
-        //     *basis.col_mut(b) = basis_a.cross(CANONICAL_BASIS[cc].into());
-        // } else {
-        //     let basis_b = basis.col_mut(b);
-        //     *basis_b = basis_b.normalize();
-        // }
-
-        // if scales[c] < EPSILON {
-        //     *basis.col_mut(c) = basis.col(a).cross(basis.col(b));
-        // } else {
-        //     let basis_c = basis.col_mut(c);
-        //     *basis_c = basis_c.normalize();
-        // }
-
-        // // TODO: det of basis matrix
-        // let det = basis.determinant();
-        // // glam_assert!(det != 0.0);
-
-        // if det < 0.0 {
-        //     scales[a] = -scales[a];
-        //     *basis.col_mut(a) = -basis.col(a);
-        //     // TODO: check for error
-        //     // det = -det;
-        // }
-
-        // // det = det - 1.0;
-        // // det = det * det;
-
-        // let scale = scales.into();
-        // let translation = self.w_axis.truncate();
-        // let rotation = Quat::from_rotation_mat3(&basis);
-        // (scale, rotation, translation)
-
         let det = self.determinant();
         glam_assert!(deg != 0.0);
 
@@ -447,35 +365,33 @@ impl Mat4 {
         self.w_axis
     }
 
-    #[allow(dead_code)]
-    #[inline]
-    pub(crate) fn col(&self, index: usize) -> Vec4 {
-        match index {
-            0 => self.x_axis,
-            1 => self.y_axis,
-            2 => self.z_axis,
-            3 => self.w_axis,
-            _ => panic!(
-                "index out of bounds: the len is 4 but the index is {}",
-                index
-            ),
-        }
-    }
+    // #[inline]
+    // pub(crate) fn col(&self, index: usize) -> Vec4 {
+    //     match index {
+    //         0 => self.x_axis,
+    //         1 => self.y_axis,
+    //         2 => self.z_axis,
+    //         3 => self.w_axis,
+    //         _ => panic!(
+    //             "index out of bounds: the len is 4 but the index is {}",
+    //             index
+    //         ),
+    //     }
+    // }
 
-    #[allow(dead_code)]
-    #[inline]
-    pub(crate) fn col_mut(&mut self, index: usize) -> &mut Vec4 {
-        match index {
-            0 => &mut self.x_axis,
-            1 => &mut self.y_axis,
-            2 => &mut self.z_axis,
-            3 => &mut self.w_axis,
-            _ => panic!(
-                "index out of bounds: the len is 4 but the index is {}",
-                index
-            ),
-        }
-    }
+    // #[inline]
+    // pub(crate) fn col_mut(&mut self, index: usize) -> &mut Vec4 {
+    //     match index {
+    //         0 => &mut self.x_axis,
+    //         1 => &mut self.y_axis,
+    //         2 => &mut self.z_axis,
+    //         3 => &mut self.w_axis,
+    //         _ => panic!(
+    //             "index out of bounds: the len is 4 but the index is {}",
+    //             index
+    //         ),
+    //     }
+    // }
 
     /// Returns the transpose of `self`.
     #[inline]

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -244,12 +244,14 @@ fn test_mat4_inverse() {
 
 #[test]
 fn test_mat4_decompose() {
+    // identity
     let (out_scale, out_rotation, out_translation) =
         Mat4::identity().to_scale_rotation_translation();
     assert_approx_eq!(Vec3::one(), out_scale);
     assert!(out_rotation.is_near_identity());
     assert_approx_eq!(Vec3::zero(), out_translation);
 
+    // no scale
     let in_scale = Vec3::one();
     let in_translation = Vec3::new(-2.0, 4.0, -0.125);
     let in_rotation = Quat::from_rotation_ypr(
@@ -257,35 +259,59 @@ fn test_mat4_decompose() {
         f32::to_radians(180.0),
         f32::to_radians(270.0),
     );
-    let (out_scale, out_rotation, out_translation) =
-        Mat4::from_scale_rotation_translation(in_scale, in_rotation, in_translation)
-            .to_scale_rotation_translation();
-    assert_approx_eq!(in_scale, out_scale, 1e6);
-    // quat rotation might be in opposite direction
-    // TODO: can decompose handle that?
+    let in_mat = Mat4::from_scale_rotation_translation(in_scale, in_rotation, in_translation);
+    let (out_scale, out_rotation, out_translation) = in_mat.to_scale_rotation_translation();
+    assert_approx_eq!(in_scale, out_scale, 1e-6);
+    // out_rotation is different but produces the same matrix
+    // assert_approx_eq!(in_rotation, out_rotation);
+    assert_approx_eq!(in_translation, out_translation);
     assert_approx_eq!(
-        in_rotation * Vec3::unit_x(),
-        out_rotation * Vec3::unit_x(),
-        1e6
+        in_mat,
+        Mat4::from_scale_rotation_translation(out_scale, out_rotation, out_translation),
+        1e-6
     );
-    assert_approx_eq!(in_translation, out_translation);
 
-    let in_scale = Vec3::new(-1.0, -2.0, 4.0);
-    let (out_scale, out_rotation, out_translation) =
-        Mat4::from_scale_rotation_translation(in_scale, Quat::identity(), in_translation)
-            .to_scale_rotation_translation();
-    assert_approx_eq!(in_scale, out_scale, 1e6);
-    // TODO: this should work
-    // assert!(out_rotation.is_near_identity());
-    assert_approx_eq!(Quat::identity(), out_rotation);
+    // positive scale
+    let in_scale = Vec3::new(1.0, 2.0, 4.0);
+    let in_mat = Mat4::from_scale_rotation_translation(in_scale, in_rotation, in_translation);
+    let (out_scale, out_rotation, out_translation) = in_mat.to_scale_rotation_translation();
+    assert_approx_eq!(in_scale, out_scale, 1e-6);
+    // out_rotation is different but produces the same matrix
+    // assert_approx_eq!(in_rotation, out_rotation);
     assert_approx_eq!(in_translation, out_translation);
+    assert_approx_eq!(
+        in_mat,
+        Mat4::from_scale_rotation_translation(out_scale, out_rotation, out_translation),
+        1e-6
+    );
 
-    // this is expected to fail:
-    // let (out_scale, out_rotation, out_translation) =
-    //     Mat4::zero().to_scale_rotation_translation();
-    // assert_approx_eq!(Vec3::zero(), out_scale);
-    // assert_approx_eq!(Quat::from_xyzw(0.0, 0.0, 0.0, 0.0), out_rotation);
-    // assert_approx_eq!(Vec3::zero(), out_translation);
+    // negative scale
+    let in_scale = Vec3::new(-4.0, 1.0, 2.0);
+    let in_mat = Mat4::from_scale_rotation_translation(in_scale, in_rotation, in_translation);
+    let (out_scale, out_rotation, out_translation) = in_mat.to_scale_rotation_translation();
+    assert_approx_eq!(in_scale, out_scale, 1e-6);
+    // out_rotation is different but produces the same matrix
+    // assert_approx_eq!(in_rotation, out_rotation);
+    assert_approx_eq!(in_translation, out_translation);
+    assert_approx_eq!(
+        in_mat,
+        Mat4::from_scale_rotation_translation(out_scale, out_rotation, out_translation),
+        1e-5
+    );
+
+    // negative scale
+    let in_scale = Vec3::new(4.0, -1.0, -2.0);
+    let in_mat = Mat4::from_scale_rotation_translation(in_scale, in_rotation, in_translation);
+    let (out_scale, out_rotation, out_translation) = in_mat.to_scale_rotation_translation();
+    // out_scale and out_rotation are different but they produce the same matrix
+    // assert_approx_eq!(in_scale, out_scale, 1e-6);
+    // assert_approx_eq!(in_rotation, out_rotation);
+    assert_approx_eq!(in_translation, out_translation);
+    assert_approx_eq!(
+        in_mat,
+        Mat4::from_scale_rotation_translation(out_scale, out_rotation, out_translation),
+        1e-6
+    );
 }
 
 #[test]

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -243,6 +243,52 @@ fn test_mat4_inverse() {
 }
 
 #[test]
+fn test_mat4_decompose() {
+    let (out_scale, out_rotation, out_translation) =
+        Mat4::identity().to_scale_rotation_translation();
+    assert_approx_eq!(Vec3::one(), out_scale);
+    assert!(out_rotation.is_near_identity());
+    assert_approx_eq!(Vec3::zero(), out_translation);
+
+    let in_scale = Vec3::one();
+    let in_translation = Vec3::new(-2.0, 4.0, -0.125);
+    let in_rotation = Quat::from_rotation_ypr(
+        f32::to_radians(-45.0),
+        f32::to_radians(180.0),
+        f32::to_radians(270.0),
+    );
+    let (out_scale, out_rotation, out_translation) =
+        Mat4::from_scale_rotation_translation(in_scale, in_rotation, in_translation)
+            .to_scale_rotation_translation();
+    assert_approx_eq!(in_scale, out_scale, 1e6);
+    // quat rotation might be in opposite direction
+    // TODO: can decompose handle that?
+    assert_approx_eq!(
+        in_rotation * Vec3::unit_x(),
+        out_rotation * Vec3::unit_x(),
+        1e6
+    );
+    assert_approx_eq!(in_translation, out_translation);
+
+    let in_scale = Vec3::new(-1.0, -2.0, 4.0);
+    let (out_scale, out_rotation, out_translation) =
+        Mat4::from_scale_rotation_translation(in_scale, Quat::identity(), in_translation)
+            .to_scale_rotation_translation();
+    assert_approx_eq!(in_scale, out_scale, 1e6);
+    // TODO: this should work
+    // assert!(out_rotation.is_near_identity());
+    assert_approx_eq!(Quat::identity(), out_rotation);
+    assert_approx_eq!(in_translation, out_translation);
+
+    // this is expected to fail:
+    // let (out_scale, out_rotation, out_translation) =
+    //     Mat4::zero().to_scale_rotation_translation();
+    // assert_approx_eq!(Vec3::zero(), out_scale);
+    // assert_approx_eq!(Quat::from_xyzw(0.0, 0.0, 0.0, 0.0), out_rotation);
+    // assert_approx_eq!(Vec3::zero(), out_translation);
+}
+
+#[test]
 fn test_mat4_look_at() {
     let eye = Vec3::new(0.0, 0.0, -5.0);
     let center = Vec3::new(0.0, 0.0, 0.0);


### PR DESCRIPTION
The function extracts scale, rotation and translation from a 4x4 homogeneous transformation matrix. Also added a number of tests.