### PR TITLE
Implements Vec3A directly

### DIFF
--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -708,7 +708,8 @@ impl From<Vec3A> for Vec3 {
 
         #[cfg(vec3a_f32)]
         {
-            v.0
+            let (x, y, z) = v.into();
+            Self { x, y, z }
         }
     }
 }

--- a/src/f32/vec3a.rs
+++ b/src/f32/vec3a.rs
@@ -675,21 +675,21 @@ impl Vec3A {
     /// Returns a `Vec3A` containing `e^self` (the exponential function) for each element of `self`.
     #[inline]
     pub fn exp(self) -> Self {
-        Self {
-            x: self.x.exp(),
-            y: self.y.exp(),
-            z: self.z.exp(),
-        }
+        Self::new(
+            self.x.exp(),
+            self.y.exp(),
+            self.z.exp(),
+        )
     }
 
     /// Returns a `Vec3A` containing each element of `self` raised to the power of `n`.
     #[inline]
     pub fn powf(self, n: f32) -> Self {
-        Self {
-            x: self.x.powf(n),
-            y: self.y.powf(n),
-            z: self.z.powf(n),
-        }
+        Self::new(
+            self.x.powf(n),
+            self.y.powf(n),
+            self.z.powf(n),
+        )
     }
 
     /// Performs `is_nan()` on each element of self, returning a `Vec3AMask` of the results.
@@ -725,22 +725,22 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self {
-                x: self.x.signum(),
-                y: self.y.signum(),
-                z: self.z.signum(),
-            }
+            Self::new(
+                self.x.signum(),
+                self.y.signum(),
+                self.z.signum(),
+            )
         }
     }
 
     /// Returns a `Vec3A` containing the reciprocal `1.0/n` of each element of `self`.
     #[inline]
     pub fn recip(self) -> Self {
-        Self {
-            x: self.x.recip(),
-            y: self.y.recip(),
-            z: self.z.recip(),
-        }
+        Self::new(
+            self.x.recip(),
+            self.y.recip(),
+            self.z.recip(),
+        )
     }
 
     /// Performs a linear interpolation between `self` and `other` based on

--- a/src/f32/vec3a.rs
+++ b/src/f32/vec3a.rs
@@ -19,6 +19,7 @@ use std::iter::{Product, Sum};
 
 #[cfg(vec3a_sse2)]
 use crate::Align16;
+use crate::Vec3Mask;
 
 const ZERO: Vec3A = const_vec3a!([0.0; 3]);
 const ONE: Vec3A = const_vec3a!([1.0; 3]);
@@ -34,9 +35,7 @@ const Z_AXIS: Vec3A = const_vec3a!([0.0, 0.0, 1.0]);
 /// It is possible to convert between `Vec3` and `Vec3A` types using `From` trait implementations.
 #[cfg(doc)]
 #[derive(Clone, Copy, PartialEq, PartialOrd, Default)]
-#[repr(align(16))]
-#[cfg_attr(not(target_arch = "spirv"), repr(C))]
-#[cfg_attr(target_arch = "spirv", repr(simd))]
+#[repr(align(16), C)]
 pub struct Vec3A {
     pub x: f32,
     pub y: f32,
@@ -50,8 +49,14 @@ pub struct Vec3A(pub(crate) __m128);
 
 #[cfg(all(any(not(target_feature = "sse2"), feature = "scalar-math"), not(doc)))]
 #[derive(Clone, Copy, PartialEq, PartialOrd, Default)]
-#[repr(align(16), C)]
-pub struct Vec3A(pub(crate) Vec3);
+#[repr(align(16))]
+#[cfg_attr(not(target_arch = "spirv"), repr(C))]
+#[cfg_attr(target_arch = "spirv", repr(simd))]
+pub struct Vec3A {
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+}
 
 #[cfg(vec3a_sse2)]
 impl Vec3A {
@@ -124,7 +129,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(Vec3::new(x, y, z))
+            Self {x, y, z }
         }
     }
 
@@ -168,7 +173,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(Vec3::splat(v))
+            Self { x: v, y: v, z: v }
         }
     }
 
@@ -184,7 +189,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.extend(w)
+            Vec4::new(self.x, self.y, self.z, w)
         }
     }
 
@@ -201,7 +206,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.truncate()
+            Vec2::new(self.x, self.y)
         }
     }
 
@@ -215,7 +220,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.dot(other.0)
+            (self.x * other.x) + (self.y * other.y) + (self.z * other.z)
         }
     }
 
@@ -231,7 +236,8 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.dot_as_vec3(other.0))
+            let dot = self.dot(other);
+            Self { x: dot, y: dot, z: dot }
         }
     }
 
@@ -255,7 +261,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.cross(other.0))
+            Self {
+                x: self.y * other.z - other.y * self.z,
+                y: self.z * other.x - other.z * self.x,
+                z: self.x * other.y - other.x * self.y,
+            }
         }
     }
 
