### PR TITLE
Migrated from using cfg-if to setting mutually exclusive cfg values via build.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,6 @@ scalar-math = []
 transform-types = []
 
 [dependencies]
-cfg-if = "0.1"
 mint = { version = "0.5", optional = true, default-features = false  }
 rand = { version = "0.7", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 license = "MIT OR Apache-2.0"
 keywords = ["gamedev", "math", "matrix", "vector", "quaternion"]
 categories = ["game-engines"]
+build = "build.rs"
 
 [badges]
 travis-ci = { repository = "bitshifter/glam-rs" }

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,35 @@
+use std::{collections::HashSet, env};
+
+fn main() {
+    let force_scalar_math = env::var("CARGO_FEATURE_SCALAR_MATH").is_ok();
+    let force_packed_vec3 = env::var("CARGO_FEATURE_PACKED_VEC3").is_ok();
+
+    let cfg_target_feature: Option<String> = env::var("CARGO_CFG_TARGET_FEATURE").ok();
+    let target_features: HashSet<&str> = cfg_target_feature
+        .as_ref()
+        .map_or(HashSet::new(), |v| v.split(',').collect());
+
+    let target_feature_sse2 = target_features.contains("sse2");
+
+    if target_feature_sse2 && !force_scalar_math && !force_packed_vec3 {
+        println!("cargo:rustc-cfg=vec3sse2_data");
+        println!("cargo:rustc-cfg=vec3sse2_impl");
+    } else if force_scalar_math || force_packed_vec3 {
+        println!("cargo:rustc-cfg=vec3f32_data");
+        println!("cargo:rustc-cfg=vec3f32_impl");
+    } else {
+        // simd not available but not explicitly disabled so maintain 16 byte alignment
+        println!("cargo:rustc-cfg=vec3f32a16_data");
+        println!("cargo:rustc-cfg=vec3f32_impl");
+    }
+
+    if target_feature_sse2 && !force_scalar_math {
+        println!("cargo:rustc-cfg=vec4sse2");
+    } else {
+        if !force_scalar_math {
+            // simd not available but not explicitly disabled so maintain 16 byte alignment
+            println!("cargo:rustc-cfg=vec4f32_align16");
+        }
+        println!("cargo:rustc-cfg=vec4f32");
+    }
+}

--- a/build.rs
+++ b/build.rs
@@ -1,16 +1,11 @@
-use std::{collections::HashSet, env};
+use std::env;
 
 fn main() {
     let force_scalar_math = env::var("CARGO_FEATURE_SCALAR_MATH").is_ok();
     let force_packed_vec3 = env::var("CARGO_FEATURE_PACKED_VEC3").is_ok();
 
-    let cfg_target_feature: Option<String> = env::var("CARGO_CFG_TARGET_FEATURE").ok();
-
-    // TODO: probably excessive making a hashmap
-    let target_features: HashSet<&str> = cfg_target_feature
-        .as_ref()
-        .map_or(HashSet::new(), |v| v.split(',').collect());
-    let target_feature_sse2 = target_features.contains("sse2");
+    let target_feature_sse2 = env::var("CARGO_CFG_TARGET_FEATURE")
+        .map_or(false, |cfg| cfg.split(',').find(|&f| f == "sse2").is_some());
 
     if target_feature_sse2 && !force_scalar_math && !force_packed_vec3 {
         println!("cargo:rustc-cfg=vec3sse2");

--- a/build.rs
+++ b/build.rs
@@ -5,22 +5,21 @@ fn main() {
     let force_packed_vec3 = env::var("CARGO_FEATURE_PACKED_VEC3").is_ok();
 
     let cfg_target_feature: Option<String> = env::var("CARGO_CFG_TARGET_FEATURE").ok();
+
+    // TODO: probably excessive making a hashmap
     let target_features: HashSet<&str> = cfg_target_feature
         .as_ref()
         .map_or(HashSet::new(), |v| v.split(',').collect());
-
     let target_feature_sse2 = target_features.contains("sse2");
 
     if target_feature_sse2 && !force_scalar_math && !force_packed_vec3 {
-        println!("cargo:rustc-cfg=vec3sse2_data");
-        println!("cargo:rustc-cfg=vec3sse2_impl");
-    } else if force_scalar_math || force_packed_vec3 {
-        println!("cargo:rustc-cfg=vec3f32_data");
-        println!("cargo:rustc-cfg=vec3f32_impl");
+        println!("cargo:rustc-cfg=vec3sse2");
     } else {
-        // simd not available but not explicitly disabled so maintain 16 byte alignment
-        println!("cargo:rustc-cfg=vec3f32a16_data");
-        println!("cargo:rustc-cfg=vec3f32_impl");
+        if !force_scalar_math && !force_packed_vec3 {
+            // simd not available but not explicitly disabled so maintain 16 byte alignment
+            println!("cargo:rustc-cfg=vec3f32_align16");
+        }
+        println!("cargo:rustc-cfg=vec3f32");
     }
 
     if target_feature_sse2 && !force_scalar_math {

--- a/src/f32/funcs.rs
+++ b/src/f32/funcs.rs
@@ -43,7 +43,7 @@ pub fn scalar_acos(value: f32) -> f32 {
     }
 }
 
-#[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))]
+#[cfg(vec4sse2)]
 pub(crate) mod sse2 {
     #[cfg(target_arch = "x86")]
     use std::arch::x86::*;

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -294,9 +294,9 @@ impl Mat3 {
     pub fn transpose(&self) -> Self {
         #[cfg(vec3sse2)]
         {
-            #[cfg(all(target_arch = "x86", target_feature = "sse2"))]
+            #[cfg(target_arch = "x86")]
             use std::arch::x86::*;
-            #[cfg(all(target_arch = "x86_64", target_feature = "sse2"))]
+            #[cfg(target_arch = "x86_64")]
             use std::arch::x86_64::*;
             unsafe {
                 let tmp0 = _mm_shuffle_ps(self.x_axis.0, self.y_axis.0, 0b01_00_01_00);

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -292,7 +292,7 @@ impl Mat3 {
     /// Returns the transpose of `self`.
     #[inline]
     pub fn transpose(&self) -> Self {
-        #[cfg(vec3sse2_impl)]
+        #[cfg(vec3sse2)]
         {
             #[cfg(all(target_arch = "x86", target_feature = "sse2"))]
             use std::arch::x86::*;
@@ -309,7 +309,7 @@ impl Mat3 {
                 }
             }
         }
-        #[cfg(vec3f32_impl)]
+        #[cfg(vec3f32)]
         {
             let (m00, m01, m02) = self.x_axis.into();
             let (m10, m11, m12) = self.y_axis.into();

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -3,7 +3,7 @@ use cfg_if::cfg_if;
 use core::{fmt, ops::*};
 
 cfg_if! {
-    if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
+    if #[cfg(vec3sse2_data)] {
         use crate::{
             f32::{X_AXIS, Y_AXIS, Z_AXIS},
             Align16,
@@ -17,65 +17,72 @@ cfg_if! {
         /// A 3-dimensional vector.
         ///
         /// This type is 16 byte aligned and thus contains 4 bytes padding.
-#[derive(Clone, Copy, Debug)]
-#[repr(C)]
+        #[derive(Clone, Copy, Debug)]
+        #[repr(C)]
         pub struct Vec3(pub(crate) __m128);
 
-        impl Vec3 {
-            /// Calculates the Vec3 dot product and returns answer in x lane of __m128.
-            #[inline]
-            unsafe fn dot_as_m128(self, other: Self) -> __m128 {
-                let x2_y2_z2_w2 = _mm_mul_ps(self.0, other.0);
-                let y2_0_0_0 = _mm_shuffle_ps(x2_y2_z2_w2, x2_y2_z2_w2, 0b00_00_00_01);
-                let z2_0_0_0 = _mm_shuffle_ps(x2_y2_z2_w2, x2_y2_z2_w2, 0b00_00_00_10);
-                let x2y2_0_0_0 = _mm_add_ss(x2_y2_z2_w2, y2_0_0_0);
-                _mm_add_ss(x2y2_0_0_0, z2_0_0_0)
-            }
-        }
-
-        impl Default for Vec3 {
-            #[inline]
-            fn default() -> Self {
-                Vec3::zero()
-            }
-        }
-
-        impl PartialEq for Vec3 {
-            #[inline]
-            fn eq(&self, other: &Self) -> bool {
-                self.cmpeq(*other).all()
-            }
-        }
-
-        impl PartialOrd for Vec3 {
-            #[inline]
-            fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-                self.as_ref().partial_cmp(other.as_ref())
-            }
-        }
-
-        impl From<Vec3> for __m128 {
-            // TODO: write test
-            #[cfg_attr(tarpaulin, skip)]
-            #[inline]
-            fn from(t: Vec3) -> Self {
-                t.0
-            }
-        }
-
-        impl From<__m128> for Vec3 {
-            #[inline]
-            fn from(t: __m128) -> Self {
-                Self(t)
-            }
-        }
     } else {
         /// A 3-dimensional vector.
         #[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Default)]
         // if compiling with simd enabled assume alignment needs to match the simd type
-        #[cfg_attr(all(not(feature = "packed-vec3"), not(feature = "scalar-math")), repr(align(16)))]
+        #[cfg_attr(vec3f32a16_data, repr(align(16)))]
         #[repr(C)]
         pub struct Vec3(pub(crate) f32, pub(crate) f32, pub(crate) f32);
+    }
+}
+
+#[cfg(vec3sse2_impl)]
+impl Vec3 {
+    /// Calculates the Vec3 dot product and returns answer in x lane of __m128.
+    #[inline]
+    unsafe fn dot_as_m128(self, other: Self) -> __m128 {
+        let x2_y2_z2_w2 = _mm_mul_ps(self.0, other.0);
+        let y2_0_0_0 = _mm_shuffle_ps(x2_y2_z2_w2, x2_y2_z2_w2, 0b00_00_00_01);
+        let z2_0_0_0 = _mm_shuffle_ps(x2_y2_z2_w2, x2_y2_z2_w2, 0b00_00_00_10);
+        let x2y2_0_0_0 = _mm_add_ss(x2_y2_z2_w2, y2_0_0_0);
+        _mm_add_ss(x2y2_0_0_0, z2_0_0_0)
+    }
+}
+
+#[cfg(vec3sse2_impl)]
+impl Default for Vec3 {
+    #[inline]
+    fn default() -> Self {
+        Vec3::zero()
+    }
+}
+
+#[cfg(vec3sse2_impl)]
+impl PartialEq for Vec3 {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.cmpeq(*other).all()
+    }
+}
+
+#[cfg(vec3sse2_impl)]
+impl PartialOrd for Vec3 {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.as_ref().partial_cmp(other.as_ref())
+    }
+}
+
+#[cfg(vec3sse2_impl)]
+impl From<Vec3> for __m128 {
+    // TODO: write test
+    #[cfg_attr(tarpaulin, skip)]
+    #[inline]
+    fn from(t: Vec3) -> Self {
+        t.0
+    }
+}
+
+#[cfg(vec3sse2_impl)]
+impl From<__m128> for Vec3 {
+    #[inline]
+    fn from(t: __m128) -> Self {
+        Self(t)
     }
 }
 
@@ -88,98 +95,114 @@ impl Vec3 {
     /// Creates a new `Vec3`.
     #[inline]
     pub fn new(x: f32, y: f32, z: f32) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_set_ps(z, z, y, x)) }
-            } else {
-                Self(x, y, z)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_set_ps(z, z, y, x))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(x, y, z)
         }
     }
 
     /// Creates a new `Vec3` with all elements set to `0.0`.
     #[inline]
     pub fn zero() -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_setzero_ps()) }
-            } else {
-                Self(0.0, 0.0, 0.0)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_setzero_ps())
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(0.0, 0.0, 0.0)
         }
     }
 
     /// Creates a new `Vec3` with all elements set to `1.0`.
     #[inline]
     pub fn one() -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_set1_ps(1.0)) }
