### PR TITLE
Add `packed-vec3` feature to opt out of SIMD storage for `Vec3` and `Mat3`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rust:
 
 env:
   - CARGO_FEATURES="mint rand serde debug-glam-assert transform-types"
+  - CARGO_FEATURES="mint rand serde packed-vec3 debug-glam-assert transform-types"
   - CARGO_FEATURES="mint rand serde scalar-math debug-glam-assert transform-types"
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
-### Changed
+### Added
+* Added the `packed-vec3` feature flag to disable using SIMD types for `Vec3`
+  and `Mat3` types. This avoids wasting some space due to 16 byte alignment at
+  the cost of some performance.
 
+### Changed
 * Merged SSE2 and scalar `Vec3` and `Vec4` implementations into single files
   using the `cfg-if` crate.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ debug-glam-assert = []
 # always enable additional glam checks
 glam-assert = []
 
+# opt in to Vec3 and Mat3 using SIMD (and thus being 16 byte aligned)
+simd-vec3 = []
+
 # this is primarily for testing the fallback implementation
 scalar-math = []
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glam"
-version = "0.8.5" # remember to update html_root_url
+version = "0.8.6" # remember to update html_root_url
 edition = "2018"
 authors = ["Cameron Hart <cameron.hart@gmail.com>"]
 description = "A simple and fast 3D math library for games and graphics"
@@ -24,8 +24,8 @@ debug-glam-assert = []
 # always enable additional glam checks
 glam-assert = []
 
-# opt in to Vec3 and Mat3 using SIMD (and thus being 16 byte aligned)
-simd-vec3 = []
+# opt out of Vec3 and Mat3 using SIMD (and thus being 16 byte aligned)
+packed-vec3 = []
 
 # this is primarily for testing the fallback implementation
 scalar-math = []

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ has a SIMD implementation yet.
 Note that this does result in some wasted space in the case of `Vec3` and `Mat3`
 as the SIMD vector type is 16 bytes large and 16 byte aligned.
 
+It is possible to opt out of using SIMD types for Vec3 and Mat3 storage with the
+`packed-vec3` feature.
+
 `glam` outperforms similar Rust libraries such as [`cgmath`][cgmath],
 [`nalgebra-glm`][nalgebra-glm] and others for common operations as tested by the
 [`mathbench`][mathbench] project.
@@ -51,6 +54,8 @@ let (x, y, z) = v.into();
 
 ### Feature gates
 
+* `packed-vec3` - disable using SIMD types for `Vec3` and `Mat3` storage.  This
+  avoids wasting space due to 16 byte alignment at the cost of some performance.
 * `scalar-math` - compiles with SIMD support disabled
 * `glam-assert` - adds assertions which check the validity of parameters passed to
   `glam` to help catch runtime errors
@@ -81,8 +86,8 @@ Rotations follow the left-hand rule.
 The design of this library is guided by a desire for simplicity and good
 performance.
 
-* Only single precision floating point (`f32`) arithmetic is supported
 * No traits or generics for simplicity of implementation and usage
+* Only single precision floating point (`f32`) arithmetic is supported
 * All dependencies are optional (e.g. `mint`, `rand` and `serde`)
 * Follows the [Rust API Guidelines] where possible
 * Aiming for 100% test [coverage][coveralls.io]
@@ -90,10 +95,10 @@ performance.
 
 ## Future work
 
-* Writing documentation
 * Experiment with a using a 4x3 matrix as a 3D transform type that can be more
   efficient than `Mat4` for certain operations like inverse and multiplies
 * `no-std` support