@@ -269,7 +279,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.length()
+            self.dot(self).sqrt()
         }
     }
 
@@ -298,7 +308,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.length_recip()
+            self.length().recip()
         }
     }
 
@@ -327,7 +337,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.normalize())
+            self * self.length_recip()
         }
     }
 
@@ -345,7 +355,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.min(other.0))
+            Self {
+                x: self.x.min(other.x),
+                y: self.y.min(other.y),
+                z: self.z.min(other.z),
+            }
         }
     }
 
@@ -363,7 +377,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.max(other.0))
+            Self {
+                x: self.x.max(other.x),
+                y: self.y.max(other.y),
+                z: self.z.max(other.z),
+            }
         }
     }
 
@@ -382,7 +400,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.min_element()
+            self.x.min(self.y.min(self.z))
         }
     }
 
@@ -401,7 +419,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.max_element()
+            self.x.max(self.y.max(self.z))
         }
     }
 
@@ -418,7 +436,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3AMask(self.0.cmpeq(other.0))
+            Vec3AMask::new(
+                self.x.eq(&other.x),
+                self.y.eq(&other.y),
+                self.z.eq(&other.z),
+            )
         }
     }
 
@@ -435,7 +457,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3AMask(self.0.cmpne(other.0))
+            Vec3AMask::new(
+                self.x.ne(&other.x),
+                self.y.ne(&other.y),
+                self.z.ne(&other.z),
+            )
         }
     }
 
@@ -452,7 +478,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3AMask(self.0.cmpge(other.0))
+            Vec3AMask::new(
+                self.x.ge(&other.x),
+                self.y.ge(&other.y),
+                self.z.ge(&other.z),
+            )
         }
     }
 
@@ -469,7 +499,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3AMask(self.0.cmpgt(other.0))
+            Vec3AMask::new(
+                self.x.gt(&other.x),
+                self.y.gt(&other.y),
+                self.z.gt(&other.z),
+            )
         }
     }
 
@@ -486,7 +520,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3AMask(self.0.cmple(other.0))
+            Vec3AMask::new(
+                self.x.le(&other.x),
+                self.y.le(&other.y),
+                self.z.le(&other.z),
+            )
         }
     }
 
@@ -503,7 +541,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3AMask(self.0.cmplt(other.0))
+            Vec3AMask::new(
+                self.x.lt(&other.x),
+                self.y.lt(&other.y),
+                self.z.lt(&other.z),
+            )
         }
     }
 
@@ -541,7 +583,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.mul_add(a.0, b.0))
+            Self {
+                x: (self.x * a.x) + b.x,
+                y: (self.y * a.y) + b.y,
+                z: (self.z * a.z) + b.z,
+            }
         }
     }
 
@@ -558,7 +604,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.abs())
+            Self {
+                x: self.x.abs(),
+                y: self.y.abs(),
+                z: self.z.abs(),
+            }
         }
     }
 
@@ -574,7 +624,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.round())
+            Self {
+                x: self.x.round(),
+                y: self.y.round(),
+                z: self.z.round(),
+            }
         }
     }
 
@@ -590,7 +644,11 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.floor())
+            Self {
+                x: self.x.floor(),
+                y: self.y.floor(),
+                z: self.z.floor(),
+            }
         }
     }
 
@@ -606,20 +664,32 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.ceil())
+            Self {
+                x: self.x.ceil(),
+                y: self.y.ceil(),
+                z: self.z.ceil(),
+            }
         }
     }
 
     /// Returns a `Vec3A` containing `e^self` (the exponential function) for each element of `self`.
     #[inline]
     pub fn exp(self) -> Self {
-        Self::new(self.x.exp(), self.y.exp(), self.z.exp())
+        Self {
+            x: self.x.exp(),
+            y: self.y.exp(),
+            z: self.z.exp(),
+        }
     }
 
     /// Returns a `Vec3A` containing each element of `self` raised to the power of `n`.
     #[inline]
     pub fn powf(self, n: f32) -> Self {
-        Self::new(self.x.powf(n), self.y.powf(n), self.z.powf(n))
+        Self {
+            x: self.x.powf(n),
+            y: self.y.powf(n),
+            z: self.z.powf(n),
+        }
     }
 
     /// Performs `is_nan()` on each element of self, returning a `Vec3AMask` of the results.
@@ -634,7 +704,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3AMask(self.0.is_nan_mask())
+            Vec3AMask::new(self.x.is_nan(), self.y.is_nan(), self.z.is_nan())
         }
     }
 
@@ -655,15 +725,22 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(self.0.signum())
+            Self {
+                x: self.x.signum(),
+                y: self.y.signum(),
+                z: self.z.signum(),
+            }
         }
     }
 
     /// Returns a `Vec3A` containing the reciprocal `1.0/n` of each element of `self`.
     #[inline]
     pub fn recip(self) -> Self {
-        // TODO: Optimize
-        Self::one() / self
+        Self {
+            x: self.x.recip(),
+            y: self.y.recip(),
+            z: self.z.recip(),
+        }
     }
 
     /// Performs a linear interpolation between `self` and `other` based on
