### PR TITLE
Methods to clamp vector length

### DIFF
--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -401,6 +401,36 @@ impl Vec2 {
             angle
         }
     }
+
+    /// Returns a `Vec2` with a length no less than `min` and no more than `max`
+    pub fn clamp_length(&self, min: f32, max: f32) -> Self {
+        let length_sq = self.length_squared();
+        if length_sq < min * min {
+            self.normalize() * min
+        } else if length_sq > max * max {
+            self.normalize() * max
+        } else {
+            *self
+        }
+    }
+
+    /// Returns a `Vec2` with a length no more than `max`
+    pub fn clamp_length_max(&self, max: f32) -> Self {
+        if self.length_squared() > max * max {
+            self.normalize() * max
+        } else {
+            *self
+        }
+    }
+
+    /// Returns a `Vec2` with a length no less than `min`
+    pub fn clamp_length_min(&self, min: f32) -> Self {
+        if self.length_squared() < min * min {
+            self.normalize() * min
+        } else {
+            *self
+        }
+    }
 }
 
 impl fmt::Display for Vec2 {

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -406,9 +406,9 @@ impl Vec2 {
     pub fn clamp_length(&self, min: f32, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
-            self.normalize() * min
+            *self * (length_sq.sqrt().recip() * min)
         } else if length_sq > max * max {
-            self.normalize() * max
+            *self * (length_sq.sqrt().recip() * max)
         } else {
             *self
         }
@@ -416,8 +416,9 @@ impl Vec2 {
 
     /// Returns a `Vec2` with a length no more than `max`
     pub fn clamp_length_max(&self, max: f32) -> Self {
-        if self.length_squared() > max * max {
-            self.normalize() * max
+        let length_sq = self.length_squared();
+        if length_sq > max * max {
+            *self * (length_sq.sqrt().recip() * max)
         } else {
             *self
         }
@@ -425,8 +426,9 @@ impl Vec2 {
 
     /// Returns a `Vec2` with a length no less than `min`
     pub fn clamp_length_min(&self, min: f32) -> Self {
+        let length_sq = self.length_squared();
         if self.length_squared() < min * min {
-            self.normalize() * min
+            *self * (length_sq.sqrt().recip() * min)
         } else {
             *self
         }

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -461,9 +461,9 @@ impl Vec3 {
     pub fn clamp_length(&self, min: f32, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
-            self.normalize() * min
+            *self * (length_sq.sqrt().recip() * min)
         } else if length_sq > max * max {
-            self.normalize() * max
+            *self * (length_sq.sqrt().recip() * max)
         } else {
             *self
         }
@@ -471,8 +471,9 @@ impl Vec3 {
 
     /// Returns a `Vec3` with a length no more than `max`
     pub fn clamp_length_max(&self, max: f32) -> Self {
-        if self.length_squared() > max * max {
-            self.normalize() * max
+        let length_sq = self.length_squared();
+        if length_sq > max * max {
+            *self * (length_sq.sqrt().recip() * max)
         } else {
             *self
         }
@@ -480,8 +481,9 @@ impl Vec3 {
 
     /// Returns a `Vec3` with a length no less than `min`
     pub fn clamp_length_min(&self, min: f32) -> Self {
+        let length_sq = self.length_squared();
         if self.length_squared() < min * min {
-            self.normalize() * min
+            *self * (length_sq.sqrt().recip() * min)
         } else {
             *self
         }

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -456,6 +456,36 @@ impl Vec3 {
     pub fn angle_between(self, other: Self) -> f32 {
         crate::f32::funcs::scalar_acos(self.dot(other) / (self.dot(self) * other.dot(other)).sqrt())
     }
+
+    /// Returns a `Vec3` with a length no less than `min` and no more than `max`
+    pub fn clamp_length(&self, min: f32, max: f32) -> Self {
+        let length_sq = self.length_squared();
+        if length_sq < min * min {
+            self.normalize() * min
+        } else if length_sq > max * max {
+            self.normalize() * max
+        } else {
+            *self
+        }
+    }
+
+    /// Returns a `Vec3` with a length no more than `max`
+    pub fn clamp_length_max(&self, max: f32) -> Self {
+        if self.length_squared() > max * max {
+            self.normalize() * max
+        } else {
+            *self
+        }
+    }
+
+    /// Returns a `Vec3` with a length no less than `min`
+    pub fn clamp_length_min(&self, min: f32) -> Self {
+        if self.length_squared() < min * min {
+            self.normalize() * min
+        } else {
+            *self
+        }
+    }
 }
 
 impl AsRef<[f32; 3]> for Vec3 {

--- a/src/f32/vec3a.rs
+++ b/src/f32/vec3a.rs
@@ -723,6 +723,36 @@ impl Vec3A {
     pub fn angle_between(self, other: Self) -> f32 {
         crate::f32::funcs::scalar_acos(self.dot(other) / (self.dot(self) * other.dot(other)).sqrt())
     }
+
+    /// Returns a `Vec3A` with a length no less than `min` and no more than `max`
+    pub fn clamp_length(&self, min: f32, max: f32) -> Self {
+        let length_sq = self.length_squared();
+        if length_sq < min * min {
+            self.normalize() * min
+        } else if length_sq > max * max {
+            self.normalize() * max
+        } else {
+            *self
+        }
+    }
+
+    /// Returns a `Vec3A` with a length no more than `max`
+    pub fn clamp_length_max(&self, max: f32) -> Self {
+        if self.length_squared() > max * max {
+            self.normalize() * max
+        } else {
+            *self
+        }
+    }
+
+    /// Returns a `Vec3A` with a length no less than `min`
+    pub fn clamp_length_min(&self, min: f32) -> Self {
+        if self.length_squared() < min * min {
+            self.normalize() * min
+        } else {
+            *self
+        }
+    }
 }
 
 impl AsRef<[f32; 3]> for Vec3A {

--- a/src/f32/vec3a.rs
+++ b/src/f32/vec3a.rs
@@ -728,9 +728,9 @@ impl Vec3A {
     pub fn clamp_length(&self, min: f32, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
-            self.normalize() * min
+            *self * (length_sq.sqrt().recip() * min)
         } else if length_sq > max * max {
-            self.normalize() * max
+            *self * (length_sq.sqrt().recip() * max)
         } else {
             *self
         }
@@ -738,8 +738,9 @@ impl Vec3A {
 
     /// Returns a `Vec3A` with a length no more than `max`
     pub fn clamp_length_max(&self, max: f32) -> Self {
-        if self.length_squared() > max * max {
-            self.normalize() * max
+        let length_sq = self.length_squared();
+        if length_sq > max * max {
+            *self * (length_sq.sqrt().recip() * max)
         } else {
             *self
         }
@@ -747,8 +748,9 @@ impl Vec3A {
 
     /// Returns a `Vec3A` with a length no less than `min`
     pub fn clamp_length_min(&self, min: f32) -> Self {
+        let length_sq = self.length_squared();
         if self.length_squared() < min * min {
-            self.normalize() * min
+            *self * (length_sq.sqrt().recip() * min)
         } else {
             *self
         }

--- a/src/f32/vec4.rs
+++ b/src/f32/vec4.rs
@@ -777,9 +777,9 @@ impl Vec4 {
     pub fn clamp_length(&self, min: f32, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
-            self.normalize() * min
+            *self * (length_sq.sqrt().recip() * min)
         } else if length_sq > max * max {
-            self.normalize() * max
+            *self * (length_sq.sqrt().recip() * max)
         } else {
             *self
         }
@@ -787,8 +787,9 @@ impl Vec4 {
 
     /// Returns a `Vec4` with a length no more than `max`
     pub fn clamp_length_max(&self, max: f32) -> Self {
-        if self.length_squared() > max * max {
-            self.normalize() * max
+        let length_sq = self.length_squared();
+        if length_sq > max * max {
+            *self * (length_sq.sqrt().recip() * max)
         } else {
             *self
         }
@@ -796,8 +797,9 @@ impl Vec4 {
 
     /// Returns a `Vec4` with a length no less than `min`
     pub fn clamp_length_min(&self, min: f32) -> Self {
+        let length_sq = self.length_squared();
         if self.length_squared() < min * min {
-            self.normalize() * min
+            *self * (length_sq.sqrt().recip() * min)
         } else {
             *self
         }

--- a/src/f32/vec4.rs
+++ b/src/f32/vec4.rs
@@ -772,6 +772,36 @@ impl Vec4 {
     pub fn abs_diff_eq(self, other: Self, max_abs_diff: f32) -> bool {
         abs_diff_eq!(self, other, max_abs_diff)
     }
+
+    /// Returns a `Vec4` with a length no less than `min` and no more than `max`
+    pub fn clamp_length(&self, min: f32, max: f32) -> Self {
+        let length_sq = self.length_squared();
+        if length_sq < min * min {
+            self.normalize() * min
+        } else if length_sq > max * max {
+            self.normalize() * max
+        } else {
+            *self
+        }
+    }
+
+    /// Returns a `Vec4` with a length no more than `max`
+    pub fn clamp_length_max(&self, max: f32) -> Self {
+        if self.length_squared() > max * max {
+            self.normalize() * max
+        } else {
+            *self
+        }
+    }
+
+    /// Returns a `Vec4` with a length no less than `min`
+    pub fn clamp_length_min(&self, min: f32) -> Self {
+        if self.length_squared() < min * min {
+            self.normalize() * min
+        } else {
+            *self
+        }
+    }
 }
 
 impl AsRef<[f32; 4]> for Vec4 {

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -544,3 +544,50 @@ fn test_exp() {
         Vec2::new(1.0_f32.exp(), 2.0_f32.exp())
     );
 }
+
+#[test]
+fn test_clamp_length() {
+    // Too long gets shortened
+    assert_eq!(
+        Vec2::new(12.0, 16.0).clamp_length(7.0, 10.0),
+        Vec2::new(6.0, 8.0) // shortened to length 10.0
+    );
+    // In the middle is unchanged
+    assert_eq!(
+        Vec2::new(2.0, 1.0).clamp_length(0.5, 5.0),
+        Vec2::new(2.0, 1.0) // unchanged
+    );
+    // Too short gets lengthened
+    assert_eq!(
+        Vec2::new(0.6, 0.8).clamp_length(10.0, 20.0),
+        Vec2::new(6.0, 8.0) // lengthened to length 10.0
+    );
+}
+
+#[test]
+fn test_clamp_length_max() {
+    // Too long gets shortened
+    assert_eq!(
+        Vec2::new(12.0, 16.0).clamp_length_max(10.0),
+        Vec2::new(6.0, 8.0) // shortened to length 10.0
+    );
+    // Not too long is unchanged
+    assert_eq!(
+        Vec2::new(2.0, 1.0).clamp_length_max(5.0),
+        Vec2::new(2.0, 1.0) // unchanged
+    );
+}
+
+#[test]
+fn test_clamp_length_min() {
+    // Not too short is unchanged
+    assert_eq!(
+        Vec2::new(2.0, 1.0).clamp_length_min(0.5),
+        Vec2::new(2.0, 1.0) // unchanged
+    );
+    // Too short gets lengthened
+    assert_eq!(
+        Vec2::new(0.6, 0.8).clamp_length_min(10.0),
+        Vec2::new(6.0, 8.0) // lengthened to length 10.0
+    );
+}

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -595,3 +595,50 @@ fn test_exp() {
         Vec3::new(1.0_f32.exp(), 2.0_f32.exp(), 3.0_f32.exp())
     );
 }
+
+#[test]
+fn test_clamp_length() {
+    // Too long gets shortened
+    assert_eq!(
+        Vec3::new(12.0, 16.0, 0.0).clamp_length(7.0, 10.0),
+        Vec3::new(6.0, 8.0, 0.0) // shortened to length 10.0
+    );
+    // In the middle is unchanged
+    assert_eq!(
+        Vec3::new(2.0, 1.0, 0.0).clamp_length(0.5, 5.0),
+        Vec3::new(2.0, 1.0, 0.0) // unchanged
+    );
+    // Too short gets lengthened
+    assert_eq!(
+        Vec3::new(0.6, 0.8, 0.0).clamp_length(10.0, 20.0),
+        Vec3::new(6.0, 8.0, 0.0) // lengthened to length 10.0
+    );
+}
+
+#[test]
+fn test_clamp_length_max() {
+    // Too long gets shortened
+    assert_eq!(
+        Vec3::new(12.0, 16.0, 0.0).clamp_length_max(10.0),
+        Vec3::new(6.0, 8.0, 0.0) // shortened to length 10.0
+    );
+    // Not too long is unchanged
+    assert_eq!(
+        Vec3::new(2.0, 1.0, 0.0).clamp_length_max(5.0),
+        Vec3::new(2.0, 1.0, 0.0) // unchanged
+    );
+}
+
+#[test]
+fn test_clamp_length_min() {
+    // Not too short is unchanged
+    assert_eq!(
+        Vec3::new(2.0, 1.0, 0.0).clamp_length_min(0.5),
+        Vec3::new(2.0, 1.0, 0.0) // unchanged
+    );
+    // Too short gets lengthened
+    assert_eq!(
+        Vec3::new(0.6, 0.8, 0.0).clamp_length_min(10.0),
+        Vec3::new(6.0, 8.0, 0.0) // lengthened to length 10.0
+    );
+}

--- a/tests/vec3a.rs
+++ b/tests/vec3a.rs
@@ -643,3 +643,50 @@ fn test_exp() {
         Vec3A::new(1.0_f32.exp(), 2.0_f32.exp(), 3.0_f32.exp())
     );
 }
+
+#[test]
+fn test_clamp_length() {
+    // Too long gets shortened
+    assert_eq!(
+        Vec3A::new(12.0, 16.0, 0.0).clamp_length(7.0, 10.0),
+        Vec3A::new(6.0, 8.0, 0.0) // shortened to length 10.0
+    );
+    // In the middle is unchanged
+    assert_eq!(
+        Vec3A::new(2.0, 1.0, 0.0).clamp_length(0.5, 5.0),
+        Vec3A::new(2.0, 1.0, 0.0) // unchanged
+    );
+    // Too short gets lengthened
+    assert_eq!(
+        Vec3A::new(0.6, 0.8, 0.0).clamp_length(10.0, 20.0),
+        Vec3A::new(6.0, 8.0, 0.0) // lengthened to length 10.0
+    );
+}
+
+#[test]
+fn test_clamp_length_max() {
+    // Too long gets shortened
+    assert_eq!(
+        Vec3A::new(12.0, 16.0, 0.0).clamp_length_max(10.0),
+        Vec3A::new(6.0, 8.0, 0.0) // shortened to length 10.0
+    );
+    // Not too long is unchanged
+    assert_eq!(
+        Vec3A::new(2.0, 1.0, 0.0).clamp_length_max(5.0),
+        Vec3A::new(2.0, 1.0, 0.0) // unchanged
+    );
+}
+
+#[test]
+fn test_clamp_length_min() {
+    // Not too short is unchanged
+    assert_eq!(
+        Vec3A::new(2.0, 1.0, 0.0).clamp_length_min(0.5),
+        Vec3A::new(2.0, 1.0, 0.0) // unchanged
+    );
+    // Too short gets lengthened
+    assert_eq!(
+        Vec3A::new(0.6, 0.8, 0.0).clamp_length_min(10.0),
+        Vec3A::new(6.0, 8.0, 0.0) // lengthened to length 10.0
+    );
+}

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -667,3 +667,50 @@ fn test_exp() {
         Vec4::new(1.0_f32.exp(), 2.0_f32.exp(), 3.0_f32.exp(), 4.0_f32.exp())
     );
 }
+
+#[test]
+fn test_clamp_length() {
+    // Too long gets shortened
+    assert_eq!(
+        Vec4::new(12.0, 16.0, 0.0, 0.0).clamp_length(7.0, 10.0),
+        Vec4::new(6.0, 8.0, 0.0, 0.0) // shortened to length 10.0
+    );
+    // In the middle is unchanged
+    assert_eq!(
+        Vec4::new(2.0, 1.0, 0.0, 0.0).clamp_length(0.5, 5.0),
+        Vec4::new(2.0, 1.0, 0.0, 0.0) // unchanged
+    );
+    // Too short gets lengthened
+    assert_eq!(
+        Vec4::new(0.6, 0.8, 0.0, 0.0).clamp_length(10.0, 20.0),
+        Vec4::new(6.0, 8.0, 0.0, 0.0) // lengthened to length 10.0
+    );
+}
+
+#[test]
+fn test_clamp_length_max() {
+    // Too long gets shortened
+    assert_eq!(
+        Vec4::new(12.0, 16.0, 0.0, 0.0).clamp_length_max(10.0),
+        Vec4::new(6.0, 8.0, 0.0, 0.0) // shortened to length 10.0
+    );
+    // Not too long is unchanged
+    assert_eq!(
+        Vec4::new(2.0, 1.0, 0.0, 0.0).clamp_length_max(5.0),
+        Vec4::new(2.0, 1.0, 0.0, 0.0) // unchanged
+    );
+}
+
+#[test]
+fn test_clamp_length_min() {
+    // Not too short is unchanged
+    assert_eq!(
+        Vec4::new(2.0, 1.0, 0.0, 0.0).clamp_length_min(0.5),
+        Vec4::new(2.0, 1.0, 0.0, 0.0) // unchanged
+    );
+    // Too short gets lengthened
+    assert_eq!(
+        Vec4::new(0.6, 0.8, 0.0, 0.0).clamp_length_min(10.0),
+        Vec4::new(6.0, 8.0, 0.0, 0.0) // lengthened to length 10.0
+    );
+}


### PR DESCRIPTION
An implementation of `clamp_length*` methods for `Vec2`, `Vec3`, `Vec3A`, and `Vec4`.

This PR is based off of `0.11.0`, but I can see that there is a pretty heavy refactor going on in the `refactor` branch to produce the `Vec*` implementations through macros.  I'm willing to reimplement this PR off of `refactor` if that's helpful. (probably after it's in a stable state?)

Resolves #100 