+* `wasm` support
 
 ## Inspirations
 

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -294,7 +294,7 @@ impl Mat3 {
     #[inline]
     pub fn transpose(&self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 #[cfg(all(target_arch = "x86", target_feature = "sse2"))]
                 use std::arch::x86::*;
                 #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -1,16 +1,5 @@
 use super::{scalar_sin_cos, Quat, Vec2, Vec3};
-#[cfg(all(
-    target_arch = "x86",
-    target_feature = "sse2",
-    not(feature = "scalar-math")
-))]
-use std::arch::x86::*;
-#[cfg(all(
-    target_arch = "x86_64",
-    target_feature = "sse2",
-    not(feature = "scalar-math")
-))]
-use std::arch::x86_64::*;
+use cfg_if::cfg_if;
 
 use std::{
     fmt,
@@ -304,28 +293,32 @@ impl Mat3 {
     /// Returns the transpose of `self`.
     #[inline]
     pub fn transpose(&self) -> Self {
-        #[cfg(any(not(target_feature = "sse2"), feature = "scalar-math"))]
-        {
-            let (m00, m01, m02) = self.x_axis.into();
-            let (m10, m11, m12) = self.y_axis.into();
-            let (m20, m21, m22) = self.z_axis.into();
+        cfg_if! {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+                #[cfg(all(target_arch = "x86", target_feature = "sse2"))]
+                use std::arch::x86::*;
+                #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+                use std::arch::x86_64::*;
+                unsafe {
+                    let tmp0 = _mm_shuffle_ps(self.x_axis.0, self.y_axis.0, 0b01_00_01_00);
+                    let tmp1 = _mm_shuffle_ps(self.x_axis.0, self.y_axis.0, 0b11_10_11_10);
 
-            Self {
-                x_axis: Vec3::new(m00, m10, m20),
-                y_axis: Vec3::new(m01, m11, m21),
-                z_axis: Vec3::new(m02, m12, m22),
-            }
-        }
+                    Self {
+                        x_axis: _mm_shuffle_ps(tmp0, self.z_axis.0, 0b00_00_10_00).into(),
+                        y_axis: _mm_shuffle_ps(tmp0, self.z_axis.0, 0b01_01_11_01).into(),
+                        z_axis: _mm_shuffle_ps(tmp1, self.z_axis.0, 0b10_10_10_00).into(),
+                    }
+                }
+            } else {
+                let (m00, m01, m02) = self.x_axis.into();
+                let (m10, m11, m12) = self.y_axis.into();
+                let (m20, m21, m22) = self.z_axis.into();
 
-        #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))]
-        unsafe {
-            let tmp0 = _mm_shuffle_ps(self.x_axis.0, self.y_axis.0, 0b01_00_01_00);
-            let tmp1 = _mm_shuffle_ps(self.x_axis.0, self.y_axis.0, 0b11_10_11_10);
-
-            Self {
-                x_axis: _mm_shuffle_ps(tmp0, self.z_axis.0, 0b00_00_10_00).into(),
-                y_axis: _mm_shuffle_ps(tmp0, self.z_axis.0, 0b01_01_11_01).into(),
-                z_axis: _mm_shuffle_ps(tmp1, self.z_axis.0, 0b10_10_10_00).into(),
+                Self {
+                    x_axis: Vec3::new(m00, m10, m20),
+                    y_axis: Vec3::new(m01, m11, m21),
+                    z_axis: Vec3::new(m02, m12, m22),
+                }
             }
         }
     }

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -3,7 +3,7 @@ use cfg_if::cfg_if;
 use core::{fmt, ops::*};
 
 cfg_if! {
-    if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+    if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
         use crate::{
             f32::{X_AXIS, Y_AXIS, Z_AXIS},
             Align16,
@@ -71,10 +71,10 @@ cfg_if! {
         }
     } else {
         /// A 3-dimensional vector.
-#[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Default)]
+        #[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Default)]
         // if compiling with simd enabled assume alignment needs to match the simd type
-#[cfg_attr(not(feature = "scalar-math"), repr(align(16)))]
-#[repr(C)]
+        #[cfg_attr(all(feature = "simd-vec3", not(feature = "scalar-math")), repr(align(16)))]
+        #[repr(C)]
         pub struct Vec3(pub(crate) f32, pub(crate) f32, pub(crate) f32);
     }
 }
@@ -89,7 +89,7 @@ impl Vec3 {
     #[inline]
     pub fn new(x: f32, y: f32, z: f32) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_set_ps(z, z, y, x)) }
             } else {
                 Self(x, y, z)
@@ -101,7 +101,7 @@ impl Vec3 {
     #[inline]
     pub fn zero() -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_setzero_ps()) }
             } else {
                 Self(0.0, 0.0, 0.0)
@@ -113,7 +113,7 @@ impl Vec3 {
     #[inline]
     pub fn one() -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_set1_ps(1.0)) }
             } else {
                 Self(1.0, 1.0, 1.0)
@@ -125,7 +125,7 @@ impl Vec3 {
     #[inline]
     pub fn unit_x() -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_load_ps(X_AXIS.0.as_ptr())) }
             } else {
                 Self(1.0, 0.0, 0.0)
@@ -137,7 +137,7 @@ impl Vec3 {
     #[inline]
     pub fn unit_y() -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_load_ps(Y_AXIS.0.as_ptr())) }
             } else {
                 Self(0.0, 1.0, 0.0)
@@ -149,7 +149,7 @@ impl Vec3 {
     #[inline]
     pub fn unit_z() -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_load_ps(Z_AXIS.0.as_ptr())) }
             } else {
                 Self(0.0, 0.0, 1.0)
@@ -161,7 +161,7 @@ impl Vec3 {
     #[inline]
     pub fn splat(v: f32) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_set_ps1(v)) }
             } else {
                 Self(v, v, v)
@@ -173,7 +173,7 @@ impl Vec3 {
     #[inline]
     pub fn extend(self, w: f32) -> Vec4 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 let mut temp: Vec4 = self.0.into();
                 temp.set_w(w);
                 temp
@@ -188,7 +188,7 @@ impl Vec3 {
     #[inline]
     pub fn truncate(self) -> Vec2 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 let (x, y, _) = self.into();
                 Vec2::new(x, y)
             } else {
@@ -201,7 +201,7 @@ impl Vec3 {
     #[inline]
     pub fn x(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { _mm_cvtss_f32(self.0) }
             } else {
                 self.0
@@ -213,7 +213,7 @@ impl Vec3 {
     #[inline]
     pub fn y(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { _mm_cvtss_f32(_mm_shuffle_ps(self.0, self.0, 0b01_01_01_01)) }
             } else {
                 self.1
@@ -225,7 +225,7 @@ impl Vec3 {
     #[inline]
     pub fn z(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { _mm_cvtss_f32(_mm_shuffle_ps(self.0, self.0, 0b10_10_10_10)) }
             } else {
                 self.2
@@ -237,7 +237,7 @@ impl Vec3 {
     #[inline]
     pub fn set_x(&mut self, x: f32) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe {
                     self.0 = _mm_move_ss(self.0, _mm_set_ss(x));
                 }
@@ -251,7 +251,7 @@ impl Vec3 {
     #[inline]
     pub fn set_y(&mut self, y: f32) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe {
                     let mut t = _mm_move_ss(self.0, _mm_set_ss(y));
                     t = _mm_shuffle_ps(t, t, 0b11_10_00_00);
@@ -267,7 +267,7 @@ impl Vec3 {
     #[inline]
     pub fn set_z(&mut self, z: f32) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe {
                     let mut t = _mm_move_ss(self.0, _mm_set_ss(z));
                     t = _mm_shuffle_ps(t, t, 0b11_00_01_00);
@@ -283,7 +283,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn dup_x(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_shuffle_ps(self.0, self.0, 0b00_00_00_00)) }
             } else {
                 Self(self.0, self.0, self.0)
@@ -295,7 +295,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn dup_y(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_shuffle_ps(self.0, self.0, 0b01_01_01_01)) }
             } else {
                 Self(self.1, self.1, self.1)
@@ -307,7 +307,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn dup_z(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_shuffle_ps(self.0, self.0, 0b10_10_10_10)) }
             } else {
                 Self(self.2, self.2, self.2)
@@ -319,7 +319,7 @@ impl Vec3 {
     #[inline]
     pub fn dot(self, other: Self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { _mm_cvtss_f32(self.dot_as_m128(other)) }
             } else {
                 (self.0 * other.0) + (self.1 * other.1) + (self.2 * other.2)
@@ -331,7 +331,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn dot_as_vec3(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe {
                     let dot_in_x = self.dot_as_m128(other);
                     Vec3(_mm_shuffle_ps(dot_in_x, dot_in_x, 0b00_00_00_00))
@@ -347,7 +347,7 @@ impl Vec3 {
     #[inline]
     pub fn cross(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 // x  <-  a.y*b.z - a.z*b.y
                 // y  <-  a.z*b.x - a.x*b.z
                 // z  <-  a.x*b.y - a.y*b.x
@@ -375,7 +375,7 @@ impl Vec3 {
     #[inline]
     pub fn length(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { _mm_cvtss_f32(_mm_sqrt_ss(self.dot_as_m128(self))) }
             } else {
                 self.dot(self).sqrt()
@@ -398,7 +398,7 @@ impl Vec3 {
     #[inline]
     pub fn length_reciprocal(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 let dot = self.dot_as_vec3(self);
                 unsafe {
                     // _mm_rsqrt_ps is lower precision
@@ -416,7 +416,7 @@ impl Vec3 {
     #[inline]
     pub fn normalize(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 let dot = self.dot_as_vec3(self);
                 unsafe { Self(_mm_div_ps(self.0, _mm_sqrt_ps(dot.0))) }
             } else {
@@ -433,7 +433,7 @@ impl Vec3 {
     #[inline]
     pub fn min(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_min_ps(self.0, other.0)) }
             } else {
                 Self(
@@ -453,7 +453,7 @@ impl Vec3 {
     #[inline]
     pub fn max(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_max_ps(self.0, other.0)) }
             } else {
                 Self(
@@ -471,7 +471,7 @@ impl Vec3 {
     #[inline]
     pub fn min_element(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe {
                     let v = self.0;
                     let v = _mm_min_ps(v, _mm_shuffle_ps(v, v, 0b01_01_10_10));
@@ -490,7 +490,7 @@ impl Vec3 {
     #[inline]
     pub fn max_element(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe {
                     let v = self.0;
                     let v = _mm_max_ps(v, _mm_shuffle_ps(v, v, 0b00_00_10_10));
@@ -510,7 +510,7 @@ impl Vec3 {
     #[inline]
     pub fn cmpeq(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmpeq_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -529,7 +529,7 @@ impl Vec3 {
     #[inline]
     pub fn cmpne(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmpneq_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -548,7 +548,7 @@ impl Vec3 {
     #[inline]
     pub fn cmpge(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmpge_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -567,7 +567,7 @@ impl Vec3 {
     #[inline]
     pub fn cmpgt(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmpgt_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -586,7 +586,7 @@ impl Vec3 {
     #[inline]
     pub fn cmple(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmple_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -605,7 +605,7 @@ impl Vec3 {
     #[inline]
     pub fn cmplt(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmplt_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -621,7 +621,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn mul_add(self, a: Self, b: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_add_ps(_mm_mul_ps(self.0, a.0), b.0)) }
             } else {
                 Self(
@@ -639,7 +639,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn neg_mul_sub(self, a: Self, b: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_sub_ps(b.0, _mm_mul_ps(self.0, a.0))) }
             } else {
                 Self(
@@ -656,7 +656,7 @@ impl Vec3 {
     #[inline]
     pub fn abs(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe {
                     Self(_mm_and_ps(
                             self.0,
@@ -672,7 +672,7 @@ impl Vec3 {
     #[inline]
     pub fn round(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 use crate::f32::funcs::sse2::m128_round;
                 unsafe { Self(m128_round(self.0)) }
             } else {
@@ -684,7 +684,7 @@ impl Vec3 {
     #[inline]
     pub fn floor(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 use crate::f32::funcs::sse2::m128_floor;
                 unsafe { Self(m128_floor(self.0)) }
             } else {
@@ -696,7 +696,7 @@ impl Vec3 {
     #[inline]
     pub fn ceil(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 use crate::f32::funcs::sse2::m128_ceil;
                 unsafe { Self(m128_ceil(self.0)) }
             } else {
@@ -773,7 +773,7 @@ impl AsMut<[f32; 3]> for Vec3 {
 impl fmt::Display for Vec3 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 let (x, y, z) = (*self).into();
                 write!(f, "[{}, {}, {}]", x, y, z)
             } else {
@@ -788,7 +788,7 @@ impl Div<Vec3> for Vec3 {
     #[inline]
     fn div(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_div_ps(self.0, other.0)) }
             } else {
                 Self(self.0 / other.0, self.1 / other.1, self.2 / other.2)
@@ -801,7 +801,7 @@ impl DivAssign<Vec3> for Vec3 {
     #[inline]
     fn div_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_div_ps(self.0, other.0) };
             } else {
                 self.0 /= other.0;
@@ -817,7 +817,7 @@ impl Div<f32> for Vec3 {
     #[inline]
     fn div(self, other: f32) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_div_ps(self.0, _mm_set1_ps(other))) }
             } else {
                 Self(self.0 / other, self.1 / other, self.2 / other)
@@ -830,7 +830,7 @@ impl DivAssign<f32> for Vec3 {
     #[inline]
     fn div_assign(&mut self, other: f32) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_div_ps(self.0, _mm_set1_ps(other)) };
             } else {
                 self.0 /= other;
@@ -846,7 +846,7 @@ impl Mul<Vec3> for Vec3 {
     #[inline]
     fn mul(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_mul_ps(self.0, other.0)) }
             } else {
                 Self(self.0 * other.0, self.1 * other.1, self.2 * other.2)
@@ -859,7 +859,7 @@ impl MulAssign<Vec3> for Vec3 {
     #[inline]
     fn mul_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_mul_ps(self.0, other.0) };
             } else {
                 self.0 *= other.0;
@@ -875,7 +875,7 @@ impl Mul<f32> for Vec3 {
     #[inline]
     fn mul(self, other: f32) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_mul_ps(self.0, _mm_set1_ps(other))) }
             } else {
                 Self(self.0 * other, self.1 * other, self.2 * other)
@@ -888,7 +888,7 @@ impl MulAssign<f32> for Vec3 {
     #[inline]
     fn mul_assign(&mut self, other: f32) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_mul_ps(self.0, _mm_set1_ps(other)) };
             } else {
                 self.0 *= other;
@@ -904,7 +904,7 @@ impl Mul<Vec3> for f32 {
     #[inline]
     fn mul(self, other: Vec3) -> Vec3 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Vec3(_mm_mul_ps(_mm_set1_ps(self), other.0)) }
             } else {
                 Vec3(self * other.0, self * other.1, self * other.2)
@@ -918,7 +918,7 @@ impl Add for Vec3 {
     #[inline]
     fn add(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_add_ps(self.0, other.0)) }
             } else {
                 Self(self.0 + other.0, self.1 + other.1, self.2 + other.2)
@@ -931,7 +931,7 @@ impl AddAssign for Vec3 {
     #[inline]
     fn add_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_add_ps(self.0, other.0) };
             } else {
                 self.0 += other.0;
@@ -947,7 +947,7 @@ impl Sub for Vec3 {
     #[inline]
     fn sub(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_sub_ps(self.0, other.0)) }
             } else {
                 Self(self.0 - other.0, self.1 - other.1, self.2 - other.2)
@@ -960,7 +960,7 @@ impl SubAssign for Vec3 {
     #[inline]
     fn sub_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_sub_ps(self.0, other.0) };
             } else {
                 self.0 -= other.0;
@@ -976,7 +976,7 @@ impl Neg for Vec3 {
     #[inline]
     fn neg(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_sub_ps(_mm_set1_ps(0.0), self.0)) }
             } else {
                 Self(-self.0, -self.1, -self.2)
@@ -996,7 +996,7 @@ impl From<Vec3> for (f32, f32, f32) {
     #[inline]
     fn from(v: Vec3) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 let mut out: MaybeUninit<Align16<(f32, f32, f32)>> = MaybeUninit::uninit();
                 unsafe {
                     // out is 16 bytes in size due to alignment
@@ -1021,7 +1021,7 @@ impl From<Vec3> for [f32; 3] {
     #[inline]
     fn from(v: Vec3) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 let mut out: MaybeUninit<Align16<[f32; 3]>> = MaybeUninit::uninit();
                 unsafe {
                     // out is 16 bytes in size due to alignment

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -3,7 +3,7 @@ use cfg_if::cfg_if;
 use core::{fmt, ops::*};
 
 cfg_if! {
-    if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+    if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
         use crate::{
             f32::{X_AXIS, Y_AXIS, Z_AXIS},
             Align16,
@@ -73,7 +73,7 @@ cfg_if! {
         /// A 3-dimensional vector.
         #[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Default)]
         // if compiling with simd enabled assume alignment needs to match the simd type
-        #[cfg_attr(all(feature = "simd-vec3", not(feature = "scalar-math")), repr(align(16)))]
+        #[cfg_attr(all(not(feature = "packed-vec3"), not(feature = "scalar-math")), repr(align(16)))]
         #[repr(C)]
         pub struct Vec3(pub(crate) f32, pub(crate) f32, pub(crate) f32);
     }
@@ -89,7 +89,7 @@ impl Vec3 {
     #[inline]
     pub fn new(x: f32, y: f32, z: f32) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_set_ps(z, z, y, x)) }
             } else {
                 Self(x, y, z)
@@ -101,7 +101,7 @@ impl Vec3 {
     #[inline]
     pub fn zero() -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_setzero_ps()) }
             } else {
                 Self(0.0, 0.0, 0.0)
@@ -113,7 +113,7 @@ impl Vec3 {
     #[inline]
     pub fn one() -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_set1_ps(1.0)) }
             } else {
                 Self(1.0, 1.0, 1.0)
@@ -125,7 +125,7 @@ impl Vec3 {
     #[inline]
     pub fn unit_x() -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_load_ps(X_AXIS.0.as_ptr())) }
             } else {
                 Self(1.0, 0.0, 0.0)
@@ -137,7 +137,7 @@ impl Vec3 {
     #[inline]
     pub fn unit_y() -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_load_ps(Y_AXIS.0.as_ptr())) }
             } else {
                 Self(0.0, 1.0, 0.0)
@@ -149,7 +149,7 @@ impl Vec3 {
     #[inline]
     pub fn unit_z() -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_load_ps(Z_AXIS.0.as_ptr())) }
             } else {
                 Self(0.0, 0.0, 1.0)
@@ -161,7 +161,7 @@ impl Vec3 {
     #[inline]
     pub fn splat(v: f32) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_set_ps1(v)) }
             } else {
                 Self(v, v, v)
@@ -173,7 +173,7 @@ impl Vec3 {
     #[inline]
     pub fn extend(self, w: f32) -> Vec4 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 let mut temp: Vec4 = self.0.into();
                 temp.set_w(w);
                 temp
@@ -188,7 +188,7 @@ impl Vec3 {
     #[inline]
     pub fn truncate(self) -> Vec2 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 let (x, y, _) = self.into();
                 Vec2::new(x, y)
             } else {
@@ -201,7 +201,7 @@ impl Vec3 {
     #[inline]
     pub fn x(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { _mm_cvtss_f32(self.0) }
             } else {
                 self.0
@@ -213,7 +213,7 @@ impl Vec3 {
     #[inline]
     pub fn y(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { _mm_cvtss_f32(_mm_shuffle_ps(self.0, self.0, 0b01_01_01_01)) }
             } else {
                 self.1
@@ -225,7 +225,7 @@ impl Vec3 {
     #[inline]
     pub fn z(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { _mm_cvtss_f32(_mm_shuffle_ps(self.0, self.0, 0b10_10_10_10)) }
             } else {
                 self.2
@@ -237,7 +237,7 @@ impl Vec3 {
     #[inline]
     pub fn set_x(&mut self, x: f32) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe {
                     self.0 = _mm_move_ss(self.0, _mm_set_ss(x));
                 }
@@ -251,7 +251,7 @@ impl Vec3 {
     #[inline]
     pub fn set_y(&mut self, y: f32) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe {
                     let mut t = _mm_move_ss(self.0, _mm_set_ss(y));
                     t = _mm_shuffle_ps(t, t, 0b11_10_00_00);
@@ -267,7 +267,7 @@ impl Vec3 {
     #[inline]
     pub fn set_z(&mut self, z: f32) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe {
                     let mut t = _mm_move_ss(self.0, _mm_set_ss(z));
                     t = _mm_shuffle_ps(t, t, 0b11_00_01_00);
@@ -283,7 +283,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn dup_x(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_shuffle_ps(self.0, self.0, 0b00_00_00_00)) }
             } else {
                 Self(self.0, self.0, self.0)
@@ -295,7 +295,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn dup_y(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_shuffle_ps(self.0, self.0, 0b01_01_01_01)) }
             } else {
                 Self(self.1, self.1, self.1)
@@ -307,7 +307,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn dup_z(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_shuffle_ps(self.0, self.0, 0b10_10_10_10)) }
             } else {
                 Self(self.2, self.2, self.2)
@@ -319,7 +319,7 @@ impl Vec3 {
     #[inline]
     pub fn dot(self, other: Self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { _mm_cvtss_f32(self.dot_as_m128(other)) }
             } else {
                 (self.0 * other.0) + (self.1 * other.1) + (self.2 * other.2)
@@ -331,7 +331,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn dot_as_vec3(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe {
                     let dot_in_x = self.dot_as_m128(other);
                     Vec3(_mm_shuffle_ps(dot_in_x, dot_in_x, 0b00_00_00_00))
@@ -347,7 +347,7 @@ impl Vec3 {
     #[inline]
     pub fn cross(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 // x  <-  a.y*b.z - a.z*b.y
                 // y  <-  a.z*b.x - a.x*b.z
                 // z  <-  a.x*b.y - a.y*b.x
@@ -375,7 +375,7 @@ impl Vec3 {
     #[inline]
     pub fn length(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { _mm_cvtss_f32(_mm_sqrt_ss(self.dot_as_m128(self))) }
             } else {
                 self.dot(self).sqrt()
@@ -398,7 +398,7 @@ impl Vec3 {
     #[inline]
     pub fn length_reciprocal(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 let dot = self.dot_as_vec3(self);
                 unsafe {
                     // _mm_rsqrt_ps is lower precision
@@ -416,7 +416,7 @@ impl Vec3 {
     #[inline]
     pub fn normalize(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 let dot = self.dot_as_vec3(self);
                 unsafe { Self(_mm_div_ps(self.0, _mm_sqrt_ps(dot.0))) }
             } else {
@@ -433,7 +433,7 @@ impl Vec3 {
     #[inline]
     pub fn min(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_min_ps(self.0, other.0)) }
             } else {
                 Self(
@@ -453,7 +453,7 @@ impl Vec3 {
     #[inline]
     pub fn max(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_max_ps(self.0, other.0)) }
             } else {
                 Self(
@@ -471,7 +471,7 @@ impl Vec3 {
     #[inline]
     pub fn min_element(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe {
                     let v = self.0;
                     let v = _mm_min_ps(v, _mm_shuffle_ps(v, v, 0b01_01_10_10));
@@ -490,7 +490,7 @@ impl Vec3 {
     #[inline]
     pub fn max_element(self) -> f32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe {
                     let v = self.0;
                     let v = _mm_max_ps(v, _mm_shuffle_ps(v, v, 0b00_00_10_10));
@@ -510,7 +510,7 @@ impl Vec3 {
     #[inline]
     pub fn cmpeq(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmpeq_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -529,7 +529,7 @@ impl Vec3 {
     #[inline]
     pub fn cmpne(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmpneq_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -548,7 +548,7 @@ impl Vec3 {
     #[inline]
     pub fn cmpge(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmpge_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -567,7 +567,7 @@ impl Vec3 {
     #[inline]
     pub fn cmpgt(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmpgt_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -586,7 +586,7 @@ impl Vec3 {
     #[inline]
     pub fn cmple(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmple_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -605,7 +605,7 @@ impl Vec3 {
     #[inline]
     pub fn cmplt(self, other: Self) -> Vec3Mask {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Vec3Mask(_mm_cmplt_ps(self.0, other.0)) }
             } else {
                 Vec3Mask::new(
@@ -621,7 +621,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn mul_add(self, a: Self, b: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_add_ps(_mm_mul_ps(self.0, a.0), b.0)) }
             } else {
                 Self(
@@ -639,7 +639,7 @@ impl Vec3 {
     #[inline]
     pub(crate) fn neg_mul_sub(self, a: Self, b: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_sub_ps(b.0, _mm_mul_ps(self.0, a.0))) }
             } else {
                 Self(
@@ -656,7 +656,7 @@ impl Vec3 {
     #[inline]
     pub fn abs(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe {
                     Self(_mm_and_ps(
                             self.0,
@@ -672,7 +672,7 @@ impl Vec3 {
     #[inline]
     pub fn round(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 use crate::f32::funcs::sse2::m128_round;
                 unsafe { Self(m128_round(self.0)) }
             } else {
@@ -684,7 +684,7 @@ impl Vec3 {
     #[inline]
     pub fn floor(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 use crate::f32::funcs::sse2::m128_floor;
                 unsafe { Self(m128_floor(self.0)) }
             } else {
@@ -696,7 +696,7 @@ impl Vec3 {
     #[inline]
     pub fn ceil(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 use crate::f32::funcs::sse2::m128_ceil;
                 unsafe { Self(m128_ceil(self.0)) }
             } else {
@@ -773,7 +773,7 @@ impl AsMut<[f32; 3]> for Vec3 {
 impl fmt::Display for Vec3 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 let (x, y, z) = (*self).into();
                 write!(f, "[{}, {}, {}]", x, y, z)
             } else {
@@ -788,7 +788,7 @@ impl Div<Vec3> for Vec3 {
     #[inline]
     fn div(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_div_ps(self.0, other.0)) }
             } else {
                 Self(self.0 / other.0, self.1 / other.1, self.2 / other.2)
@@ -801,7 +801,7 @@ impl DivAssign<Vec3> for Vec3 {
     #[inline]
     fn div_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_div_ps(self.0, other.0) };
             } else {
                 self.0 /= other.0;
@@ -817,7 +817,7 @@ impl Div<f32> for Vec3 {
     #[inline]
     fn div(self, other: f32) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_div_ps(self.0, _mm_set1_ps(other))) }
             } else {
                 Self(self.0 / other, self.1 / other, self.2 / other)
@@ -830,7 +830,7 @@ impl DivAssign<f32> for Vec3 {
     #[inline]
     fn div_assign(&mut self, other: f32) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_div_ps(self.0, _mm_set1_ps(other)) };
             } else {
                 self.0 /= other;
@@ -846,7 +846,7 @@ impl Mul<Vec3> for Vec3 {
     #[inline]
     fn mul(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_mul_ps(self.0, other.0)) }
             } else {
                 Self(self.0 * other.0, self.1 * other.1, self.2 * other.2)
@@ -859,7 +859,7 @@ impl MulAssign<Vec3> for Vec3 {
     #[inline]
     fn mul_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_mul_ps(self.0, other.0) };
             } else {
                 self.0 *= other.0;
@@ -875,7 +875,7 @@ impl Mul<f32> for Vec3 {
     #[inline]
     fn mul(self, other: f32) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_mul_ps(self.0, _mm_set1_ps(other))) }
             } else {
                 Self(self.0 * other, self.1 * other, self.2 * other)
@@ -888,7 +888,7 @@ impl MulAssign<f32> for Vec3 {
     #[inline]
     fn mul_assign(&mut self, other: f32) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_mul_ps(self.0, _mm_set1_ps(other)) };
             } else {
                 self.0 *= other;
@@ -904,7 +904,7 @@ impl Mul<Vec3> for f32 {
     #[inline]
     fn mul(self, other: Vec3) -> Vec3 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Vec3(_mm_mul_ps(_mm_set1_ps(self), other.0)) }
             } else {
                 Vec3(self * other.0, self * other.1, self * other.2)
@@ -918,7 +918,7 @@ impl Add for Vec3 {
     #[inline]
     fn add(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_add_ps(self.0, other.0)) }
             } else {
                 Self(self.0 + other.0, self.1 + other.1, self.2 + other.2)
@@ -931,7 +931,7 @@ impl AddAssign for Vec3 {
     #[inline]
     fn add_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_add_ps(self.0, other.0) };
             } else {
                 self.0 += other.0;
@@ -947,7 +947,7 @@ impl Sub for Vec3 {
     #[inline]
     fn sub(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_sub_ps(self.0, other.0)) }
             } else {
                 Self(self.0 - other.0, self.1 - other.1, self.2 - other.2)
@@ -960,7 +960,7 @@ impl SubAssign for Vec3 {
     #[inline]
     fn sub_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_sub_ps(self.0, other.0) };
             } else {
                 self.0 -= other.0;
@@ -976,7 +976,7 @@ impl Neg for Vec3 {
     #[inline]
     fn neg(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_sub_ps(_mm_set1_ps(0.0), self.0)) }
             } else {
                 Self(-self.0, -self.1, -self.2)
@@ -996,7 +996,7 @@ impl From<Vec3> for (f32, f32, f32) {
     #[inline]
     fn from(v: Vec3) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 let mut out: MaybeUninit<Align16<(f32, f32, f32)>> = MaybeUninit::uninit();
                 unsafe {
                     // out is 16 bytes in size due to alignment
@@ -1021,7 +1021,7 @@ impl From<Vec3> for [f32; 3] {
     #[inline]
     fn from(v: Vec3) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 let mut out: MaybeUninit<Align16<[f32; 3]>> = MaybeUninit::uninit();
                 unsafe {
                     // out is 16 bytes in size due to alignment

--- a/src/f32/vec3_mask.rs
+++ b/src/f32/vec3_mask.rs
@@ -3,7 +3,7 @@ use cfg_if::cfg_if;
 use core::ops::*;
 
 cfg_if! {
-    if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+    if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
         #[cfg(target_arch = "x86")]
         use core::arch::x86::*;
         #[cfg(target_arch = "x86_64")]
@@ -24,7 +24,7 @@ cfg_if! {
                 unsafe { Self(_mm_setzero_ps()) }
             }
         }
-    } else if #[cfg(all(target_feature = "sse2", not(feature = "simd-vec3"), not(feature = "scalar-math")))] {
+    } else if #[cfg(all(target_feature = "sse2", feature = "packed-vec3", not(feature = "scalar-math")))] {
         /// A 3-dimensional vector mask.
         #[derive(Clone, Copy, Default)]
         #[repr(C)]
@@ -45,7 +45,7 @@ impl Vec3Mask {
     pub fn new(x: bool, y: bool, z: bool) -> Self {
         const MASK: [u32; 2] = [0, 0xff_ff_ff_ff];
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe {
                     Self(_mm_set_ps(
                             f32::from_bits(MASK[z as usize]),
@@ -69,7 +69,7 @@ impl Vec3Mask {
     #[inline]
     pub fn bitmask(&self) -> u32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { (_mm_movemask_ps(self.0) as u32) & 0x7 }
             } else {
                 (self.0 & 0x1) | (self.1 & 0x1) << 1 | (self.2 & 0x1) << 2
@@ -83,7 +83,7 @@ impl Vec3Mask {
     #[inline]
     pub fn any(&self) -> bool {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { (_mm_movemask_ps(self.0) & 0x7) != 0 }
             } else {
                 (self.0 != 0) || (self.1 != 0) || (self.2 != 0)
@@ -97,7 +97,7 @@ impl Vec3Mask {
     #[inline]
     pub fn all(&self) -> bool {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { (_mm_movemask_ps(self.0) & 0x7) == 0x7 }
             } else {
                 (self.0 != 0) && (self.1 != 0) && (self.2 != 0)
@@ -113,7 +113,7 @@ impl Vec3Mask {
     #[inline]
     pub fn select(self, if_true: Vec3, if_false: Vec3) -> Vec3 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe {
                     Vec3(_mm_or_ps(
                             _mm_andnot_ps(self.0, if_false.0),
@@ -136,7 +136,7 @@ impl BitAnd for Vec3Mask {
     #[inline]
     fn bitand(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_and_ps(self.0, other.0)) }
             } else {
                 Self(self.0 & other.0, self.1 & other.1, self.2 & other.2)
@@ -148,7 +148,7 @@ impl BitAnd for Vec3Mask {
 impl BitAndAssign for Vec3Mask {
     fn bitand_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_and_ps(self.0, other.0) };
             } else {
                 self.0 &= other.0;
@@ -164,7 +164,7 @@ impl BitOr for Vec3Mask {
     #[inline]
     fn bitor(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_or_ps(self.0, other.0)) }
             } else {
                 Self(self.0 | other.0, self.1 | other.1, self.2 | other.2)
@@ -176,7 +176,7 @@ impl BitOr for Vec3Mask {
 impl BitOrAssign for Vec3Mask {
     fn bitor_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_or_ps(self.0, other.0) };
             } else {
                 self.0 |= other.0;
@@ -192,7 +192,7 @@ impl Not for Vec3Mask {
     #[inline]
     fn not(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 unsafe {
                     Self(_mm_andnot_ps(
                             self.0,

--- a/src/f32/vec3_mask.rs
+++ b/src/f32/vec3_mask.rs
@@ -3,7 +3,7 @@ use cfg_if::cfg_if;
 use core::ops::*;
 
 cfg_if! {
-    if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+    if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
         #[cfg(target_arch = "x86")]
         use core::arch::x86::*;
         #[cfg(target_arch = "x86_64")]
@@ -24,6 +24,11 @@ cfg_if! {
                 unsafe { Self(_mm_setzero_ps()) }
             }
         }
+    } else if #[cfg(all(target_feature = "sse2", not(feature = "simd-vec3"), not(feature = "scalar-math")))] {
+        /// A 3-dimensional vector mask.
+        #[derive(Clone, Copy, Default)]
+        #[repr(C)]
+        pub struct Vec3Mask(pub(crate) u32, pub(crate) u32, pub(crate) u32);
     } else {
         /// A 3-dimensional vector mask.
 #[derive(Clone, Copy, Default)]
@@ -40,7 +45,7 @@ impl Vec3Mask {
     pub fn new(x: bool, y: bool, z: bool) -> Self {
         const MASK: [u32; 2] = [0, 0xff_ff_ff_ff];
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe {
                     Self(_mm_set_ps(
                             f32::from_bits(MASK[z as usize]),
@@ -64,7 +69,7 @@ impl Vec3Mask {
     #[inline]
     pub fn bitmask(&self) -> u32 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { (_mm_movemask_ps(self.0) as u32) & 0x7 }
             } else {
                 (self.0 & 0x1) | (self.1 & 0x1) << 1 | (self.2 & 0x1) << 2
@@ -78,7 +83,7 @@ impl Vec3Mask {
     #[inline]
     pub fn any(&self) -> bool {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { (_mm_movemask_ps(self.0) & 0x7) != 0 }
             } else {
                 (self.0 != 0) || (self.1 != 0) || (self.2 != 0)
@@ -92,7 +97,7 @@ impl Vec3Mask {
     #[inline]
     pub fn all(&self) -> bool {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { (_mm_movemask_ps(self.0) & 0x7) == 0x7 }
             } else {
                 (self.0 != 0) && (self.1 != 0) && (self.2 != 0)
@@ -108,7 +113,7 @@ impl Vec3Mask {
     #[inline]
     pub fn select(self, if_true: Vec3, if_false: Vec3) -> Vec3 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe {
                     Vec3(_mm_or_ps(
                             _mm_andnot_ps(self.0, if_false.0),
@@ -131,7 +136,7 @@ impl BitAnd for Vec3Mask {
     #[inline]
     fn bitand(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_and_ps(self.0, other.0)) }
             } else {
                 Self(self.0 & other.0, self.1 & other.1, self.2 & other.2)
@@ -143,7 +148,7 @@ impl BitAnd for Vec3Mask {
 impl BitAndAssign for Vec3Mask {
     fn bitand_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_and_ps(self.0, other.0) };
             } else {
                 self.0 &= other.0;
@@ -159,7 +164,7 @@ impl BitOr for Vec3Mask {
     #[inline]
     fn bitor(self, other: Self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe { Self(_mm_or_ps(self.0, other.0)) }
             } else {
                 Self(self.0 | other.0, self.1 | other.1, self.2 | other.2)
@@ -171,7 +176,7 @@ impl BitOr for Vec3Mask {
 impl BitOrAssign for Vec3Mask {
     fn bitor_assign(&mut self, other: Self) {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 self.0 = unsafe { _mm_or_ps(self.0, other.0) };
             } else {
                 self.0 |= other.0;
@@ -187,7 +192,7 @@ impl Not for Vec3Mask {
     #[inline]
     fn not(self) -> Self {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 unsafe {
                     Self(_mm_andnot_ps(
                             self.0,

--- a/src/f32/vec4.rs
+++ b/src/f32/vec4.rs
@@ -179,8 +179,11 @@ impl Vec4 {
     #[inline]
     pub fn truncate(self) -> Vec3 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
                 self.0.into()
+            } else if #[cfg(all(target_feature = "sse2", not(feature = "simd-vec3"), not(feature = "scalar-math")))] {
+                let (x, y, z, _) = self.into();
+                Vec3::new(x, y, z)
             } else {
                 Vec3::new(self.0, self.1, self.2)
             }

--- a/src/f32/vec4.rs
+++ b/src/f32/vec4.rs
@@ -179,9 +179,9 @@ impl Vec4 {
     #[inline]
     pub fn truncate(self) -> Vec3 {
         cfg_if! {
-            if #[cfg(all(target_feature = "sse2", feature = "simd-vec3", not(feature = "scalar-math")))] {
+            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
                 self.0.into()
-            } else if #[cfg(all(target_feature = "sse2", not(feature = "simd-vec3"), not(feature = "scalar-math")))] {
+            } else if #[cfg(all(target_feature = "sse2", feature = "packed-vec3", not(feature = "scalar-math")))] {
                 let (x, y, z, _) = self.into();
                 Vec3::new(x, y, z)
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ and benchmarks.
   parameters passed to `glam` to help catch runtime errors.
 
 */
-#![doc(html_root_url = "https://docs.rs/glam/0.8.5")]
+#![doc(html_root_url = "https://docs.rs/glam/0.8.6")]
 
 #[macro_use]
 mod macros;

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -12,7 +12,7 @@ const ZERO: [[f32; 3]; 3] = [[0.0; 3]; 3];
 #[test]
 fn test_mat3_align() {
     use std::mem;
-    if cfg!(any(not(feature = "simd-vec3"), feature = "scalar-math")) {
+    if cfg!(any(feature = "packed-vec3", feature = "scalar-math")) {
         assert_eq!(36, mem::size_of::<Mat3>());
         assert_eq!(4, mem::align_of::<Mat3>());
     } else {

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -12,7 +12,7 @@ const ZERO: [[f32; 3]; 3] = [[0.0; 3]; 3];
 #[test]
 fn test_mat3_align() {
     use std::mem;
-    if cfg!(feature = "scalar-math") {
+    if cfg!(any(not(feature = "simd-vec3"), feature = "scalar-math")) {
         assert_eq!(36, mem::size_of::<Mat3>());
         assert_eq!(4, mem::align_of::<Mat3>());
     } else {

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -10,7 +10,7 @@ use std::f32;
 #[test]
 fn test_vec3_align() {
     use std::mem;
-    if cfg!(feature = "scalar-math") {
+    if cfg!(any(not(feature = "simd-vec3"), feature = "scalar-math")) {
         assert_eq!(12, mem::size_of::<Vec3>());
         assert_eq!(4, mem::align_of::<Vec3>());
         assert_eq!(12, mem::size_of::<Vec3Mask>());
@@ -51,9 +51,17 @@ fn test_vec3_new() {
 #[test]
 fn test_vec3_fmt() {
     let a = Vec3::new(1.0, 2.0, 3.0);
-    #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))]
+    #[cfg(all(
+        target_feature = "sse2",
+        feature = "simd-vec3",
+        not(feature = "scalar-math")
+    ))]
     assert_eq!(format!("{:?}", a), "Vec3(__m128(1.0, 2.0, 3.0, 3.0))");
-    #[cfg(any(not(target_feature = "sse2"), feature = "scalar-math"))]
+    #[cfg(any(
+        not(target_feature = "sse2"),
+        not(feature = "simd-vec3"),
+        feature = "scalar-math"
+    ))]
     assert_eq!(format!("{:?}", a), "Vec3(1.0, 2.0, 3.0)");
     // assert_eq!(format!("{:#?}", a), "Vec3(\n    1.0,\n    2.0,\n    3.0\n)");
     assert_eq!(format!("{}", a), "[1, 2, 3]");

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -10,7 +10,7 @@ use std::f32;
 #[test]
 fn test_vec3_align() {
     use std::mem;
-    if cfg!(any(not(feature = "simd-vec3"), feature = "scalar-math")) {
+    if cfg!(any(feature = "packed-vec3", feature = "scalar-math")) {
         assert_eq!(12, mem::size_of::<Vec3>());
         assert_eq!(4, mem::align_of::<Vec3>());
         assert_eq!(12, mem::size_of::<Vec3Mask>());
@@ -53,13 +53,13 @@ fn test_vec3_fmt() {
     let a = Vec3::new(1.0, 2.0, 3.0);
     #[cfg(all(
         target_feature = "sse2",
-        feature = "simd-vec3",
+        not(feature = "packed-vec3"),
         not(feature = "scalar-math")
     ))]
     assert_eq!(format!("{:?}", a), "Vec3(__m128(1.0, 2.0, 3.0, 3.0))");
     #[cfg(any(
         not(target_feature = "sse2"),
-        not(feature = "simd-vec3"),
+        feature = "packed-vec3",
         feature = "scalar-math"
     ))]
     assert_eq!(format!("{:?}", a), "Vec3(1.0, 2.0, 3.0)");


### PR DESCRIPTION
This avoids wasting space due to 16 byte alignment at the expense of some performance.