@@ -701,7 +778,7 @@ impl Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.is_nan()
+            self.x.is_nan() || self.y.is_nan() || self.z.is_nan()
         }
     }
 
@@ -766,7 +843,7 @@ impl fmt::Display for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.fmt(f)
+            write!(f, "[{}, {}, {}]", self.x, self.y, self.z)
         }
     }
 }
@@ -782,7 +859,11 @@ impl Div<Vec3A> for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.div(other.0))
+            Self {
+                x: self.x / other.x,
+                y: self.y / other.y,
+                z: self.z / other.z,
+            }
         }
     }
 }
@@ -797,7 +878,9 @@ impl DivAssign<Vec3A> for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.div_assign(other.0);
+            self.x /= other.x;
+            self.y /= other.y;
+            self.z /= other.z;
         }
     }
 }
@@ -813,7 +896,11 @@ impl Div<f32> for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.div(other))
+            Self {
+                x: self.x / other,
+                y: self.y / other,
+                z: self.z / other,
+            }
         }
     }
 }
@@ -828,7 +915,9 @@ impl DivAssign<f32> for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.div_assign(other)
+            self.x /= other;
+            self.y /= other;
+            self.z /= other;
         }
     }
 }
@@ -844,7 +933,11 @@ impl Div<Vec3A> for f32 {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(self.div(other.0))
+            Vec3A {
+                x: self / other.x,
+                y: self / other.y,
+                z: self / other.z,
+            }
         }
     }
 }
@@ -860,7 +953,11 @@ impl Mul<Vec3A> for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.mul(other.0))
+            Self {
+                x: self.x * other.x,
+                y: self.y * other.y,
+                z: self.z * other.z,
+            }
         }
     }
 }
@@ -875,7 +972,9 @@ impl MulAssign<Vec3A> for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.mul_assign(other.0);
+            self.x *= other.x;
+            self.y *= other.y;
+            self.z *= other.z;
         }
     }
 }
@@ -891,7 +990,11 @@ impl Mul<f32> for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.mul(other))
+            Self {
+                x: self.x * other,
+                y: self.y * other,
+                z: self.z * other,
+            }
         }
     }
 }
@@ -906,7 +1009,9 @@ impl MulAssign<f32> for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.mul_assign(other);
+            self.x *= other;
+            self.y *= other;
+            self.z *= other;
         }
     }
 }
@@ -922,7 +1027,11 @@ impl Mul<Vec3A> for f32 {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(self.mul(other.0))
+            Vec3A {
+                x: self * other.x,
+                y: self * other.y,
+                z: self * other.z,
+            }
         }
     }
 }
@@ -938,7 +1047,11 @@ impl Add for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.add(other.0))
+            Self {
+                x: self.x + other.x,
+                y: self.y + other.y,
+                z: self.z + other.z,
+            }
         }
     }
 }
@@ -953,7 +1066,9 @@ impl AddAssign for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.add_assign(other.0);
+            self.x += other.x;
+            self.y += other.y;
+            self.z += other.z;
         }
     }
 }
@@ -969,7 +1084,11 @@ impl Sub for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.sub(other.0))
+            Self {
+                x: self.x - other.x,
+                y: self.y - other.y,
+                z: self.z - other.z,
+            }
         }
     }
 }
@@ -984,7 +1103,9 @@ impl SubAssign for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            self.0.sub_assign(other.0);
+            self.x -= other.x;
+            self.y -= other.y;
+            self.z -= other.z;
         }
     }
 }
@@ -1000,7 +1121,11 @@ impl Neg for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Self(self.0.neg())
+            Self {
+                x: -self.x,
+                y: -self.y,
+                z: -self.z,
+            }
         }
     }
 }
@@ -1042,7 +1167,7 @@ impl From<Vec3A> for (f32, f32, f32) {
 
         #[cfg(vec3a_f32)]
         {
-            v.0.into()
+            (v.x, v.y, v.z)
         }
     }
 }
@@ -1069,7 +1194,7 @@ impl From<Vec3A> for [f32; 3] {
 
         #[cfg(vec3a_f32)]
         {
-            v.0.into()
+            [v.x, v.y, v.z]
         }
     }
 }
@@ -1097,7 +1222,7 @@ impl From<Vec3A> for Vec2 {
 
         #[cfg(vec3a_f32)]
         {
-            v.0.into()
+            v.into()
         }
     }
 }

--- a/src/f32/vec3a_mask.rs
+++ b/src/f32/vec3a_mask.rs
@@ -167,7 +167,11 @@ impl Vec3AMask {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(self.0.select(if_true.0, if_false.0))
+            Vec3A {
+                x: if self.0.0 != 0 { if_true.x } else { if_false.x },
+                y: if self.0.1 != 0 { if_true.y } else { if_false.y },
+                z: if self.0.2 != 0 { if_true.z } else { if_false.z },
+            }
         }
     }
 }