-            } else {
-                Self(1.0, 1.0, 1.0)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_set1_ps(1.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(1.0, 1.0, 1.0)
         }
     }
 
     /// Creates a new `Vec3` with values `[x: 1.0, y: 0.0, z: 0.0]`.
     #[inline]
     pub fn unit_x() -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_load_ps(X_AXIS.0.as_ptr())) }
-            } else {
-                Self(1.0, 0.0, 0.0)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_load_ps(X_AXIS.0.as_ptr()))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(1.0, 0.0, 0.0)
         }
     }
 
     /// Creates a new `Vec3` with values `[x: 0.0, y: 1.0, z: 0.0]`.
     #[inline]
     pub fn unit_y() -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_load_ps(Y_AXIS.0.as_ptr())) }
-            } else {
-                Self(0.0, 1.0, 0.0)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_load_ps(Y_AXIS.0.as_ptr()))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(0.0, 1.0, 0.0)
         }
     }
 
     /// Creates a new `Vec3` with values `[x: 0.0, y: 0.0, z: 1.0]`.
     #[inline]
     pub fn unit_z() -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_load_ps(Z_AXIS.0.as_ptr())) }
-            } else {
-                Self(0.0, 0.0, 1.0)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_load_ps(Z_AXIS.0.as_ptr()))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(0.0, 0.0, 1.0)
         }
     }
 
     /// Creates a new `Vec3` with all elements set to `v`.
     #[inline]
     pub fn splat(v: f32) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_set_ps1(v)) }
-            } else {
-                Self(v, v, v)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_set_ps1(v))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(v, v, v)
         }
     }
 
     /// Creates a new `Vec4` from `self` and the given `w` value.
     #[inline]
     pub fn extend(self, w: f32) -> Vec4 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                let mut temp: Vec4 = self.0.into();
