### PR TITLE
Rename perspective_rh to match perspective_lh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+# [Unreleased]
+
+### Changed
+* Renamed `Mat4::perspective_rh_gl` to `Mat4::perspective_rh`.
+
 ## [0.8.6] - 2020-02-18
 
 ### Added

--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -542,6 +542,9 @@ impl Mat4 {
         Mat4::look_to_lh(eye, center - eye, up)
     }
 
+    /// Creates a right-handed view transform.
+    /// This is the same as the OpenGL `gluLookAt` function.
+    /// See https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluLookAt.xml
     #[inline]
     pub fn look_at_rh(eye: Vec3, center: Vec3, up: Vec3) -> Self {
         glam_assert!(up.is_normalized());
@@ -551,7 +554,7 @@ impl Mat4 {
     /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml
-    pub fn perspective_rh_gl(
+    pub fn perspective_rh(
         fov_y_radians: f32,
         aspect_ratio: f32,
         z_near: f32,

--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -554,12 +554,7 @@ impl Mat4 {
     /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml
-    pub fn perspective_rh(
-        fov_y_radians: f32,
-        aspect_ratio: f32,
-        z_near: f32,
-        z_far: f32,
-    ) -> Self {
+    pub fn perspective_rh(fov_y_radians: f32, aspect_ratio: f32, z_near: f32, z_far: f32) -> Self {
         let inv_length = 1.0 / (z_near - z_far);
         let f = 1.0 / (0.5 * fov_y_radians).tan();
         let a = f / aspect_ratio;
@@ -621,14 +616,25 @@ impl Mat4 {
     }
 
     #[inline]
-    #[deprecated(since = "0.8.2", note = "please use `Mat4::perspective_rh_gl` instead")]
+    #[deprecated(since = "0.8.6", note = "please use `Mat4::perspective_rh` instead")]
+    pub fn perspective_rh_gl(
+        fov_y_radians: f32,
+        aspect_ratio: f32,
+        z_near: f32,
+        z_far: f32,
+    ) -> Self {
+        Mat4::perspective_rh(fov_y_radians, aspect_ratio, z_near, z_far)
+    }
+
+    #[inline]
+    #[deprecated(since = "0.8.2", note = "please use `Mat4::perspective_rh` instead")]
     pub fn perspective_glu_rh(
         fov_y_radians: f32,
         aspect_ratio: f32,
         z_near: f32,
         z_far: f32,
     ) -> Self {
-        Mat4::perspective_rh_gl(fov_y_radians, aspect_ratio, z_near, z_far)
+        Mat4::perspective_rh(fov_y_radians, aspect_ratio, z_near, z_far)
     }
 
     /// Creates an infinite right-handed perspective projection matrix with

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -327,8 +327,19 @@ fn test_mat4_look_at() {
 }
 
 #[test]
-fn test_mat4_perspective_gl_rh() {
-    let projection = Mat4::perspective_rh_gl(f32::to_radians(90.0), 2.0, 5.0, 15.0);
+fn test_mat4_perspective_rh() {
+    let projection = Mat4::perspective_rh(f32::to_radians(90.0), 2.0, 5.0, 15.0);
+
+    #[allow(deprecated)]
+    let projection_deprecated_glu_rh =
+        Mat4::perspective_glu_rh(f32::to_radians(90.0), 2.0, 5.0, 15.0);
+
+    #[allow(deprecated)]
+    let projection_deprecated_rh_gl =
+        Mat4::perspective_rh_gl(f32::to_radians(90.0), 2.0, 5.0, 15.0);
+
+    assert_approx_eq!(projection, projection_deprecated_glu_rh);
+    assert_approx_eq!(projection, projection_deprecated_rh_gl);
 
     let original = Vec3::new(5.0, 5.0, -15.0);
     let projected = projection * original.extend(1.0);


### PR DESCRIPTION
Dropping the `_gl` suffix is consistent with #39. Also added the `gluLookAt` doc link for `Mat4::look_at_rh`.