--- a/src/f32/vec3a_swizzle.rs
+++ b/src/f32/vec3a_swizzle.rs
@@ -140,7 +140,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.x, z: self.0.x, w: self.0.x }
+            Vec4 { x: self.x, y: self.x, z: self.x, w: self.x }
         }
     }
     #[inline]
@@ -152,7 +152,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.x, z: self.0.x, w: self.0.y }
+            Vec4 { x: self.x, y: self.x, z: self.x, w: self.y }
         }
     }
     #[inline]
@@ -164,7 +164,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.x, z: self.0.x, w: self.0.z }
+            Vec4 { x: self.x, y: self.x, z: self.x, w: self.z }
         }
     }
     #[inline]
@@ -176,7 +176,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.x, z: self.0.y, w: self.0.x }
+            Vec4 { x: self.x, y: self.x, z: self.y, w: self.x }
         }
     }
     #[inline]
@@ -188,7 +188,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.x, z: self.0.y, w: self.0.y }
+            Vec4 { x: self.x, y: self.x, z: self.y, w: self.y }
         }
     }
     #[inline]
@@ -200,7 +200,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.x, z: self.0.y, w: self.0.z }
+            Vec4 { x: self.x, y: self.x, z: self.y, w: self.z }
         }
     }
     #[inline]
@@ -212,7 +212,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.x, z: self.0.z, w: self.0.x }
+            Vec4 { x: self.x, y: self.x, z: self.z, w: self.x }
         }
     }
     #[inline]
@@ -224,7 +224,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.x, z: self.0.z, w: self.0.y }
+            Vec4 { x: self.x, y: self.x, z: self.z, w: self.y }
         }
     }
     #[inline]
@@ -236,7 +236,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.x, z: self.0.z, w: self.0.z }
+            Vec4 { x: self.x, y: self.x, z: self.z, w: self.z }
         }
     }
     #[inline]
@@ -248,7 +248,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.y, z: self.0.x, w: self.0.x }
+            Vec4 { x: self.x, y: self.y, z: self.x, w: self.x }
         }
     }
     #[inline]
@@ -260,7 +260,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.y, z: self.0.x, w: self.0.y }
+            Vec4 { x: self.x, y: self.y, z: self.x, w: self.y }
         }
     }
     #[inline]
@@ -272,7 +272,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.y, z: self.0.x, w: self.0.z }
+            Vec4 { x: self.x, y: self.y, z: self.x, w: self.z }
         }
     }
     #[inline]
@@ -284,7 +284,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.y, z: self.0.y, w: self.0.x }
+            Vec4 { x: self.x, y: self.y, z: self.y, w: self.x }
         }
     }
     #[inline]
@@ -296,7 +296,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.y, z: self.0.y, w: self.0.y }
+            Vec4 { x: self.x, y: self.y, z: self.y, w: self.y }
         }
     }
     #[inline]
@@ -308,7 +308,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.y, z: self.0.y, w: self.0.z }
+            Vec4 { x: self.x, y: self.y, z: self.y, w: self.z }
         }
     }
     #[inline]
@@ -320,7 +320,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.y, z: self.0.z, w: self.0.x }
+            Vec4 { x: self.x, y: self.y, z: self.z, w: self.x }
         }
     }
     #[inline]
@@ -332,7 +332,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.y, z: self.0.z, w: self.0.y }
+            Vec4 { x: self.x, y: self.y, z: self.z, w: self.y }
         }
     }
     #[inline]
@@ -344,7 +344,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.y, z: self.0.z, w: self.0.z }
+            Vec4 { x: self.x, y: self.y, z: self.z, w: self.z }
         }
     }
     #[inline]
@@ -356,7 +356,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.z, z: self.0.x, w: self.0.x }
+            Vec4 { x: self.x, y: self.z, z: self.x, w: self.x }
         }
     }
     #[inline]
@@ -368,7 +368,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.z, z: self.0.x, w: self.0.y }
+            Vec4 { x: self.x, y: self.z, z: self.x, w: self.y }
         }
     }
     #[inline]
@@ -380,7 +380,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.z, z: self.0.x, w: self.0.z }
+            Vec4 { x: self.x, y: self.z, z: self.x, w: self.z }
         }
     }
     #[inline]
@@ -392,7 +392,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.z, z: self.0.y, w: self.0.x }
+            Vec4 { x: self.x, y: self.z, z: self.y, w: self.x }
         }
     }
     #[inline]
@@ -404,7 +404,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.z, z: self.0.y, w: self.0.y }
+            Vec4 { x: self.x, y: self.z, z: self.y, w: self.y }
         }
     }
     #[inline]
@@ -416,7 +416,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.z, z: self.0.y, w: self.0.z }
+            Vec4 { x: self.x, y: self.z, z: self.y, w: self.z }
         }
     }
     #[inline]
