### PR TITLE
Documentation clarifications

### DIFF
--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -1,7 +1,7 @@
 use super::{Vec2, Vec3A, Vec3Mask, Vec4};
 use core::{fmt, ops::*};
 
-/// A 3-dimensional vector.
+/// A 3-dimensional vector without SIMD support.
 #[derive(Clone, Copy, PartialEq, PartialOrd, Debug, Default)]
 #[repr(C)]
 pub struct Vec3(pub(crate) f32, pub(crate) f32, pub(crate) f32);

--- a/src/f32/vec3a.rs
+++ b/src/f32/vec3a.rs
@@ -15,7 +15,7 @@ use crate::{
     Align16,
 };
 
-/// A 3-dimensional vector.
+/// A 3-dimensional vector with SIMD support.
 ///
 /// This type uses 16 byte aligned SIMD vector4 types for storage on supported platforms for better
 /// performance than the `Vec3` type.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ supported as this is what stable Rust supports.
 
 * Single precision float (`f32`) support only
 * SSE2 implementation for most types, including `Mat2`, `Mat3`, `Mat4`, `Quat`,
-  `Vec3` and `Vec4`
+  `Vec3A` and `Vec4`
 * Scalar fallback implementations exist when SSE2 is not available
 * Most functionality includes unit tests and benchmarks
 
@@ -44,17 +44,16 @@ assert!(v.abs_diff_eq(-Vec3::unit_z(), core::f32::EPSILON));
 ## Size and alignment of types
 
 Most `glam` types use SIMD for storage meaning most types are 16 byte aligned.
-The only exception is Vec2`. When SSE2 is not available on the target
-architecture the types will still be 16 byte aligned, so object sizes and
-layouts will not change between architectures.
-
-16 byte alignment means that some types will have a stride larger than their
-size resulting in some wasted space.
+The exceptions are `Vec2`, `Vec3` and `Mat3` types.
+`Vec3A` is a 3D vector type that is 16 byte aligned. Having 16 byte alignment means that
+it will have a stride larger than their size resulting in some wasted space.  
+When SSE2 is not available on the target architecture this type will still be 16 byte aligned, 
+so object sizes and layouts will not change between architectures.
 
 | Type | f32 bytes | SIMD bytes | Wasted bytes |
 |:-----|----------:|-----------:|-------------:|
-|`Vec3`|         12|          16|             4|
-|`Mat3`|         36|          48|            12|
+|`Vec3` |        12|         N/A|            0|
+|`Vec3A`|        12|          16|            4|
 
 Despite this wasted space the SIMD version tends to outperform the `f32`
 implementation in [**mathbench**](https://github.com/bitshifter/mathbench-rs)
@@ -65,7 +64,7 @@ feature will also disable SIMD alignment meaning most types will use native
 `f32` alignment of 4 bytes.
 
 All the main `glam` types are tagged with #[repr(C)], so they are possible
-to expose as struct members to C interfaces if desired. Be mindful of Vec3's
+to expose as struct members to C interfaces if desired. Be mindful of Vec3A's
 extra float though.
 
 ## Accessing internal data
@@ -75,8 +74,8 @@ directly accessible. Because of this `glam` types uses getter and setter
 methods instead of providing direct access.
 
 ```
-use glam::Vec3;
-let mut v = Vec3::new(1.0, 2.0, 3.0);
+use glam::Vec3A;
+let mut v = Vec3A::new(1.0, 2.0, 3.0);
 assert_eq!(v.y(), 2.0);
 v.set_z(1.0);
 assert_eq!(v.z(), 1.0);
@@ -86,8 +85,8 @@ If you need to access multiple elements it is easier to convert the type to a
 tuple or array:
 
 ```
-use glam::Vec3;
-let v = Vec3::new(1.0, 2.0, 3.0);
+use glam::Vec3A;
+let v = Vec3A::new(1.0, 2.0, 3.0);
 let (x, y, z) = v.into();
 assert_eq!((x, y, z), (1.0, 2.0, 3.0));
 ```
@@ -102,8 +101,8 @@ The SIMD versions implement `core::fmt::Display` traits so they print the same a
 the scalar version.
 
 ```
-use glam::Vec3;
-let a = Vec3::new(1.0, 2.0, 3.0);
+use glam::Vec3A;
+let a = Vec3A::new(1.0, 2.0, 3.0);
 assert_eq!(format!("{}", a), "[1, 2, 3]");
 ```
 


### PR DESCRIPTION
I've added some clarification around Vec3/Vec3A change, as the docs.rs docs still mentions Vec3 almost everywhere and that was a bit confusing.