### PR TITLE
Implement Add<Quat> Sub<Quat>, Mul<f32> and Div<f32> for Quat

### DIFF
--- a/src/f32/quat.rs
+++ b/src/f32/quat.rs
@@ -455,22 +455,6 @@ impl Quat {
     }
 
     #[inline]
-    /// Adds two quaternions.
-    /// The sum not guaranteed to be normalized.
-    /// NB: Addition is not the same as combining the rotations represented by the two quaternions!
-    /// That corresponds to multiplication.
-    pub fn add_quat(self, other: Self) -> Self {
-        Self(self.0 + other.0)
-    }
-
-    #[inline]
-    /// Multiplies a quaternion with an f32.
-    /// The product is not guaranteed to be normalized.
-    pub fn mul_f32(self, other: f32) -> Self {
-        Self(self.0 * other)
-    }
-
-    #[inline]
     /// Multiplies two quaternions.
     /// If they each represent a rotation, the result will represent the combined rotation.
     /// Note that due to floating point rounding the result may not be perfectly normalized.
@@ -573,14 +557,21 @@ impl fmt::Display for Quat {
 impl Add<Quat> for Quat {
     type Output = Self;
     #[inline]
+    /// Adds two quaternions.
+    /// The sum is not guaranteed to be normalized.
+    ///
+    /// NB: Addition is not the same as combining the rotations represented by the two quaternions!
+    /// That corresponds to multiplication.
     fn add(self, other: Self) -> Self {
-        self.add_quat(other)
+        Self(self.0 + other.0)
     }
 }
 
 impl Sub<Quat> for Quat {
     type Output = Self;
     #[inline]
+    /// Subtracts the other quaternion from self.
+    /// The difference is not guaranteed to be normalized.
     fn sub(self, other: Self) -> Self {
         Self(self.0 - other.0)
     }
@@ -589,16 +580,20 @@ impl Sub<Quat> for Quat {
 impl Mul<f32> for Quat {
     type Output = Self;
     #[inline]
+    /// Multiplies a quaternion with an f32.
+    /// The product is not guaranteed to be normalized.
     fn mul(self, other: f32) -> Self {
-        self.mul_f32(other)
+        Self(self.0 * other)
     }
 }
 
 impl Div<f32> for Quat {
     type Output = Self;
     #[inline]
+    /// Divides a quaternion by an f32.
+    /// The quotient is not guaranteed to be normalized.
     fn div(self, other: f32) -> Self {
-        self.mul_f32(1. / other)
+        Self(self.0 / other)
     }
 }
 

--- a/src/f32/quat.rs
+++ b/src/f32/quat.rs
@@ -6,7 +6,7 @@ use core::arch::x86_64::*;
 use core::{
     cmp::Ordering,
     fmt,
-    ops::{Add, Mul, MulAssign, Neg, Sub},
+    ops::{Add, Div, Mul, MulAssign, Neg, Sub},
 };
 
 const IDENTITY: Quat = const_quat!([0.0, 0.0, 0.0, 1.0]);
@@ -456,11 +456,18 @@ impl Quat {
 
     #[inline]
     /// Adds two quaternions.
-    /// The sum is probably not anywhere near normalized.
+    /// The sum not guaranteed to be normalized.
     /// NB: Addition is not the same as combining the rotations represented by the two quaternions!
     /// That corresponds to multiplication.
     pub fn add_quat(self, other: Self) -> Self {
         Self(self.0 + other.0)
+    }
+
+    #[inline]
+    /// Multiplies a quaternion with an f32.
+    /// The product is not guaranteed to be normalized.
+    pub fn mul_f32(self, other: f32) -> Self {
+        Self(self.0 * other)
     }
 
     #[inline]
@@ -576,6 +583,22 @@ impl Sub<Quat> for Quat {
     #[inline]
     fn sub(self, other: Self) -> Self {
         Self(self.0 - other.0)
+    }
+}
+
+impl Mul<f32> for Quat {
+    type Output = Self;
+    #[inline]
+    fn mul(self, other: f32) -> Self {
+        self.mul_f32(other)
+    }
+}
+
+impl Div<f32> for Quat {
+    type Output = Self;
+    #[inline]
+    fn div(self, other: f32) -> Self {
+        self.mul_f32(1. / other)
     }
 }
 

--- a/src/f32/quat.rs
+++ b/src/f32/quat.rs
@@ -6,7 +6,7 @@ use core::arch::x86_64::*;
 use core::{
     cmp::Ordering,
     fmt,
-    ops::{Mul, MulAssign, Neg},
+    ops::{Add, Mul, MulAssign, Neg, Sub},
 };
 
 const IDENTITY: Quat = const_quat!([0.0, 0.0, 0.0, 1.0]);
@@ -455,7 +455,17 @@ impl Quat {
     }
 
     #[inline]
+    /// Adds two quaternions.
+    /// The sum is probably not anywhere near normalized.
+    /// NB: Addition is not the same as combining the rotations represented by the two quaternions!
+    /// That corresponds to multiplication.
+    pub fn add_quat(self, other: Self) -> Self {
+        Self(self.0 + other.0)
+    }
+
+    #[inline]
     /// Multiplies two quaternions.
+    /// If they each represent a rotation, the result will represent the combined rotation.
     /// Note that due to floating point rounding the result may not be perfectly normalized.
     pub fn mul_quat(self, other: Self) -> Self {
         glam_assert!(self.is_normalized());
@@ -550,6 +560,22 @@ impl fmt::Display for Quat {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         let (x, y, z, w) = self.0.into();
         write!(fmt, "[{}, {}, {}, {}]", x, y, z, w)
+    }
+}
+
+impl Add<Quat> for Quat {
+    type Output = Self;
+    #[inline]
+    fn add(self, other: Self) -> Self {
+        self.add_quat(other)
+    }
+}
+
+impl Sub<Quat> for Quat {
+    type Output = Self;
+    #[inline]
+    fn sub(self, other: Self) -> Self {
+        Self(self.0 - other.0)
     }
 }
 

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -330,6 +330,32 @@ fn test_quat_elements() {
     assert!(a.w() == w);
 }
 
+#[test]
+fn test_quat_addition() {
+    let a = Quat::from_xyzw(1.0, 2.0, 3.0, 4.0);
+    let b = Quat::from_xyzw(5.0, 6.0, 7.0, -9.0);
+    assert_eq!(a + b, Quat::from_xyzw(6.0, 8.0, 10.0, -5.0));
+}
+
+#[test]
+fn test_quat_subtraction() {
+    let a = Quat::from_xyzw(6.0, 8.0, 10.0, -5.0);
+    let b = Quat::from_xyzw(5.0, 6.0, 7.0, -9.0);
+    assert_eq!(a - b, Quat::from_xyzw(1.0, 2.0, 3.0, 4.0));
+}
+
+#[test]
+fn test_quat_f32_multiplication() {
+    let a = Quat::from_xyzw(1.0, 2.0, 3.0, 4.0);
+    assert_eq!(a * 2.0, Quat::from_xyzw(2.0, 4.0, 6.0, 8.0));
+}
+
+#[test]
+fn test_quat_f32_division() {
+    let a = Quat::from_xyzw(2.0, 4.0, 6.0, 8.0);
+    assert_eq!(a / 2.0, Quat::from_xyzw(1.0, 2.0, 3.0, 4.0));
+}
+
 #[cfg(feature = "serde")]
 #[test]
 fn test_quat_serde() {


### PR DESCRIPTION
closes #82 

I tried to clarify in docs that these ops are not what you want to use most of the time. No editor I know of will show these docs when just using the `+` or `-` operator, but I couldn't think of a better way.