-                temp.set_w(w);
-                temp
-            } else {
-                Vec4::new(self.0, self.1, self.2, w)
-            }
+        #[cfg(vec3sse2_impl)]
+        {
+            let mut temp: Vec4 = self.0.into();
+            temp.set_w(w);
+            temp
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Vec4::new(self.0, self.1, self.2, w)
         }
     }
 
@@ -187,235 +210,259 @@ impl Vec3 {
     /// removing `z`.
     #[inline]
     pub fn truncate(self) -> Vec2 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                let (x, y, _) = self.into();
-                Vec2::new(x, y)
-            } else {
-                Vec2::new(self.0, self.1)
-            }
+        #[cfg(vec3sse2_impl)]
+        {
+            let (x, y, _) = self.into();
+            Vec2::new(x, y)
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Vec2::new(self.0, self.1)
         }
     }
 
     /// Returns element `x`.
     #[inline]
     pub fn x(self) -> f32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { _mm_cvtss_f32(self.0) }
-            } else {
-                self.0
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            _mm_cvtss_f32(self.0)
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.0
         }
     }
 
     /// Returns element `y`.
     #[inline]
     pub fn y(self) -> f32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { _mm_cvtss_f32(_mm_shuffle_ps(self.0, self.0, 0b01_01_01_01)) }
-            } else {
-                self.1
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            _mm_cvtss_f32(_mm_shuffle_ps(self.0, self.0, 0b01_01_01_01))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.1
         }
     }
 
     /// Returns element `z`.
     #[inline]
     pub fn z(self) -> f32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { _mm_cvtss_f32(_mm_shuffle_ps(self.0, self.0, 0b10_10_10_10)) }
-            } else {
-                self.2
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            _mm_cvtss_f32(_mm_shuffle_ps(self.0, self.0, 0b10_10_10_10))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.2
         }
     }
 
     /// Returns a mutable reference to element `x`.
     #[inline]
     pub fn x_mut(&mut self) -> &mut f32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { &mut *(self as *mut Self as *mut f32) }
-            } else {
-                &mut self.0
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            &mut *(self as *mut Self as *mut f32)
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            &mut self.0
         }
     }
 
     /// Returns a mutable reference to element `y`.
     #[inline]
     pub fn y_mut(&mut self) -> &mut f32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { &mut *(self as *mut Self as *mut f32).offset(1) }
-            } else {
-                &mut self.1
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            &mut *(self as *mut Self as *mut f32).offset(1)
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            &mut self.1
         }
     }
 
     /// Returns a mutable reference to element `z`.
     #[inline]
     pub fn z_mut(&mut self) -> &mut f32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { &mut *(self as *mut Self as *mut f32).offset(2) }
-            } else {
-                &mut self.2
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            &mut *(self as *mut Self as *mut f32).offset(2)
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            &mut self.2
         }
     }
 
     /// Sets element `x`.
     #[inline]
     pub fn set_x(&mut self, x: f32) {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe {
-                    self.0 = _mm_move_ss(self.0, _mm_set_ss(x));
-                }
-            } else {
-                self.0 = x;
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            self.0 = _mm_move_ss(self.0, _mm_set_ss(x));
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.0 = x;
         }
     }
 
     /// Sets element `y`.
     #[inline]
     pub fn set_y(&mut self, y: f32) {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe {
-                    let mut t = _mm_move_ss(self.0, _mm_set_ss(y));
-                    t = _mm_shuffle_ps(t, t, 0b11_10_00_00);
-                    self.0 = _mm_move_ss(t, self.0);
-                }
-            } else {
-                self.1 = y;
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            let mut t = _mm_move_ss(self.0, _mm_set_ss(y));
+            t = _mm_shuffle_ps(t, t, 0b11_10_00_00);
+            self.0 = _mm_move_ss(t, self.0);
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.1 = y;
         }
     }
 
     /// Sets element `z`.
     #[inline]
     pub fn set_z(&mut self, z: f32) {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe {
-                    let mut t = _mm_move_ss(self.0, _mm_set_ss(z));
-                    t = _mm_shuffle_ps(t, t, 0b11_00_01_00);
-                    self.0 = _mm_move_ss(t, self.0);
-                }
-            } else {
-                self.2 = z;
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            let mut t = _mm_move_ss(self.0, _mm_set_ss(z));
+            t = _mm_shuffle_ps(t, t, 0b11_00_01_00);
+            self.0 = _mm_move_ss(t, self.0);
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.2 = z;
         }
     }
 
     /// Returns a `Vec3` with all elements set to the value of element `x`.
     #[inline]
     pub(crate) fn dup_x(self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_shuffle_ps(self.0, self.0, 0b00_00_00_00)) }
-            } else {
-                Self(self.0, self.0, self.0)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_shuffle_ps(self.0, self.0, 0b00_00_00_00))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.0, self.0, self.0)
         }
     }
 
     /// Returns a `Vec3` with all elements set to the value of element `y`.
     #[inline]
     pub(crate) fn dup_y(self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_shuffle_ps(self.0, self.0, 0b01_01_01_01)) }
-            } else {
-                Self(self.1, self.1, self.1)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_shuffle_ps(self.0, self.0, 0b01_01_01_01))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.1, self.1, self.1)
         }
     }
 
     /// Returns a `Vec3` with all elements set to the value of element `z`.
     #[inline]
     pub(crate) fn dup_z(self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_shuffle_ps(self.0, self.0, 0b10_10_10_10)) }
-            } else {
-                Self(self.2, self.2, self.2)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_shuffle_ps(self.0, self.0, 0b10_10_10_10))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.2, self.2, self.2)
         }
     }
 
     /// Computes the dot product of `self` and `other`.
     #[inline]
     pub fn dot(self, other: Self) -> f32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { _mm_cvtss_f32(self.dot_as_m128(other)) }