@@ -428,7 +428,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.z, z: self.0.z, w: self.0.x }
+            Vec4 { x: self.x, y: self.z, z: self.z, w: self.x }
         }
     }
     #[inline]
@@ -440,7 +440,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.z, z: self.0.z, w: self.0.y }
+            Vec4 { x: self.x, y: self.z, z: self.z, w: self.y }
         }
     }
     #[inline]
@@ -452,7 +452,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.x, y: self.0.z, z: self.0.z, w: self.0.z }
+            Vec4 { x: self.x, y: self.z, z: self.z, w: self.z }
         }
     }
     #[inline]
@@ -464,7 +464,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.x, z: self.0.x, w: self.0.x }
+            Vec4 { x: self.y, y: self.x, z: self.x, w: self.x }
         }
     }
     #[inline]
@@ -476,7 +476,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.x, z: self.0.x, w: self.0.y }
+            Vec4 { x: self.y, y: self.x, z: self.x, w: self.y }
         }
     }
     #[inline]
@@ -488,7 +488,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.x, z: self.0.x, w: self.0.z }
+            Vec4 { x: self.y, y: self.x, z: self.x, w: self.z }
         }
     }
     #[inline]
@@ -500,7 +500,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.x, z: self.0.y, w: self.0.x }
+            Vec4 { x: self.y, y: self.x, z: self.y, w: self.x }
         }
     }
     #[inline]
@@ -512,7 +512,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.x, z: self.0.y, w: self.0.y }
+            Vec4 { x: self.y, y: self.x, z: self.y, w: self.y }
         }
     }
     #[inline]
@@ -524,7 +524,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.x, z: self.0.y, w: self.0.z }
+            Vec4 { x: self.y, y: self.x, z: self.y, w: self.z }
         }
     }
     #[inline]
@@ -536,7 +536,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.x, z: self.0.z, w: self.0.x }
+            Vec4 { x: self.y, y: self.x, z: self.z, w: self.x }
         }
     }
     #[inline]
@@ -548,7 +548,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.x, z: self.0.z, w: self.0.y }
+            Vec4 { x: self.y, y: self.x, z: self.z, w: self.y }
         }
     }
     #[inline]
@@ -560,7 +560,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.x, z: self.0.z, w: self.0.z }
+            Vec4 { x: self.y, y: self.x, z: self.z, w: self.z }
         }
     }
     #[inline]
@@ -572,7 +572,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.y, z: self.0.x, w: self.0.x }
+            Vec4 { x: self.y, y: self.y, z: self.x, w: self.x }
         }
     }
     #[inline]
@@ -584,7 +584,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.y, z: self.0.x, w: self.0.y }
+            Vec4 { x: self.y, y: self.y, z: self.x, w: self.y }
         }
     }
     #[inline]
@@ -596,7 +596,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.y, z: self.0.x, w: self.0.z }
+            Vec4 { x: self.y, y: self.y, z: self.x, w: self.z }
         }
     }
     #[inline]
@@ -608,7 +608,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.y, z: self.0.y, w: self.0.x }
+            Vec4 { x: self.y, y: self.y, z: self.y, w: self.x }
         }
     }
     #[inline]
@@ -620,7 +620,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.y, z: self.0.y, w: self.0.y }
+            Vec4 { x: self.y, y: self.y, z: self.y, w: self.y }
         }
     }
     #[inline]
@@ -632,7 +632,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.y, z: self.0.y, w: self.0.z }
+            Vec4 { x: self.y, y: self.y, z: self.y, w: self.z }
         }
     }
     #[inline]
@@ -644,7 +644,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.y, z: self.0.z, w: self.0.x }
+            Vec4 { x: self.y, y: self.y, z: self.z, w: self.x }
         }
     }
     #[inline]
@@ -656,7 +656,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.y, z: self.0.z, w: self.0.y }
+            Vec4 { x: self.y, y: self.y, z: self.z, w: self.y }
         }
     }
     #[inline]
@@ -668,7 +668,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.y, z: self.0.z, w: self.0.z }
+            Vec4 { x: self.y, y: self.y, z: self.z, w: self.z }
         }
     }
     #[inline]
@@ -680,7 +680,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.z, z: self.0.x, w: self.0.x }
+            Vec4 { x: self.y, y: self.z, z: self.x, w: self.x }
         }
     }
     #[inline]
@@ -692,7 +692,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.z, z: self.0.x, w: self.0.y }
+            Vec4 { x: self.y, y: self.z, z: self.x, w: self.y }
         }
     }
     #[inline]
@@ -704,7 +704,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.z, z: self.0.x, w: self.0.z }
+            Vec4 { x: self.y, y: self.z, z: self.x, w: self.z }
         }
     }
     #[inline]
@@ -716,7 +716,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.z, z: self.0.y, w: self.0.x }
+            Vec4 { x: self.y, y: self.z, z: self.y, w: self.x }
         }
     }
     #[inline]
