### PR TITLE
Ignore duplicate dependencies inside criterion

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,11 +1,9 @@
 [bans]
 multiple-versions = "deny"
 deny = []
-skip = [
-    # criterion uses old 0.3, glam uses 0.4
-    { name = "rand_xoshiro", version = "=0.3" },
-    # serde_json uses old 0.2 instead of 1.0
-    { name = "ryu", version = "=0.2" },
+skip-tree = [
+    # ignore criterion dev-dependency that often have duplicate dependencies internally
+    { name = "criterion" },
 ]
 
 [licenses]


### PR DESCRIPTION
Latest master was getting CI failures on cargo-deny due to duplicate dependencies inside criterion:
https://github.com/bitshifter/glam-rs/pull/44/checks?check_run_id=396139085

And as that is not something we can control here and criterion is just a dev dependency, I disabled duplicate crate detection specifically for criterion