-            } else {
-                (self.0 * other.0) + (self.1 * other.1) + (self.2 * other.2)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            _mm_cvtss_f32(self.dot_as_m128(other))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            (self.0 * other.0) + (self.1 * other.1) + (self.2 * other.2)
         }
     }
 
     /// Returns Vec3 dot in all lanes of Vec3
     #[inline]
     pub(crate) fn dot_as_vec3(self, other: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe {
-                    let dot_in_x = self.dot_as_m128(other);
-                    Vec3(_mm_shuffle_ps(dot_in_x, dot_in_x, 0b00_00_00_00))
-                }
-            } else {
-                let dot = self.dot(other);
-                Vec3::new(dot, dot, dot)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            let dot_in_x = self.dot_as_m128(other);
+            Vec3(_mm_shuffle_ps(dot_in_x, dot_in_x, 0b00_00_00_00))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            let dot = self.dot(other);
+            Vec3::new(dot, dot, dot)
         }
     }
 
     /// Computes the cross product of `self` and `other`.
     #[inline]
     pub fn cross(self, other: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                // x  <-  a.y*b.z - a.z*b.y
-                // y  <-  a.z*b.x - a.x*b.z
-                // z  <-  a.x*b.y - a.y*b.x
-                // We can save a shuffle by grouping it in this wacky order:
-                // (self.zxy() * other - self * other.zxy()).zxy()
-                unsafe {
-                    let lhszxy = _mm_shuffle_ps(self.0, self.0, 0b01_01_00_10);
-                    let rhszxy = _mm_shuffle_ps(other.0, other.0, 0b01_01_00_10);
-                    let lhszxy_rhs = _mm_mul_ps(lhszxy, other.0);
-                    let rhszxy_lhs = _mm_mul_ps(rhszxy, self.0);
-                    let sub = _mm_sub_ps(lhszxy_rhs, rhszxy_lhs);
-                    Self(_mm_shuffle_ps(sub, sub, 0b01_01_00_10))
-                }
-            } else {
-                Self(
-                    self.1 * other.2 - other.1 * self.2,
-                    self.2 * other.0 - other.2 * self.0,
-                    self.0 * other.1 - other.0 * self.1,
-                )
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            // x  <-  a.y*b.z - a.z*b.y
+            // y  <-  a.z*b.x - a.x*b.z
+            // z  <-  a.x*b.y - a.y*b.x
+            // We can save a shuffle by grouping it in this wacky order:
+            // (self.zxy() * other - self * other.zxy()).zxy()
+            let lhszxy = _mm_shuffle_ps(self.0, self.0, 0b01_01_00_10);
+            let rhszxy = _mm_shuffle_ps(other.0, other.0, 0b01_01_00_10);
+            let lhszxy_rhs = _mm_mul_ps(lhszxy, other.0);
+            let rhszxy_lhs = _mm_mul_ps(rhszxy, self.0);
+            let sub = _mm_sub_ps(lhszxy_rhs, rhszxy_lhs);
+            Self(_mm_shuffle_ps(sub, sub, 0b01_01_00_10))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(
+                self.1 * other.2 - other.1 * self.2,
+                self.2 * other.0 - other.2 * self.0,
+                self.0 * other.1 - other.0 * self.1,
+            )
         }
     }
 
     /// Computes the length of `self`.
     #[inline]
     pub fn length(self) -> f32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { _mm_cvtss_f32(_mm_sqrt_ss(self.dot_as_m128(self))) }
-            } else {
-                self.dot(self).sqrt()
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            _mm_cvtss_f32(_mm_sqrt_ss(self.dot_as_m128(self)))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.dot(self).sqrt()
         }
     }
 
@@ -433,16 +480,18 @@ impl Vec3 {
     /// For valid results, `self` must _not_ be of length zero.
     #[inline]
     pub fn length_reciprocal(self) -> f32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                let dot = self.dot_as_vec3(self);
-                unsafe {
-                    // _mm_rsqrt_ps is lower precision
-                    _mm_cvtss_f32(_mm_div_ps(_mm_set_ps1(1.0), _mm_sqrt_ps(dot.0)))
-                }
-            } else {
-                1.0 / self.length()
+        #[cfg(vec3sse2_impl)]
+        {
+            let dot = self.dot_as_vec3(self);
+            unsafe {
+                // _mm_rsqrt_ps is lower precision
+                _mm_cvtss_f32(_mm_div_ps(_mm_set_ps1(1.0), _mm_sqrt_ps(dot.0)))
             }
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            1.0 / self.length()
         }
     }
 
@@ -451,13 +500,15 @@ impl Vec3 {
     /// For valid results, `self` must _not_ be of length zero.
     #[inline]
     pub fn normalize(self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                let dot = self.dot_as_vec3(self);
-                unsafe { Self(_mm_div_ps(self.0, _mm_sqrt_ps(dot.0))) }
-            } else {
-                self * self.length_reciprocal()
-            }
+        #[cfg(vec3sse2_impl)]
+        {
+            let dot = self.dot_as_vec3(self);
+            unsafe { Self(_mm_div_ps(self.0, _mm_sqrt_ps(dot.0))) }
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self * self.length_reciprocal()
         }
     }
 
@@ -468,16 +519,18 @@ impl Vec3 {
     /// taking the minimum of each element individually.
     #[inline]
     pub fn min(self, other: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_min_ps(self.0, other.0)) }
-            } else {
-                Self(
-                    self.0.min(other.0),
-                    self.1.min(other.1),
-                    self.2.min(other.2),
-                )
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_min_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(
+                self.0.min(other.0),
+                self.1.min(other.1),
+                self.2.min(other.2),
+            )
         }
     }
 
@@ -488,16 +541,18 @@ impl Vec3 {
     /// taking the maximum of each element individually.
     #[inline]
     pub fn max(self, other: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_max_ps(self.0, other.0)) }
-            } else {
-                Self(
-                    self.0.max(other.0),
-                    self.1.max(other.1),
-                    self.2.max(other.2),
-                )
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_max_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(
+                self.0.max(other.0),
+                self.1.max(other.1),
+                self.2.max(other.2),
+            )
         }
     }
 
@@ -506,17 +561,17 @@ impl Vec3 {
     /// In other words, this computes `min(x, y, z)`.
     #[inline]
     pub fn min_element(self) -> f32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe {
-                    let v = self.0;
-                    let v = _mm_min_ps(v, _mm_shuffle_ps(v, v, 0b01_01_10_10));
-                    let v = _mm_min_ps(v, _mm_shuffle_ps(v, v, 0b00_00_00_01));
-                    _mm_cvtss_f32(v)
-                }
-            } else {
-                self.0.min(self.1.min(self.2))
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            let v = self.0;
+            let v = _mm_min_ps(v, _mm_shuffle_ps(v, v, 0b01_01_10_10));
+            let v = _mm_min_ps(v, _mm_shuffle_ps(v, v, 0b00_00_00_01));
+            _mm_cvtss_f32(v)
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.0.min(self.1.min(self.2))
         }
     }
 
@@ -525,17 +580,17 @@ impl Vec3 {
     /// In other words, this computes `max(x, y, z)`.
     #[inline]
     pub fn max_element(self) -> f32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe {
-                    let v = self.0;
-                    let v = _mm_max_ps(v, _mm_shuffle_ps(v, v, 0b00_00_10_10));
-                    let v = _mm_max_ps(v, _mm_shuffle_ps(v, v, 0b00_00_00_01));
-                    _mm_cvtss_f32(v)
-                }
-            } else {
-                self.0.max(self.1.max(self.2))
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            let v = self.0;
+            let v = _mm_max_ps(v, _mm_shuffle_ps(v, v, 0b00_00_10_10));
+            let v = _mm_max_ps(v, _mm_shuffle_ps(v, v, 0b00_00_00_01));
+            _mm_cvtss_f32(v)
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.0.max(self.1.max(self.2))
         }
     }
 
@@ -545,16 +600,18 @@ impl Vec3 {
     /// In other words, this computes `[x1 == x2, y1 == y2, z1 == z2, w1 == w2]`.
     #[inline]
     pub fn cmpeq(self, other: Self) -> Vec3Mask {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Vec3Mask(_mm_cmpeq_ps(self.0, other.0)) }
-            } else {
-                Vec3Mask::new(
-                    self.0.eq(&other.0),
-                    self.1.eq(&other.1),
-                    self.2.eq(&other.2),
-                )
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Vec3Mask(_mm_cmpeq_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Vec3Mask::new(
+                self.0.eq(&other.0),
+                self.1.eq(&other.1),
+                self.2.eq(&other.2),
+            )
         }
     }
 