@@ -728,7 +728,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.z, z: self.0.y, w: self.0.y }
+            Vec4 { x: self.y, y: self.z, z: self.y, w: self.y }
         }
     }
     #[inline]
@@ -740,7 +740,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.z, z: self.0.y, w: self.0.z }
+            Vec4 { x: self.y, y: self.z, z: self.y, w: self.z }
         }
     }
     #[inline]
@@ -752,7 +752,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.z, z: self.0.z, w: self.0.x }
+            Vec4 { x: self.y, y: self.z, z: self.z, w: self.x }
         }
     }
     #[inline]
@@ -764,7 +764,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.z, z: self.0.z, w: self.0.y }
+            Vec4 { x: self.y, y: self.z, z: self.z, w: self.y }
         }
     }
     #[inline]
@@ -776,7 +776,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.y, y: self.0.z, z: self.0.z, w: self.0.z }
+            Vec4 { x: self.y, y: self.z, z: self.z, w: self.z }
         }
     }
     #[inline]
@@ -788,7 +788,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.x, z: self.0.x, w: self.0.x }
+            Vec4 { x: self.z, y: self.x, z: self.x, w: self.x }
         }
     }
     #[inline]
@@ -800,7 +800,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.x, z: self.0.x, w: self.0.y }
+            Vec4 { x: self.z, y: self.x, z: self.x, w: self.y }
         }
     }
     #[inline]
@@ -812,7 +812,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.x, z: self.0.x, w: self.0.z }
+            Vec4 { x: self.z, y: self.x, z: self.x, w: self.z }
         }
     }
     #[inline]
@@ -824,7 +824,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.x, z: self.0.y, w: self.0.x }
+            Vec4 { x: self.z, y: self.x, z: self.y, w: self.x }
         }
     }
     #[inline]
@@ -836,7 +836,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.x, z: self.0.y, w: self.0.y }
+            Vec4 { x: self.z, y: self.x, z: self.y, w: self.y }
         }
     }
     #[inline]
@@ -848,7 +848,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.x, z: self.0.y, w: self.0.z }
+            Vec4 { x: self.z, y: self.x, z: self.y, w: self.z }
         }
     }
     #[inline]
@@ -860,7 +860,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.x, z: self.0.z, w: self.0.x }
+            Vec4 { x: self.z, y: self.x, z: self.z, w: self.x }
         }
     }
     #[inline]
@@ -872,7 +872,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.x, z: self.0.z, w: self.0.y }
+            Vec4 { x: self.z, y: self.x, z: self.z, w: self.y }
         }
     }
     #[inline]
@@ -884,7 +884,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.x, z: self.0.z, w: self.0.z }
+            Vec4 { x: self.z, y: self.x, z: self.z, w: self.z }
         }
     }
     #[inline]
@@ -896,7 +896,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.y, z: self.0.x, w: self.0.x }
+            Vec4 { x: self.z, y: self.y, z: self.x, w: self.x }
         }
     }
     #[inline]
@@ -908,7 +908,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.y, z: self.0.x, w: self.0.y }
+            Vec4 { x: self.z, y: self.y, z: self.x, w: self.y }
         }
     }
     #[inline]
@@ -920,7 +920,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.y, z: self.0.x, w: self.0.z }
+            Vec4 { x: self.z, y: self.y, z: self.x, w: self.z }
         }
     }
     #[inline]
@@ -932,7 +932,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.y, z: self.0.y, w: self.0.x }
+            Vec4 { x: self.z, y: self.y, z: self.y, w: self.x }
         }
     }
     #[inline]
@@ -944,7 +944,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.y, z: self.0.y, w: self.0.y }
+            Vec4 { x: self.z, y: self.y, z: self.y, w: self.y }
         }
     }
     #[inline]
@@ -956,7 +956,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.y, z: self.0.y, w: self.0.z }
+            Vec4 { x: self.z, y: self.y, z: self.y, w: self.z }
         }
     }
     #[inline]
@@ -968,7 +968,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.y, z: self.0.z, w: self.0.x }
+            Vec4 { x: self.z, y: self.y, z: self.z, w: self.x }
         }
     }
     #[inline]
@@ -980,7 +980,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.y, z: self.0.z, w: self.0.y }
+            Vec4 { x: self.z, y: self.y, z: self.z, w: self.y }
         }
     }
     #[inline]
@@ -992,7 +992,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.y, z: self.0.z, w: self.0.z }
+            Vec4 { x: self.z, y: self.y, z: self.z, w: self.z }
         }
     }
     #[inline]
@@ -1004,7 +1004,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.z, z: self.0.x, w: self.0.x }
+            Vec4 { x: self.z, y: self.z, z: self.x, w: self.x }
         }
     }
     #[inline]
@@ -1016,7 +1016,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.z, z: self.0.x, w: self.0.y }
+            Vec4 { x: self.z, y: self.z, z: self.x, w: self.y }
         }
     }
     #[inline]
@@ -1028,7 +1028,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.z, z: self.0.x, w: self.0.z }
+            Vec4 { x: self.z, y: self.z, z: self.x, w: self.z }
         }
     }
     #[inline]
