### PR TITLE
Implement arithmetic traits

### DIFF
--- a/src/f32/mat2.rs
+++ b/src/f32/mat2.rs
@@ -8,6 +8,9 @@ use core::{
     ops::{Add, Mul, Sub},
 };
 
+#[cfg(feature = "std")]
+use std::iter::{Product, Sum};
+
 const ZERO: Mat2 = const_mat2!([0.0; 4]);
 const IDENTITY: Mat2 = const_mat2!([1.0, 0.0], [0.0, 1.0]);
 
@@ -357,5 +360,25 @@ impl Mul<f32> for Mat2 {
     #[inline]
     fn mul(self, other: f32) -> Self {
         self.mul_scalar(other)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Sum<&'a Self> for Mat2 {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ZERO, |a, &b| Self::add(a, b))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Product<&'a Self> for Mat2 {
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(IDENTITY, |a, &b| Self::mul(a, b))
     }
 }

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -4,6 +4,9 @@ use core::{
     ops::{Add, Mul, Sub},
 };
 
+#[cfg(feature = "std")]
+use std::iter::{Product, Sum};
+
 const ZERO: Mat3 = const_mat3!([0.0; 9]);
 const IDENTITY: Mat3 = const_mat3!([1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]);
 
@@ -518,5 +521,25 @@ impl Mul<f32> for Mat3 {
     #[inline]
     fn mul(self, other: f32) -> Self {
         self.mul_scalar(other)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Sum<&'a Self> for Mat3 {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ZERO, |a, &b| Self::add(a, b))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Product<&'a Self> for Mat3 {
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(IDENTITY, |a, &b| Self::mul(a, b))
     }
 }

--- a/src/f32/mat4.rs
+++ b/src/f32/mat4.rs
@@ -8,6 +8,9 @@ use core::{
     ops::{Add, Mul, Sub},
 };
 
+#[cfg(feature = "std")]
+use std::iter::{Product, Sum};
+
 const ZERO: Mat4 = const_mat4!([0.0; 16]);
 const IDENTITY: Mat4 = const_mat4!(
     [1.0, 0.0, 0.0, 0.0],
@@ -1130,5 +1133,25 @@ impl Mul<f32> for Mat4 {
     #[inline]
     fn mul(self, other: f32) -> Self {
         self.mul_scalar(other)
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Sum<&'a Self> for Mat4 {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ZERO, |a, &b| Self::add(a, b))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Product<&'a Self> for Mat4 {
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(IDENTITY, |a, &b| Self::mul(a, b))
     }
 }

--- a/src/f32/quat.rs
+++ b/src/f32/quat.rs
@@ -9,6 +9,10 @@ use core::{
     ops::{Add, Div, Mul, MulAssign, Neg, Sub},
 };
 
+#[cfg(feature = "std")]
+use std::iter::{Product, Sum};
+
+const ZERO: Quat = const_quat!([0.0, 0.0, 0.0, 0.0]);
 const IDENTITY: Quat = const_quat!([0.0, 0.0, 0.0, 1.0]);
 
 /// A quaternion representing an orientation.
@@ -723,5 +727,25 @@ impl From<__m128> for Quat {
     #[inline]
     fn from(t: __m128) -> Self {
         Self(Vec4(t))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Sum<&'a Self> for Quat {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ZERO, |a, &b| Self::add(a, b))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Product<&'a Self> for Quat {
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(IDENTITY, |a, &b| Self::mul(a, b))
     }
 }

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -1,6 +1,9 @@
 use crate::f32::{Vec2Mask, Vec3};
 use core::{f32, fmt, ops::*};
 
+#[cfg(feature = "std")]
+use std::iter::{Product, Sum};
+
 const ZERO: Vec2 = const_vec2!([0.0; 2]);
 const ONE: Vec2 = const_vec2!([1.0; 2]);
 const X_AXIS: Vec2 = const_vec2!([1.0, 0.0]);
@@ -561,5 +564,25 @@ impl From<Vec2> for [f32; 2] {
     #[inline]
     fn from(v: Vec2) -> Self {
         [v.0, v.1]
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Sum<&'a Self> for Vec2 {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ZERO, |a, &b| Self::add(a, b))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Product<&'a Self> for Vec2 {
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ONE, |a, &b| Self::mul(a, b))
     }
 }

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -1,6 +1,9 @@
 use super::{Vec2, Vec3A, Vec3Mask, Vec4};
 use core::{fmt, ops::*};
 
+#[cfg(feature = "std")]
+use std::iter::{Product, Sum};
+
 const ZERO: Vec3 = const_vec3!([0.0; 3]);
 const ONE: Vec3 = const_vec3!([1.0; 3]);
 const X_AXIS: Vec3 = const_vec3!([1.0, 0.0, 0.0]);
@@ -682,4 +685,24 @@ fn test_vec3_private() {
         vec3(1.0, 1.0, 1.0).mul_add(vec3(0.5, 2.0, -4.0), vec3(-1.0, -1.0, -1.0)),
         vec3(-0.5, 1.0, -5.0)
     );
+}
+
+#[cfg(feature = "std")]
+impl<'a> Sum<&'a Self> for Vec3 {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ZERO, |a, &b| Self::add(a, b))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Product<&'a Self> for Vec3 {
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ONE, |a, &b| Self::mul(a, b))
+    }
 }

--- a/src/f32/vec3a.rs
+++ b/src/f32/vec3a.rs
@@ -9,6 +9,9 @@ use core::arch::x86_64::*;
 #[cfg(vec3a_sse2)]
 use core::{cmp::Ordering, f32, mem::MaybeUninit};
 
+#[cfg(feature = "std")]
+use std::iter::{Product, Sum};
+
 #[cfg(vec3a_sse2)]
 use crate::Align16;
 
@@ -1194,6 +1197,26 @@ impl From<Vec3A> for Vec2 {
         {
             v.0.into()
         }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Sum<&'a Self> for Vec3A {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ZERO, |a, &b| Self::add(a, b))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Product<&'a Self> for Vec3A {
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ONE, |a, &b| Self::mul(a, b))
     }
 }
 

--- a/src/f32/vec4.rs
+++ b/src/f32/vec4.rs
@@ -6,6 +6,9 @@ use core::arch::x86::*;
 #[cfg(all(vec4_sse2, target_arch = "x86_64"))]
 use core::arch::x86_64::*;
 
+#[cfg(feature = "std")]
+use std::iter::{Product, Sum};
+
 #[cfg(vec4_sse2)]
 use crate::Align16;
 #[cfg(vec4_sse2)]
@@ -1356,6 +1359,26 @@ impl From<Vec4> for Vec2 {
         {
             Vec2(v.0, v.1)
         }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Sum<&'a Self> for Vec4 {
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ZERO, |a, &b| Self::add(a, b))
+    }
+}
+
+#[cfg(feature = "std")]
+impl<'a> Product<&'a Self> for Vec4 {
+    fn product<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = &'a Self>,
+    {
+        iter.fold(ONE, |a, &b| Self::mul(a, b))
     }
 }
 


### PR DESCRIPTION
This PR implements the arithmetic traits `Sum` and `Product`, allowing you to do this stuff:
```rust
let vecs: Vec<Vec2> = vec![Vec2::new(1.0, 2.0), Vec2::new(3.0, 4.0)];

assert_eq!(v.iter().sum::<Vec2>(), Vec2::new(4.0, 6.0));
```