### PR TITLE
Added x,y,z,w methods to Quat

### DIFF
--- a/src/f32/quat.rs
+++ b/src/f32/quat.rs
@@ -441,6 +441,29 @@ impl Quat {
             Self(Vec4(_mm_add_ps(result0, result1)))
         }
     }
+    /// Returns element `x`.
+    #[inline]
+    pub fn x(self) -> f32 {
+        self.0.x()
+    }
+
+    /// Returns element `y`.
+    #[inline]
+    pub fn y(self) -> f32 {
+        self.0.y()
+    }
+
+    /// Returns element `z`.
+    #[inline]
+    pub fn z(self) -> f32 {
+        self.0.z()
+    }
+
+    /// Returns element `w`.
+    #[inline]
+    pub fn w(self) -> f32 {
+        self.0.w()
+    }
 }
 
 impl fmt::Debug for Quat {

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -230,3 +230,17 @@ fn test_quat_serde() {
     let deserialized = serde_json::from_str::<Quat>("[1.0,2.0,3.0,4.0,5.0]");
     assert!(deserialized.is_err());
 }
+
+#[test]
+fn test_quat_elements() {
+    let x = 1.0;
+    let y = 2.0;
+    let z = 3.0;
+    let w = 4.0;
+
+    let a = Quat::from_xyzw(x, y, z, w);
+    assert!(a.x() == x);
+    assert!(a.y() == y);
+    assert!(a.z() == z);
+    assert!(a.w() == w);
+}


### PR DESCRIPTION
This adds methods to read the elements of a quaternion directly. 
You can currently do this by using the various `From` traits implemented on Quat, e.g.: 
```rust
let (x, y, z, w) = quat;
```
or 

```rust
let x = Vec4::from(quat).x();
```
The first of these has the disadvantage that you don't know for sure that you got the order correct without looking up the source. The second is better, perhaps, but again, it's not obvious that it's valid without checking, since the Quat type could well store its elements in the order `w`,`x`,`y`,`z`.

Adding these methods removes the need for any indirection, brings Quat more in line with other data types, and I think it leads to more obviously correct code. 

