### PR TITLE
Fix Mat4::transform_point3 to account for homogeneous w coordinate

### DIFF
--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -835,7 +835,9 @@ impl Mat4 {
         // // other w = 1
         // res = self.w_axis.truncate() + res;
         // res
-        Vec3::from(self.mul_vec4(other.extend(1.0)).truncate())
+        let transformed = self.mul_vec4(other.extend(1.0));
+        let w = transformed.w();
+        Vec3::from(transformed.truncate() / w)
     }
 
     /// Transforms the give `Vec3` as 3D vector.


### PR DESCRIPTION
Currently, transform_point3 will fail on many perspective projections or other situations in which the homogeneous coordinate does not stay the same as it gets tossed out after the transformation. Instead, it must be renormalized to 1 by dividing by w.