### PR TITLE
Upgrade cargo-deny-action v0 -> v1

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,4 +5,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: EmbarkStudios/cargo-deny-action@v0
+      - uses: EmbarkStudios/cargo-deny-action@v1


### PR DESCRIPTION
We made a proper v1 release of it, that is also on the GitHub Marketplace now