### PR TITLE
Added distance and distance_square to calculate distance between two points

### DIFF
--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -199,6 +199,14 @@ impl Vec2 {
         self.length().recip()
     }
 
+    /// Computes the Euclidean distance between two points.
+    #[inline]
+    pub fn distance(self, other: Vec2) -> f32 { (self - other).length() }
+
+    /// Compute the squared Euclidean distance between two points.
+    #[inline]
+    pub fn distance_squared(self, other: Vec2) -> f32 { (self - other).length_squared() }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -201,11 +201,15 @@ impl Vec2 {
 
     /// Computes the Euclidean distance between two points.
     #[inline]
-    pub fn distance(self, other: Vec2) -> f32 { (self - other).length() }
+    pub fn distance(self, other: Vec2) -> f32 {
+        (self - other).length()
+    }
 
     /// Compute the squared Euclidean distance between two points.
     #[inline]
-    pub fn distance_squared(self, other: Vec2) -> f32 { (self - other).length_squared() }
+    pub fn distance_squared(self, other: Vec2) -> f32 {
+        (self - other).length_squared()
+    }
 
     /// Returns `self` normalized to length 1.0.
     ///

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -184,11 +184,15 @@ impl Vec3 {
 
     /// Computes the Euclidean distance between two points in space.
     #[inline]
-    pub fn distance(self, other: Vec3) -> f32 { (self - other).length() }
+    pub fn distance(self, other: Vec3) -> f32 {
+        (self - other).length()
+    }
 
     /// Compute the squared Euclidean distance between two points in space.
     #[inline]
-    pub fn distance_squared(self, other: Vec3) -> f32 { (self - other).length_squared() }
+    pub fn distance_squared(self, other: Vec3) -> f32 {
+        (self - other).length_squared()
+    }
 
     /// Returns `self` normalized to length 1.0.
     ///

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -182,6 +182,14 @@ impl Vec3 {
         self.length().recip()
     }
 
+    /// Computes the Euclidean distance between two points in space.
+    #[inline]
+    pub fn distance(self, other: Vec3) -> f32 { (self - other).length() }
+
+    /// Compute the squared Euclidean distance between two points in space.
+    #[inline]
+    pub fn distance_squared(self, other: Vec3) -> f32 { (self - other).length_squared() }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero.

--- a/src/f32/vec3a.rs
+++ b/src/f32/vec3a.rs
@@ -422,11 +422,15 @@ impl Vec3A {
 
     /// Computes the Euclidean distance between two points in space.
     #[inline]
-    pub fn distance(self, other: Vec3A) -> f32 { (self - other).length() }
+    pub fn distance(self, other: Vec3A) -> f32 {
+        (self - other).length()
+    }
 
     /// Compute the squared euclidean distance between two points in space.
     #[inline]
-    pub fn distance_squared(self, other: Vec3A) -> f32 { (self - other).length_squared() }
+    pub fn distance_squared(self, other: Vec3A) -> f32 {
+        (self - other).length_squared()
+    }
 
     /// Returns `self` normalized to length 1.0.
     ///

--- a/src/f32/vec3a.rs
+++ b/src/f32/vec3a.rs
@@ -420,6 +420,14 @@ impl Vec3A {
         }
     }
 
+    /// Computes the Euclidean distance between two points in space.
+    #[inline]
+    pub fn distance(self, other: Vec3A) -> f32 { (self - other).length() }
+
+    /// Compute the squared euclidean distance between two points in space.
+    #[inline]
+    pub fn distance_squared(self, other: Vec3A) -> f32 { (self - other).length_squared() }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero.

--- a/src/f32/vec4.rs
+++ b/src/f32/vec4.rs
@@ -421,6 +421,14 @@ impl Vec4 {
         }
     }
 
+    /// Computes the Euclidean distance between two points in space.
+    #[inline]
+    pub fn distance(self, other: Vec4) -> f32 { (self - other).length() }
+
+    /// Compute the squared euclidean distance between two points in space.
+    #[inline]
+    pub fn distance_squared(self, other: Vec4) -> f32 { (self - other).length_squared() }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero.

--- a/src/f32/vec4.rs
+++ b/src/f32/vec4.rs
@@ -423,11 +423,15 @@ impl Vec4 {
 
     /// Computes the Euclidean distance between two points in space.
     #[inline]
-    pub fn distance(self, other: Vec4) -> f32 { (self - other).length() }
+    pub fn distance(self, other: Vec4) -> f32 {
+        (self - other).length()
+    }
 
     /// Compute the squared euclidean distance between two points in space.
     #[inline]
-    pub fn distance_squared(self, other: Vec4) -> f32 { (self - other).length_squared() }
+    pub fn distance_squared(self, other: Vec4) -> f32 {
+        (self - other).length_squared()
+    }
 
     /// Returns `self` normalized to length 1.0.
     ///

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -91,6 +91,11 @@ fn test_vec2_funcs() {
     assert_eq!(9.0, (-3.0 * y).length_squared());
     assert_eq!(2.0, (-2.0 * x).length());
     assert_eq!(3.0, (3.0 * y).length());
+    assert_eq!(2.0, x.distance_squared(y));
+    assert_eq!(13.0, (2.0 * x).distance_squared(-3.0 * y));
+    assert_eq!(2.0_f32.sqrt(), x.distance(y));
+    assert_eq!(5.0, (3.0 * x).distance(-4.0 * y));
+    assert_eq!(13.0, (-5.0 * x).distance(12.0 * y));
     assert_eq!(x, (2.0 * x).normalize());
     assert_eq!(1.0 * 3.0 + 2.0 * 4.0, vec2(1.0, 2.0).dot(vec2(3.0, 4.0)));
     assert_eq!(2.0 * 2.0 + 3.0 * 3.0, vec2(2.0, 3.0).length_squared());

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -104,6 +104,11 @@ fn test_vec3_funcs() {
     assert_eq!(2.0, (-2.0 * x).length());
     assert_eq!(3.0, (3.0 * y).length());
     assert_eq!(4.0, (-4.0 * z).length());
+    assert_eq!(2.0, x.distance_squared(y));
+    assert_eq!(13.0, (2.0 * x).distance_squared(-3.0 * z));
+    assert_eq!(2.0_f32.sqrt(), x.distance(y));
+    assert_eq!(5.0, (3.0 * x).distance(-4.0 * y));
+    assert_eq!(13.0, (-5.0 * z).distance(12.0 * y));
     assert_eq!(x, (2.0 * x).normalize());
     assert_eq!(
         1.0 * 4.0 + 2.0 * 5.0 + 3.0 * 6.0,

--- a/tests/vec3a.rs
+++ b/tests/vec3a.rs
@@ -104,6 +104,11 @@ fn test_vec3a_funcs() {
     assert_eq!(2.0, (-2.0 * x).length());
     assert_eq!(3.0, (3.0 * y).length());
     assert_eq!(4.0, (-4.0 * z).length());
+    assert_eq!(2.0, x.distance_squared(y));
+    assert_eq!(13.0, (2.0 * x).distance_squared(-3.0 * z));
+    assert_eq!(2.0_f32.sqrt(), x.distance(y));
+    assert_eq!(5.0, (3.0 * x).distance(-4.0 * y));
+    assert_eq!(13.0, (-5.0 * z).distance(12.0 * y));
     assert_eq!(x, (2.0 * x).normalize());
     assert_eq!(
         1.0 * 4.0 + 2.0 * 5.0 + 3.0 * 6.0,

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -121,6 +121,11 @@ fn test_vec4_funcs() {
     assert_eq!(3.0, (3.0 * y).length());
     assert_eq!(4.0, (-4.0 * z).length());
     assert_eq!(5.0, (-5.0 * w).length());
+    assert_eq!(2.0, x.distance_squared(y));
+    assert_eq!(13.0, (2.0 * x).distance_squared(-3.0 * z));
+    assert_eq!(2.0_f32.sqrt(), w.distance(y));
+    assert_eq!(5.0, (3.0 * x).distance(-4.0 * y));
+    assert_eq!(13.0, (-5.0 * w).distance(12.0 * y));
     assert_eq!(x, (2.0 * x).normalize());
     assert_eq!(
         1.0 * 5.0 + 2.0 * 6.0 + 3.0 * 7.0 + 4.0 * 8.0,


### PR DESCRIPTION
These two operations should be common enough to merit their own methods.

Closes #72 

This implementation reused the `length` and `length_squared` functions so they automatically have SIMD.