@@ -1040,7 +1040,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.z, z: self.0.y, w: self.0.x }
+            Vec4 { x: self.z, y: self.z, z: self.y, w: self.x }
         }
     }
     #[inline]
@@ -1052,7 +1052,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.z, z: self.0.y, w: self.0.y }
+            Vec4 { x: self.z, y: self.z, z: self.y, w: self.y }
         }
     }
     #[inline]
@@ -1064,7 +1064,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.z, z: self.0.y, w: self.0.z }
+            Vec4 { x: self.z, y: self.z, z: self.y, w: self.z }
         }
     }
     #[inline]
@@ -1076,7 +1076,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.z, z: self.0.z, w: self.0.x }
+            Vec4 { x: self.z, y: self.z, z: self.z, w: self.x }
         }
     }
     #[inline]
@@ -1088,7 +1088,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.z, z: self.0.z, w: self.0.y }
+            Vec4 { x: self.z, y: self.z, z: self.z, w: self.y }
         }
     }
     #[inline]
@@ -1100,7 +1100,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec4 { x: self.0.z, y: self.0.z, z: self.0.z, w: self.0.z }
+            Vec4 { x: self.z, y: self.z, z: self.z, w: self.z }
         }
     }
     #[inline]
@@ -1112,7 +1112,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.x, y: self.0.x, z: self.0.x })
+            Vec3A { x: self.x, y: self.x, z: self.x }
         }
     }
     #[inline]
@@ -1124,7 +1124,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.x, y: self.0.x, z: self.0.y })
+            Vec3A { x: self.x, y: self.x, z: self.y }
         }
     }
     #[inline]
@@ -1136,7 +1136,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.x, y: self.0.x, z: self.0.z })
+            Vec3A { x: self.x, y: self.x, z: self.z }
         }
     }
     #[inline]
@@ -1148,7 +1148,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.x, y: self.0.y, z: self.0.x })
+            Vec3A { x: self.x, y: self.y, z: self.x }
         }
     }
     #[inline]
@@ -1160,7 +1160,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.x, y: self.0.y, z: self.0.y })
+            Vec3A { x: self.x, y: self.y, z: self.y }
         }
     }
     #[inline]
@@ -1172,7 +1172,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.x, y: self.0.z, z: self.0.x })
+            Vec3A { x: self.x, y: self.z, z: self.x }
         }
     }
     #[inline]
@@ -1184,7 +1184,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.x, y: self.0.z, z: self.0.y })
+            Vec3A { x: self.x, y: self.z, z: self.y }
         }
     }
     #[inline]
@@ -1196,7 +1196,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.x, y: self.0.z, z: self.0.z })
+            Vec3A { x: self.x, y: self.z, z: self.z }
         }
     }
     #[inline]
@@ -1208,7 +1208,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.y, y: self.0.x, z: self.0.x })
+            Vec3A { x: self.y, y: self.x, z: self.x }
         }
     }
     #[inline]
@@ -1220,7 +1220,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.y, y: self.0.x, z: self.0.y })
+            Vec3A { x: self.y, y: self.x, z: self.y }
         }
     }
     #[inline]
@@ -1232,7 +1232,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.y, y: self.0.x, z: self.0.z })
+            Vec3A { x: self.y, y: self.x, z: self.z }
         }
     }
     #[inline]
@@ -1244,7 +1244,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.y, y: self.0.y, z: self.0.x })
+            Vec3A { x: self.y, y: self.y, z: self.x }
         }
     }
     #[inline]
@@ -1256,7 +1256,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.y, y: self.0.y, z: self.0.y })
+            Vec3A { x: self.y, y: self.y, z: self.y }
         }
     }
     #[inline]
@@ -1268,7 +1268,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.y, y: self.0.y, z: self.0.z })
+            Vec3A { x: self.y, y: self.y, z: self.z }
         }
     }
     #[inline]
@@ -1280,7 +1280,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.y, y: self.0.z, z: self.0.x })
+            Vec3A { x: self.y, y: self.z, z: self.x }
         }
     }
     #[inline]
@@ -1292,7 +1292,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.y, y: self.0.z, z: self.0.y })
+            Vec3A { x: self.y, y: self.z, z: self.y }
         }
     }
     #[inline]
@@ -1304,7 +1304,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.y, y: self.0.z, z: self.0.z })
+            Vec3A { x: self.y, y: self.z, z: self.z }
         }
     }
     #[inline]
@@ -1316,7 +1316,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.z, y: self.0.x, z: self.0.x })
+            Vec3A { x: self.z, y: self.x, z: self.x }
         }
     }
     #[inline]
@@ -1328,7 +1328,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.z, y: self.0.x, z: self.0.y })
+            Vec3A { x: self.z, y: self.x, z: self.y }
         }
     }
     #[inline]
