### PR TITLE
Add perp() method to Vec2

### DIFF
--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -375,6 +375,14 @@ impl Vec2 {
         }
     }
 
+    /// Returns a `Vec2` that is equal to `self` rotated by 90 degrees.
+    pub fn perp(self) -> Self {
+        return Self {
+            x: -self.y,
+            y: self.x
+        }
+    }
+
     /// The perpendicular dot product of the vector and `other`.
     #[inline]
     pub fn perp_dot(self, other: Vec2) -> f32 {

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -1,6 +1,6 @@
 mod support;
 
-use glam::{vec2, vec3, Vec2, Vec2Mask, Vec3};
+use glam::{vec2, vec3, Vec2, Vec2Mask, Vec3, Mat2};
 use std::f32;
 
 #[test]
@@ -477,6 +477,21 @@ fn test_vec2_angle_between() {
 
     let angle = Vec2::new(-1.0, 0.0).angle_between(Vec2::new(0.0, 1.0));
     assert_approx_eq!(-f32::consts::FRAC_PI_2, angle, 1e-6);
+}
+
+#[test]
+fn test_vec2_perp() {
+    let v1 = Vec2::new(1.0, 2.0);
+    let v2 = Vec2::new(1.0, 1.0);
+    let v1_perp = Vec2::new(-2.0, 1.0);
+    let rot90 = Mat2::from_angle(90.0_f32.to_radians());
+    
+    assert_eq!(v1_perp, v1.perp());
+    assert_eq!(v1.perp().dot(v1), 0.0);
+    assert_eq!(v2.perp().dot(v2), 0.0);
+    assert_eq!(v1.perp().dot(v2), v1.perp_dot(v2));
+
+    assert_approx_eq!(v1.perp(), rot90 * v1);
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
A perp() method for Vec2 that returns (-y, x) is pretty useful.
Given that there's already a perp_dot I think it makes sense to have this too.