@@ -564,16 +621,18 @@ impl Vec3 {
     /// In other words, this computes `[x1 != x2, y1 != y2, z1 != z2, w1 != w2]`.
     #[inline]
     pub fn cmpne(self, other: Self) -> Vec3Mask {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Vec3Mask(_mm_cmpneq_ps(self.0, other.0)) }
-            } else {
-                Vec3Mask::new(
-                    self.0.ne(&other.0),
-                    self.1.ne(&other.1),
-                    self.2.ne(&other.2),
-                )
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Vec3Mask(_mm_cmpneq_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Vec3Mask::new(
+                self.0.ne(&other.0),
+                self.1.ne(&other.1),
+                self.2.ne(&other.2),
+            )
         }
     }
 
@@ -583,16 +642,18 @@ impl Vec3 {
     /// In other words, this computes `[x1 >= x2, y1 >= y2, z1 >= z2, w1 >= w2]`.
     #[inline]
     pub fn cmpge(self, other: Self) -> Vec3Mask {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Vec3Mask(_mm_cmpge_ps(self.0, other.0)) }
-            } else {
-                Vec3Mask::new(
-                    self.0.ge(&other.0),
-                    self.1.ge(&other.1),
-                    self.2.ge(&other.2),
-                )
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Vec3Mask(_mm_cmpge_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Vec3Mask::new(
+                self.0.ge(&other.0),
+                self.1.ge(&other.1),
+                self.2.ge(&other.2),
+            )
         }
     }
 
@@ -602,16 +663,18 @@ impl Vec3 {
     /// In other words, this computes `[x1 > x2, y1 > y2, z1 > z2, w1 > w2]`.
     #[inline]
     pub fn cmpgt(self, other: Self) -> Vec3Mask {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Vec3Mask(_mm_cmpgt_ps(self.0, other.0)) }
-            } else {
-                Vec3Mask::new(
-                    self.0.gt(&other.0),
-                    self.1.gt(&other.1),
-                    self.2.gt(&other.2),
-                )
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Vec3Mask(_mm_cmpgt_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Vec3Mask::new(
+                self.0.gt(&other.0),
+                self.1.gt(&other.1),
+                self.2.gt(&other.2),
+            )
         }
     }
 
@@ -621,16 +684,18 @@ impl Vec3 {
     /// In other words, this computes `[x1 <= x2, y1 <= y2, z1 <= z2, w1 <= w2]`.
     #[inline]
     pub fn cmple(self, other: Self) -> Vec3Mask {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Vec3Mask(_mm_cmple_ps(self.0, other.0)) }
-            } else {
-                Vec3Mask::new(
-                    self.0.le(&other.0),
-                    self.1.le(&other.1),
-                    self.2.le(&other.2),
-                )
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Vec3Mask(_mm_cmple_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Vec3Mask::new(
+                self.0.le(&other.0),
+                self.1.le(&other.1),
+                self.2.le(&other.2),
+            )
         }
     }
 
@@ -640,32 +705,36 @@ impl Vec3 {
     /// In other words, this computes `[x1 < x2, y1 < y2, z1 < z2, w1 < w2]`.
     #[inline]
     pub fn cmplt(self, other: Self) -> Vec3Mask {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Vec3Mask(_mm_cmplt_ps(self.0, other.0)) }
-            } else {
-                Vec3Mask::new(
-                    self.0.lt(&other.0),
-                    self.1.lt(&other.1),
-                    self.2.lt(&other.2),
-                )
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Vec3Mask(_mm_cmplt_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Vec3Mask::new(
+                self.0.lt(&other.0),
+                self.1.lt(&other.1),
+                self.2.lt(&other.2),
+            )
         }
     }
 
     /// Per element multiplication/addition of the three inputs: b + (self * a)
     #[inline]
     pub(crate) fn mul_add(self, a: Self, b: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_add_ps(_mm_mul_ps(self.0, a.0), b.0)) }
-            } else {
-                Self(
-                    (self.0 * a.0) + b.0,
-                    (self.1 * a.1) + b.1,
-                    (self.2 * a.2) + b.2,
-                )
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_add_ps(_mm_mul_ps(self.0, a.0), b.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(
+                (self.0 * a.0) + b.0,
+                (self.1 * a.1) + b.1,
+                (self.2 * a.2) + b.2,
+            )
         }
     }
 
@@ -674,16 +743,18 @@ impl Vec3 {
     #[allow(dead_code)]
     #[inline]
     pub(crate) fn neg_mul_sub(self, a: Self, b: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_sub_ps(b.0, _mm_mul_ps(self.0, a.0))) }
-            } else {
-                Self(
-                    b.0 - (self.0 * a.0),
-                    b.1 - (self.1 * a.1),
-                    b.2 - (self.2 * a.2),
-                )
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_sub_ps(b.0, _mm_mul_ps(self.0, a.0)))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(
+                b.0 - (self.0 * a.0),
+                b.1 - (self.1 * a.1),
+                b.2 - (self.2 * a.2),
+            )
         }
     }
 
@@ -691,53 +762,59 @@ impl Vec3 {
     /// `Vec3`.
     #[inline]
     pub fn abs(self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe {
-                    Self(_mm_and_ps(
-                            self.0,
-                            _mm_castsi128_ps(_mm_set1_epi32(0x7f_ff_ff_ff)),
-                    ))
-                }
-            } else {
-                Self(self.0.abs(), self.1.abs(), self.2.abs())
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_and_ps(
+                self.0,
+                _mm_castsi128_ps(_mm_set1_epi32(0x7f_ff_ff_ff)),
+            ))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.0.abs(), self.1.abs(), self.2.abs())
         }
     }
 
     #[inline]
     pub fn round(self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                use crate::f32::funcs::sse2::m128_round;
-                unsafe { Self(m128_round(self.0)) }
-            } else {
-                Self(self.0.round(), self.1.round(), self.2.round())
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            use crate::f32::funcs::sse2::m128_round;
+            Self(m128_round(self.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.0.round(), self.1.round(), self.2.round())
         }
     }
 
     #[inline]
     pub fn floor(self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                use crate::f32::funcs::sse2::m128_floor;
-                unsafe { Self(m128_floor(self.0)) }
-            } else {
-                Self(self.0.floor(), self.1.floor(), self.2.floor())
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            use crate::f32::funcs::sse2::m128_floor;
+            Self(m128_floor(self.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.0.floor(), self.1.floor(), self.2.floor())
         }
     }
 
     #[inline]
     pub fn ceil(self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                use crate::f32::funcs::sse2::m128_ceil;
-                unsafe { Self(m128_ceil(self.0)) }
-            } else {
-                Self(self.0.ceil(), self.1.ceil(), self.2.ceil())
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            use crate::f32::funcs::sse2::m128_ceil;
+            Self(m128_ceil(self.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.0.ceil(), self.1.ceil(), self.2.ceil())
         }
     }
 