@@ -1340,7 +1340,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.z, y: self.0.x, z: self.0.z })
+            Vec3A { x: self.z, y: self.x, z: self.z }
         }
     }
     #[inline]
@@ -1352,7 +1352,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.z, y: self.0.y, z: self.0.x })
+            Vec3A { x: self.z, y: self.y, z: self.x }
         }
     }
     #[inline]
@@ -1364,7 +1364,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.z, y: self.0.y, z: self.0.y })
+            Vec3A { x: self.z, y: self.y, z: self.y }
         }
     }
     #[inline]
@@ -1376,7 +1376,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.z, y: self.0.y, z: self.0.z })
+            Vec3A { x: self.z, y: self.y, z: self.z }
         }
     }
     #[inline]
@@ -1388,7 +1388,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.z, y: self.0.z, z: self.0.x })
+            Vec3A { x: self.z, y: self.z, z: self.x }
         }
     }
     #[inline]
@@ -1400,7 +1400,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.z, y: self.0.z, z: self.0.y })
+            Vec3A { x: self.z, y: self.z, z: self.y }
         }
     }
     #[inline]
@@ -1412,7 +1412,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec3A(Vec3 { x: self.0.z, y: self.0.z, z: self.0.z })
+            Vec3A { x: self.z, y: self.z, z: self.z }
         }
     }
     #[inline]
@@ -1424,7 +1424,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec2 { x: self.0.x, y: self.0.x }
+            Vec2 { x: self.x, y: self.x }
         }
     }
     #[inline]
@@ -1436,7 +1436,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec2 { x: self.0.x, y: self.0.y }
+            Vec2 { x: self.x, y: self.y }
         }
     }
     #[inline]
@@ -1448,7 +1448,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec2 { x: self.0.x, y: self.0.z }
+            Vec2 { x: self.x, y: self.z }
         }
     }
     #[inline]
@@ -1460,7 +1460,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec2 { x: self.0.y, y: self.0.x }
+            Vec2 { x: self.y, y: self.x }
         }
     }
     #[inline]
@@ -1472,7 +1472,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec2 { x: self.0.y, y: self.0.y }
+            Vec2 { x: self.y, y: self.y }
         }
     }
     #[inline]
@@ -1484,7 +1484,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec2 { x: self.0.y, y: self.0.z }
+            Vec2 { x: self.y, y: self.z }
         }
     }
     #[inline]
@@ -1496,7 +1496,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec2 { x: self.0.z, y: self.0.x }
+            Vec2 { x: self.z, y: self.x }
         }
     }
     #[inline]
@@ -1508,7 +1508,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec2 { x: self.0.z, y: self.0.y }
+            Vec2 { x: self.z, y: self.y }
         }
     }
     #[inline]
@@ -1520,7 +1520,7 @@ impl Vec3ASwizzles for Vec3A {
 
         #[cfg(vec3a_f32)]
         {
-            Vec2 { x: self.0.z, y: self.0.z }
+            Vec2 { x: self.z, y: self.z }
         }
     }
 }

--- a/swizzlegen/src/main.rs
+++ b/swizzlegen/src/main.rs
@@ -267,7 +267,7 @@ impl Vec3ASwizzles for Vec3A {{"#
 
         #[cfg(vec3a_f32)]
         {{
-            Vec4 {{ x: self.0.{}, y: self.0.{}, z: self.0.{}, w: self.0.{} }}
+            Vec4 {{ x: self.{}, y: self.{}, z: self.{}, w: self.{} }}
         }}
     }}"#,
                 E[e0], E[e1], E[e2], E[e3], B[e3], B[e2], B[e1], B[e0], E[e0], E[e1], E[e2], E[e3],
@@ -286,7 +286,7 @@ impl Vec3ASwizzles for Vec3A {{"#
 
         #[cfg(vec3a_f32)]
         {{
-            Vec3A(Vec3 {{ x: self.0.{}, y: self.0.{}, z: self.0.{} }})
+            Vec3A {{ x: self.{}, y: self.{}, z: self.{} }}
         }}
     }}"#,
                 E[e0], E[e1], E[e2], B[e2], B[e1], B[e0], E[e0], E[e1], E[e2]
@@ -305,7 +305,7 @@ impl Vec3ASwizzles for Vec3A {{"#
 
         #[cfg(vec3a_f32)]
         {{
-            Vec2 {{ x: self.0.{}, y: self.0.{} }}
+            Vec2 {{ x: self.{}, y: self.{} }}
         }}
     }}"#,
                 E[e0], E[e1], B[e1], B[e0], E[e0], E[e1]


### PR DESCRIPTION
Instead of forwarding calls to Vec3 and having Vec3A wrap Vec3, this implements all the functions in Vec3A manually. This is required for SPRIR-V support because rust can't have repr(simd) on a type that isn't a collection of it's basic types.

This fixes the issue we found in #85 where Vec3A would accidentally not get the `repr(simd)` applied to it, because it only got applied to the documentation type and not to the actual type we're using.