### PR TITLE
Add From<(VecN-1, f32)> for VecN

### DIFF
--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -756,3 +756,13 @@ impl<'a> Product<&'a Self> for Vec3 {
         iter.fold(ONE, |a, &b| Self::mul(a, b))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Vec2, vec3};
+    
+    #[test]
+    fn from_vec2() {
+        assert_eq!(vec3(1.0, 2.0, 3.0), (Vec2::new(1.0, 2.0), 3.0).into());
+    }
+}

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -676,6 +676,13 @@ impl From<(f32, f32, f32)> for Vec3 {
     }
 }
 
+impl From<(Vec2, f32)> for Vec3 {
+    #[inline]
+    fn from((v, z): (Vec2, f32)) -> Self {
+        Self::new(v.x, v.y, z)
+    }
+}
+
 impl From<Vec3> for (f32, f32, f32) {
     #[inline]
     fn from(v: Vec3) -> Self {

--- a/src/f32/vec4.rs
+++ b/src/f32/vec4.rs
@@ -1302,3 +1302,13 @@ fn test_vec4_private() {
         vec4(-0.5, 1.0, -5.0, -1.0)
     );
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{Vec3, vec4};
+    
+    #[test]
+    fn from_vec3() {
+        assert_eq!(vec4(1.0, 2.0, 3.0, 4.0), (Vec3::new(1.0, 2.0, 3.0), 4.0).into());
+    }
+}

--- a/src/f32/vec4.rs
+++ b/src/f32/vec4.rs
@@ -1131,6 +1131,13 @@ impl From<(f32, f32, f32, f32)> for Vec4 {
     }
 }
 
+impl From<(Vec3, f32)> for Vec4 {
+    #[inline]
+    fn from((v, w): (Vec3, f32)) -> Self {
+        Self::new(v.x, v.y, v.z, w)
+    }
+}
+
 impl From<Vec4> for (f32, f32, f32, f32) {
     #[inline]
     fn from(v: Vec4) -> Self {


### PR DESCRIPTION
This PR adds some convenience `From` impls that allow you concat a tuple of a vector with a f32 into the next biggest vector similar to GLSL's initialisers such as `vec4(vec3, w)` without having to write out every coordinate.

```rust
let v2 = Vec2::from((1.0, 2.0));
let v3 = Vec3::from((v2, 3.0));
let v4 = Vec4::from((v3, 4.0));
```