@@ -808,13 +885,15 @@ impl AsMut<[f32; 3]> for Vec3 {
 
 impl fmt::Display for Vec3 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                let (x, y, z) = (*self).into();
-                write!(f, "[{}, {}, {}]", x, y, z)
-            } else {
-                write!(f, "[{}, {}, {}]", self.0, self.1, self.2)
-            }
+        #[cfg(vec3sse2_impl)]
+        {
+            let (x, y, z) = (*self).into();
+            write!(f, "[{}, {}, {}]", x, y, z)
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            write!(f, "[{}, {}, {}]", self.0, self.1, self.2)
         }
     }
 }
@@ -823,12 +902,14 @@ impl Div<Vec3> for Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, other: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_div_ps(self.0, other.0)) }
-            } else {
-                Self(self.0 / other.0, self.1 / other.1, self.2 / other.2)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_div_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.0 / other.0, self.1 / other.1, self.2 / other.2)
         }
     }
 }
@@ -836,14 +917,16 @@ impl Div<Vec3> for Vec3 {
 impl DivAssign<Vec3> for Vec3 {
     #[inline]
     fn div_assign(&mut self, other: Self) {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                self.0 = unsafe { _mm_div_ps(self.0, other.0) };
-            } else {
-                self.0 /= other.0;
-                self.1 /= other.1;
-                self.2 /= other.2;
-            }
+        #[cfg(vec3sse2_impl)]
+        {
+            self.0 = unsafe { _mm_div_ps(self.0, other.0) };
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.0 /= other.0;
+            self.1 /= other.1;
+            self.2 /= other.2;
         }
     }
 }
@@ -852,12 +935,14 @@ impl Div<f32> for Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, other: f32) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_div_ps(self.0, _mm_set1_ps(other))) }
-            } else {
-                Self(self.0 / other, self.1 / other, self.2 / other)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_div_ps(self.0, _mm_set1_ps(other)))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.0 / other, self.1 / other, self.2 / other)
         }
     }
 }
@@ -865,14 +950,16 @@ impl Div<f32> for Vec3 {
 impl DivAssign<f32> for Vec3 {
     #[inline]
     fn div_assign(&mut self, other: f32) {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                self.0 = unsafe { _mm_div_ps(self.0, _mm_set1_ps(other)) };
-            } else {
-                self.0 /= other;
-                self.1 /= other;
-                self.2 /= other;
-            }
+        #[cfg(vec3sse2_impl)]
+        {
+            self.0 = unsafe { _mm_div_ps(self.0, _mm_set1_ps(other)) };
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.0 /= other;
+            self.1 /= other;
+            self.2 /= other;
         }
     }
 }
@@ -881,12 +968,14 @@ impl Mul<Vec3> for Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, other: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_mul_ps(self.0, other.0)) }
-            } else {
-                Self(self.0 * other.0, self.1 * other.1, self.2 * other.2)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_mul_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.0 * other.0, self.1 * other.1, self.2 * other.2)
         }
     }
 }
@@ -894,14 +983,16 @@ impl Mul<Vec3> for Vec3 {
 impl MulAssign<Vec3> for Vec3 {
     #[inline]
     fn mul_assign(&mut self, other: Self) {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                self.0 = unsafe { _mm_mul_ps(self.0, other.0) };
-            } else {
-                self.0 *= other.0;
-                self.1 *= other.1;
-                self.2 *= other.2;
-            }
+        #[cfg(vec3sse2_impl)]
+        {
+            self.0 = unsafe { _mm_mul_ps(self.0, other.0) };
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.0 *= other.0;
+            self.1 *= other.1;
+            self.2 *= other.2;
         }
     }
 }
@@ -910,12 +1001,14 @@ impl Mul<f32> for Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, other: f32) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_mul_ps(self.0, _mm_set1_ps(other))) }
-            } else {
-                Self(self.0 * other, self.1 * other, self.2 * other)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_mul_ps(self.0, _mm_set1_ps(other)))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.0 * other, self.1 * other, self.2 * other)
         }
     }
 }
@@ -923,14 +1016,16 @@ impl Mul<f32> for Vec3 {
 impl MulAssign<f32> for Vec3 {
     #[inline]
     fn mul_assign(&mut self, other: f32) {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                self.0 = unsafe { _mm_mul_ps(self.0, _mm_set1_ps(other)) };
-            } else {
-                self.0 *= other;
-                self.1 *= other;
-                self.2 *= other;
-            }
+        #[cfg(vec3sse2_impl)]
+        {
+            self.0 = unsafe { _mm_mul_ps(self.0, _mm_set1_ps(other)) };
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.0 *= other;
+            self.1 *= other;
+            self.2 *= other;
         }
     }
 }
@@ -939,12 +1034,14 @@ impl Mul<Vec3> for f32 {
     type Output = Vec3;
     #[inline]
     fn mul(self, other: Vec3) -> Vec3 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Vec3(_mm_mul_ps(_mm_set1_ps(self), other.0)) }
-            } else {
-                Vec3(self * other.0, self * other.1, self * other.2)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Vec3(_mm_mul_ps(_mm_set1_ps(self), other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Vec3(self * other.0, self * other.1, self * other.2)
         }
     }
 }
@@ -953,12 +1050,14 @@ impl Add for Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, other: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_add_ps(self.0, other.0)) }
-            } else {
-                Self(self.0 + other.0, self.1 + other.1, self.2 + other.2)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_add_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.0 + other.0, self.1 + other.1, self.2 + other.2)
         }
     }
 }
@@ -966,14 +1065,16 @@ impl Add for Vec3 {
 impl AddAssign for Vec3 {
     #[inline]
     fn add_assign(&mut self, other: Self) {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                self.0 = unsafe { _mm_add_ps(self.0, other.0) };
-            } else {
-                self.0 += other.0;
-                self.1 += other.1;
-                self.2 += other.2;
-            }
+        #[cfg(vec3sse2_impl)]
+        {
+            self.0 = unsafe { _mm_add_ps(self.0, other.0) };
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.0 += other.0;
+            self.1 += other.1;
+            self.2 += other.2;
         }
     }
 }
@@ -982,12 +1083,14 @@ impl Sub for Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, other: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_sub_ps(self.0, other.0)) }
-            } else {
-                Self(self.0 - other.0, self.1 - other.1, self.2 - other.2)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_sub_ps(self.0, other.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(self.0 - other.0, self.1 - other.1, self.2 - other.2)
         }
     }
 }
@@ -995,14 +1098,16 @@ impl Sub for Vec3 {
 impl SubAssign for Vec3 {
     #[inline]
     fn sub_assign(&mut self, other: Self) {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                self.0 = unsafe { _mm_sub_ps(self.0, other.0) };
-            } else {
-                self.0 -= other.0;
-                self.1 -= other.1;
-                self.2 -= other.2;
-            }
+        #[cfg(vec3sse2_impl)]
+        {
+            self.0 = unsafe { _mm_sub_ps(self.0, other.0) };
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            self.0 -= other.0;
+            self.1 -= other.1;
+            self.2 -= other.2;
         }
     }
 }
