### PR TITLE
abs() to prevent inversion when point behind camera

### DIFF
--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -836,7 +836,7 @@ impl Mat4 {
         // res = self.w_axis.truncate() + res;
         // res
         let transformed = self.mul_vec4(other.extend(1.0));
-        let w_recip = transformed.w().recip();
+        let w_recip = transformed.w().abs().recip();
         Vec3::from(transformed.truncate() * w_recip)
     }
 


### PR DESCRIPTION
@termhn was helping me out when #75 was found. As a workaround, I manually implemented a transform_point3 with the same code as shown in that PR. 

However, I think there may be a bug with this. I recently had an issue where when vertices went behind the camera, `w` would negate and cause the vertices' coordinates to flip. The fix was to add an `.abs()` to the `let w` statement. See: https://github.com/aevyrie/bevy_mod_picking/issues/15#issuecomment-688431590

This is not my area of expertise, so I would appreciate feedback if this is incorrect. 🙂 