### PR TITLE
normalize_safe()

### DIFF
--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -176,6 +176,18 @@ impl Vec2 {
         self * self.length_reciprocal()
     }
 
+
+    /// Same as `normalize`, but will not normalize if `self` is zero length.
+    ///
+    /// Slightly slower than `normalize`.
+    #[inline]
+    pub fn normalize_safe(self) -> Self{
+        if self.length_squared() > f32::EPSILON {
+            return self.normalize();
+        }
+        return self;
+    }
+
     /// Returns the vertical minimum of `self` and `other`.
     ///
     /// In other words, this computes

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -197,6 +197,17 @@ impl Vec3 {
         self * self.length_reciprocal()
     }
 
+    /// Same as `normalize`, but will not normalize if `self` is zero length.
+    ///
+    /// Slightly slower than `normalize`.
+    #[inline]
+    pub fn normalize_safe(self) -> Self{
+        if self.length_squared() > f32::EPSILON {
+            return self.normalize();
+        }
+        return self;
+    }
+
     /// Returns the vertical minimum of `self` and `other`.
     ///
     /// In other words, this computes

--- a/src/f32/vec3a.rs
+++ b/src/f32/vec3a.rs
@@ -511,6 +511,17 @@ impl Vec3A {
         }
     }
 
+    /// Same as `normalize`, but will not normalize if `self` is zero length.
+    ///
+    /// Slightly slower than `normalize`.
+    #[inline]
+    pub fn normalize_safe(self) -> Self{
+        if self.length_squared() > f32::EPSILON {
+            return self.normalize();
+        }
+        return self;
+    }
+
     /// Returns the vertical minimum of `self` and `other`.
     ///
     /// In other words, this computes

--- a/src/f32/vec4.rs
+++ b/src/f32/vec4.rs
@@ -545,6 +545,18 @@ impl Vec4 {
         }
     }
 
+
+    /// Same as `normalize`, but will not normalize if `self` is zero length.
+    ///
+    /// Slightly slower than `normalize`.
+    #[inline]
+    pub fn normalize_safe(self) -> Self{
+        if self.length_squared() > f32::EPSILON {
+            return self.normalize();
+        }
+        return self;
+    }
+
     /// Returns the vertical minimum of `self` and `other`.
     ///
     /// In other words, this computes

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -105,6 +105,9 @@ fn test_vec2_funcs() {
         vec2(2.0, 3.0).normalize()
     );
     assert_eq!(vec2(0.5, 0.25), vec2(2.0, 4.0).reciprocal());
+
+    let zero = vec2(0.0, 0.0, 0.0);
+    assert_eq!(zero, zero.normalize_safe());
 }
 
 #[test]

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -106,7 +106,7 @@ fn test_vec2_funcs() {
     );
     assert_eq!(vec2(0.5, 0.25), vec2(2.0, 4.0).reciprocal());
 
-    let zero = vec2(0.0, 0.0, 0.0);
+    let zero = vec2(0.0, 0.0);
     assert_eq!(zero, zero.normalize_safe());
 }
 

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -127,6 +127,9 @@ fn test_vec3_funcs() {
         vec3(2.0, 3.0, 4.0).normalize()
     );
     assert_eq!(vec3(0.5, 0.25, 0.125), vec3(2.0, 4.0, 8.0).reciprocal());
+
+    let zero = vec3(0.0, 0.0, 0.0);
+    assert_eq!(zero, zero.normalize_safe());
 }
 
 #[test]

--- a/tests/vec3a.rs
+++ b/tests/vec3a.rs
@@ -127,6 +127,9 @@ fn test_vec3a_funcs() {
         vec3a(2.0, 3.0, 4.0).normalize()
     );
     assert_eq!(vec3a(0.5, 0.25, 0.125), vec3a(2.0, 4.0, 8.0).reciprocal());
+
+    let zero = vec3a(0.0, 0.0, 0.0);
+    assert_eq!(zero, zero.normalize_safe());
 }
 
 #[test]

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -147,6 +147,9 @@ fn test_vec4_funcs() {
         vec4(0.5, 0.25, 0.125, 0.0625),
         vec4(2.0, 4.0, 8.0, 16.0).reciprocal()
     );
+
+    let zero = vec4(0.0, 0.0, 0.0, 0.0);
+    assert_eq!(zero, zero.normalize_safe());
 }
 
 #[test]


### PR DESCRIPTION
I've added a ``normalize_safe()`` function to all vector structs. This should make life a little simpler when dealing with vectors that can be zero.

### Use Case
Say you an object that constantly seeks a target. To compute the direction, you would use:
``` rust
let direction = target - my_position;
let velocity = direction.normalize() * delta_time;
my_position += velocity;
```

However if ``target``  is equal to ``position``, velocity will be ``NaN``, which will also "infect" ``position``.
Fixing this would be:
```rust
let direction = target - my_position;
let velocity = if direction.length_squared() > f32::EPSILON {
   direction.normalize() * delta_time
} else {
   direction
};
my_position += velocity;
```
Which, to me, feels messy. Also, less expierenced users might use ``.length()``, which is slower or don't know about ``f32::EPSILON`` at all.

With ``normalize_safe()`` this would simply be:
``` rust
let direction = target - my_position;
let velocity = direction.normalize_safe() * delta_time;
my_position += velocity;
```