@@ -1011,12 +1116,14 @@ impl Neg for Vec3 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_sub_ps(_mm_set1_ps(0.0), self.0)) }
-            } else {
-                Self(-self.0, -self.1, -self.2)
-            }
+        #[cfg(vec3sse2_impl)]
+        unsafe {
+            Self(_mm_sub_ps(_mm_set1_ps(0.0), self.0))
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            Self(-self.0, -self.1, -self.2)
         }
     }
 }
@@ -1046,17 +1153,19 @@ impl From<(f32, f32, f32)> for Vec3 {
 impl From<Vec3> for (f32, f32, f32) {
     #[inline]
     fn from(v: Vec3) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                let mut out: MaybeUninit<Align16<(f32, f32, f32)>> = MaybeUninit::uninit();
-                unsafe {
-                    // out is 16 bytes in size due to alignment
-                    _mm_store_ps(out.as_mut_ptr() as *mut f32, v.0);
-                    out.assume_init().0
-                }
-            } else {
-                (v.0, v.1, v.2)
+        #[cfg(vec3sse2_impl)]
+        {
+            let mut out: MaybeUninit<Align16<(f32, f32, f32)>> = MaybeUninit::uninit();
+            unsafe {
+                // out is 16 bytes in size due to alignment
+                _mm_store_ps(out.as_mut_ptr() as *mut f32, v.0);
+                out.assume_init().0
             }
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            (v.0, v.1, v.2)
         }
     }
 }
@@ -1071,17 +1180,19 @@ impl From<[f32; 3]> for Vec3 {
 impl From<Vec3> for [f32; 3] {
     #[inline]
     fn from(v: Vec3) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "packed-vec3"), not(feature = "scalar-math")))] {
-                let mut out: MaybeUninit<Align16<[f32; 3]>> = MaybeUninit::uninit();
-                unsafe {
-                    // out is 16 bytes in size due to alignment
-                    _mm_store_ps(out.as_mut_ptr() as *mut f32, v.0);
-                    out.assume_init().0
-                }
-            } else {
-                [v.0, v.1, v.2]
+        #[cfg(vec3sse2_impl)]
+        {
+            let mut out: MaybeUninit<Align16<[f32; 3]>> = MaybeUninit::uninit();
+            unsafe {
+                // out is 16 bytes in size due to alignment
+                _mm_store_ps(out.as_mut_ptr() as *mut f32, v.0);
+                out.assume_init().0
             }
+        }
+
+        #[cfg(vec3f32_impl)]
+        {
+            [v.0, v.1, v.2]
         }
     }
 }

--- a/src/f32/vec4_mask.rs
+++ b/src/f32/vec4_mask.rs
@@ -1,39 +1,31 @@
 use crate::Vec4;
-use cfg_if::cfg_if;
 use core::ops::*;
 
-cfg_if! {
-    if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
-        #[cfg(target_arch = "x86")]
-        use core::arch::x86::*;
-        #[cfg(target_arch = "x86_64")]
-        use core::arch::x86_64::*;
+#[cfg(all(vec4sse2, target_arch = "x86"))]
+use core::arch::x86::*;
+#[cfg(all(vec4sse2, target_arch = "x86_64"))]
+use core::arch::x86_64::*;
 
-        /// A 4-dimensional vector mask.
-        ///
-        /// This type is typically created by comparison methods on `Vec4`.  It is
-        /// essentially a vector of four boolean values.
-        #[derive(Clone, Copy)]
-        #[repr(C)]
-        pub struct Vec4Mask(pub(crate) __m128);
+/// A 4-dimensional vector mask.
+///
+/// This type is typically created by comparison methods on `Vec4`.  It is
+/// essentially a vector of four boolean values.
+#[cfg(vec4sse2)]
+#[derive(Clone, Copy)]
+#[repr(C)]
+pub struct Vec4Mask(pub(crate) __m128);
 
-        impl Default for Vec4Mask {
-            #[inline]
-            fn default() -> Self {
-                unsafe { Self(_mm_setzero_ps()) }
-            }
-        }
+#[cfg(vec4f32)]
+#[derive(Clone, Copy, Default)]
+#[cfg_attr(vec4f32_align16, repr(align(16)))]
+#[repr(C)]
+pub struct Vec4Mask(u32, u32, u32, u32);
 
-    } else {
-        /// A 4-dimensional vector mask.
-        ///
-        /// This type is typically created by comparison methods on `Vec4`.  It is
-        /// essentially a vector of four boolean values.
-        #[derive(Clone, Copy, Default)]
-        // if compiling with simd enabled assume alignment needs to match the simd type
-        #[cfg_attr(not(feature = "scalar-math"), repr(align(16)))]
-        #[repr(C)]
-        pub struct Vec4Mask(u32, u32, u32, u32);
+#[cfg(vec4sse2)]
+impl Default for Vec4Mask {
+    #[inline]
+    fn default() -> Self {
+        unsafe { Self(_mm_setzero_ps()) }
     }
 }
 
@@ -42,24 +34,24 @@ impl Vec4Mask {
     #[inline]
     pub fn new(x: bool, y: bool, z: bool, w: bool) -> Self {
         const MASK: [u32; 2] = [0, 0xff_ff_ff_ff];
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
-                unsafe {
-                    Self(_mm_set_ps(
-                            f32::from_bits(MASK[w as usize]),
-                            f32::from_bits(MASK[z as usize]),
-                            f32::from_bits(MASK[y as usize]),
-                            f32::from_bits(MASK[x as usize]),
-                    ))
-                }
-            } else {
-                Self(
-                    MASK[x as usize],
-                    MASK[y as usize],
-                    MASK[z as usize],
-                    MASK[w as usize],
-                )
-            }
+        #[cfg(vec4sse2)]
+        unsafe {
+            Self(_mm_set_ps(
+                f32::from_bits(MASK[w as usize]),
+                f32::from_bits(MASK[z as usize]),
+                f32::from_bits(MASK[y as usize]),
+                f32::from_bits(MASK[x as usize]),
+            ))
+        }
+
+        #[cfg(vec4f32)]
+        {
+            Self(
+                MASK[x as usize],
+                MASK[y as usize],
+                MASK[z as usize],
+                MASK[w as usize],
+            )
         }
     }
 
@@ -71,12 +63,14 @@ impl Vec4Mask {
     /// second, etc.
     #[inline]
     pub fn bitmask(self) -> u32 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
-                unsafe { _mm_movemask_ps(self.0) as u32 }
-            } else {
-                (self.0 & 0x1) | (self.1 & 0x1) << 1 | (self.2 & 0x1) << 2 | (self.3 & 0x1) << 3
-            }
+        #[cfg(vec4sse2)]
+        unsafe {
+            _mm_movemask_ps(self.0) as u32
+        }
+
+        #[cfg(vec4f32)]
+        {
+            (self.0 & 0x1) | (self.1 & 0x1) << 1 | (self.2 & 0x1) << 2 | (self.3 & 0x1) << 3
         }
     }
 
