### PR TITLE
Add Quat::slerp

### DIFF
--- a/benches/quat.rs
+++ b/benches/quat.rs
@@ -22,6 +22,13 @@ bench_binop!(
     from => random_quat
 );
 
+bench_binop!(
+    quat_dot,
+    "quat dot",
+    op => dot,
+    from => random_quat
+);
+
 bench_trinop!(
     quat_lerp,
     "quat lerp",
@@ -45,6 +52,7 @@ bench_from_ypr!(quat_from_ypr, "quat from ypr", ty => Quat);
 criterion_group!(
     benches,
     quat_conjugate,
+    quat_dot,
     quat_lerp,
     quat_slerp,
     quat_mul_quat,

--- a/benches/quat.rs
+++ b/benches/quat.rs
@@ -31,12 +31,22 @@ bench_trinop!(
     from3 => random_f32
 );
 
+bench_trinop!(
+    quat_slerp,
+    "quat slerp",
+    op => slerp,
+    from1 => random_quat,
+    from2 => random_quat,
+    from3 => random_f32
+);
+
 bench_from_ypr!(quat_from_ypr, "quat from ypr", ty => Quat);
 
 criterion_group!(
     benches,
     quat_conjugate,
     quat_lerp,
+    quat_slerp,
     quat_mul_quat,
     quat_from_ypr
 );

--- a/src/f32/funcs.rs
+++ b/src/f32/funcs.rs
@@ -115,20 +115,6 @@ pub(crate) mod sse2 {
     _ps_const_ty!(PS_TWO_PI, f32x4, std::f32::consts::PI * 2.0);
     _ps_const_ty!(PS_RECIPROCAL_TWO_PI, f32x4, 0.159154943);
 
-    #[cfg(target_feature = "avx")]
-    macro_rules! m128_permute {
-        ($v:expr, $c:expr) => {
-            _mm_permute_ps($v, $c)
-        };
-    }
-
-    #[cfg(not(target_feature = "avx"))]
-    macro_rules! m128_permute {
-        ($v:expr, $c:expr) => {
-            _mm_shuffle_ps($v, $v, $c)
-        };
-    }
-
     #[cfg(target_feature = "fma")]
     macro_rules! m128_mul_add {
         ($a:expr, $b:expr, $c:expr) => {
@@ -248,19 +234,19 @@ pub(crate) mod sse2 {
 
         // Compute polynomial approximation
         const SC1: __m128 = unsafe { PS_SIN_COEFFICIENTS1.m128 };
-        let v_constants_b = m128_permute!(SC1, 0b00_00_00_00);
+        let v_constants_b = _mm_shuffle_ps(SC1, SC1, 0b00_00_00_00);
 
         const SC0: __m128 = unsafe { PS_SIN_COEFFICIENTS0.m128 };
-        let mut v_constants = m128_permute!(SC0, 0b11_11_11_11);
+        let mut v_constants = _mm_shuffle_ps(SC0, SC0, 0b11_11_11_11);
         let mut result = m128_mul_add!(v_constants_b, x2, v_constants);
 
-        v_constants = m128_permute!(SC0, 0b10_10_10_10);
+        v_constants = _mm_shuffle_ps(SC0, SC0, 0b10_10_10_10);
         result = m128_mul_add!(result, x2, v_constants);
 
-        v_constants = m128_permute!(SC0, 0b01_01_01_01);
+        v_constants = _mm_shuffle_ps(SC0, SC0, 0b01_01_01_01);
         result = m128_mul_add!(result, x2, v_constants);
 
-        v_constants = m128_permute!(SC0, 0b00_00_00_00);
+        v_constants = _mm_shuffle_ps(SC0, SC0, 0b00_00_00_00);
         result = m128_mul_add!(result, x2, v_constants);
 
         result = m128_mul_add!(result, x2, PS_ONE.m128);

--- a/src/f32/x86_utils.rs
+++ b/src/f32/x86_utils.rs
@@ -5,6 +5,7 @@ use std::arch::x86_64::*;
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[allow(dead_code)]
+#[repr(C)]
 pub(crate) union UnionCast {
     pub m128: __m128,
     pub m128i: __m128i,

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -174,6 +174,31 @@ fn test_quat_lerp() {
 }
 
 #[test]
+fn test_quat_slerp() {
+    let q0 = Quat::from_rotation_y(deg(0.0));
+    let q1 = Quat::from_rotation_y(deg(90.0));
+    assert_approx_eq!(q0, q0.slerp(q1, 0.0), 1.0e-3);
+    assert_approx_eq!(q1, q0.slerp(q1, 1.0), 1.0e-3);
+    assert_approx_eq!(Quat::from_rotation_y(deg(45.0)), q0.slerp(q1, 0.5), 1.0e-3);
+}
+
+#[test]
+fn test_quat_slerp_constant_speed() {
+    let step = 0.01;
+    let mut s = 0.0;
+    while s <= 1.0 {
+        let q0 = Quat::from_rotation_y(deg(0.0));
+        let q1 = Quat::from_rotation_y(deg(90.0));
+        assert_approx_eq!(
+            Quat::from_rotation_y(deg(s * 90.0)),
+            q0.slerp(q1, s),
+            1.0e-3
+        );
+        s += step;
+    }
+}
+
+#[test]
 fn test_quat_fmt() {
     let a = Quat::identity();
     #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))]


### PR DESCRIPTION
This PR adds `Quat::slerp`. This implementation is derived from the cgmath implementation which is based on http://number-none.com/product/Understanding%20Slerp,%20Then%20Not%20Using%20It/

Unlike the cgmath implementation , intrinsics are used here when available.

Opening as draft to gain feedback.

1. `_MM_SHUFFLE` is considerably more readable than the duplication of the binary constants. Although it's implemented in the rust std library, it's currently nightly only. I've copied that implementation here.
2. I've added a few macros that mirror the DirectXMath macros, but I'm not sure if these are something you'll want in the code.
3. I've used the DirectXMath constant names which aren't snake case. I think it makes it easier when comparing the code, but I can understand if you wouldn't want that.