@@ -85,12 +79,14 @@ impl Vec4Mask {
     /// In other words: `x || y || z || w`.
     #[inline]
     pub fn any(self) -> bool {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
-                unsafe { _mm_movemask_ps(self.0) != 0 }
-            } else {
-                (self.0 != 0) || (self.1 != 0) || (self.2 != 0) || (self.3 != 0)
-            }
+        #[cfg(vec4sse2)]
+        unsafe {
+            _mm_movemask_ps(self.0) != 0
+        }
+
+        #[cfg(vec4f32)]
+        {
+            (self.0 != 0) || (self.1 != 0) || (self.2 != 0) || (self.3 != 0)
         }
     }
 
@@ -99,12 +95,14 @@ impl Vec4Mask {
     /// In other words: `x && y && z && w`.
     #[inline]
     pub fn all(self) -> bool {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
-                unsafe { _mm_movemask_ps(self.0) == 0xf }
-            } else {
-                (self.0 != 0) && (self.1 != 0) && (self.2 != 0) && (self.3 != 0)
-            }
+        #[cfg(vec4sse2)]
+        unsafe {
+            _mm_movemask_ps(self.0) == 0xf
+        }
+
+        #[cfg(vec4f32)]
+        {
+            (self.0 != 0) && (self.1 != 0) && (self.2 != 0) && (self.3 != 0)
         }
     }
 
@@ -115,22 +113,22 @@ impl Vec4Mask {
     /// `if_true`, and false uses the element from `if_false`.
     #[inline]
     pub fn select(self, if_true: Vec4, if_false: Vec4) -> Vec4 {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
-                unsafe {
-                    Vec4(_mm_or_ps(
-                            _mm_andnot_ps(self.0, if_false.0),
-                            _mm_and_ps(if_true.0, self.0),
-                    ))
-                }
-            } else {
-                Vec4(
-                    if self.0 != 0 { if_true.0 } else { if_false.0 },
-                    if self.1 != 0 { if_true.1 } else { if_false.1 },
-                    if self.2 != 0 { if_true.2 } else { if_false.2 },
-                    if self.3 != 0 { if_true.3 } else { if_false.3 },
-                )
-            }
+        #[cfg(vec4sse2)]
+        unsafe {
+            Vec4(_mm_or_ps(
+                _mm_andnot_ps(self.0, if_false.0),
+                _mm_and_ps(if_true.0, self.0),
+            ))
+        }
+
+        #[cfg(vec4f32)]
+        {
+            Vec4(
+                if self.0 != 0 { if_true.0 } else { if_false.0 },
+                if self.1 != 0 { if_true.1 } else { if_false.1 },
+                if self.2 != 0 { if_true.2 } else { if_false.2 },
+                if self.3 != 0 { if_true.3 } else { if_false.3 },
+            )
         }
     }
 }
@@ -139,32 +137,36 @@ impl BitAnd for Vec4Mask {
     type Output = Self;
     #[inline]
     fn bitand(self, other: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_and_ps(self.0, other.0)) }
-            } else {
-                Self(
-                    self.0 & other.0,
-                    self.1 & other.1,
-                    self.2 & other.2,
-                    self.3 & other.3,
-                )
-            }
+        #[cfg(vec4sse2)]
+        unsafe {
+            Self(_mm_and_ps(self.0, other.0))
+        }
+
+        #[cfg(vec4f32)]
+        {
+            Self(
+                self.0 & other.0,
+                self.1 & other.1,
+                self.2 & other.2,
+                self.3 & other.3,
+            )
         }
     }
 }
 
 impl BitAndAssign for Vec4Mask {
     fn bitand_assign(&mut self, other: Self) {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
-                self.0 = unsafe { _mm_and_ps(self.0, other.0) };
-            } else {
-                self.0 &= other.0;
-                self.1 &= other.1;
-                self.2 &= other.2;
-                self.3 &= other.3;
-            }
+        #[cfg(vec4sse2)]
+        {
+            self.0 = unsafe { _mm_and_ps(self.0, other.0) };
+        }
+
+        #[cfg(vec4f32)]
+        {
+            self.0 &= other.0;
+            self.1 &= other.1;
+            self.2 &= other.2;
+            self.3 &= other.3;
         }
     }
 }
@@ -173,32 +175,36 @@ impl BitOr for Vec4Mask {
     type Output = Self;
     #[inline]
     fn bitor(self, other: Self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
-                unsafe { Self(_mm_or_ps(self.0, other.0)) }
-            } else {
-                Self(
-                    self.0 | other.0,
-                    self.1 | other.1,
-                    self.2 | other.2,
-                    self.3 | other.3,
-                )
-            }
+        #[cfg(vec4sse2)]
+        unsafe {
+            Self(_mm_or_ps(self.0, other.0))
+        }
+
+        #[cfg(vec4f32)]
+        {
+            Self(
+                self.0 | other.0,
+                self.1 | other.1,
+                self.2 | other.2,
+                self.3 | other.3,
+            )
         }
     }
 }
 
 impl BitOrAssign for Vec4Mask {
     fn bitor_assign(&mut self, other: Self) {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
-                self.0 = unsafe { _mm_or_ps(self.0, other.0) };
-            } else {
-                self.0 |= other.0;
-                self.1 |= other.1;
-                self.2 |= other.2;
-                self.3 |= other.3;
-            }
+        #[cfg(vec4sse2)]
+        {
+            self.0 = unsafe { _mm_or_ps(self.0, other.0) };
+        }
+
+        #[cfg(vec4f32)]
+        {
+            self.0 |= other.0;
+            self.1 |= other.1;
+            self.2 |= other.2;
+            self.3 |= other.3;
         }
     }
 }
@@ -207,17 +213,17 @@ impl Not for Vec4Mask {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        cfg_if! {
-            if #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))] {
-                unsafe {
-                    Self(_mm_andnot_ps(
-                            self.0,
-                            _mm_set_ps1(f32::from_bits(0xff_ff_ff_ff)),
-                    ))
-                }
-            } else {
-                Self(!self.0, !self.1, !self.2, !self.3)
-            }
+        #[cfg(vec4sse2)]
+        unsafe {
+            Self(_mm_andnot_ps(
+                self.0,
+                _mm_set_ps1(f32::from_bits(0xff_ff_ff_ff)),
+            ))
+        }
+
+        #[cfg(vec4f32)]
+        {
+            Self(!self.0, !self.1, !self.2, !self.3)
         }
     }
 }


### PR DESCRIPTION
I was having a few issues with `cfg-if` like rustfmt didn't seem to like it and neither did `tarpaulin`.

Separate to that it seemed like checking target features and features in rust code was getting complicated with more targets and features. So instead I'm doing the more complex logic in rust code to generate rust-cfg's that can be used mutually exclusively in Rust code. This is independent of whether or not cfg-if it being used.