### PR TITLE
Add Vec2::X Vec4::W etc as shorter versions of unit_x() et al

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
 ## [Unreleased]
+### Added
+* Added `Vec2::X`, `Vec4::W` etc as a shorter versions of `unit_x()` and friends.
 
 ### Added
 

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -9,6 +9,12 @@ use std::iter::{Product, Sum};
 
 macro_rules! impl_vec2_common_methods {
     ($t:ty, $vec2:ident, $vec3:ident, $mask:ident, $inner:ident) => {
+        /// `[1, 0]`: a unit-length vector pointing along the positive X axis.
+        pub const X: Self = Self($inner::UNIT_X);
+
+        /// `[0, 1]`: a unit-length vector pointing along the positive Y axis.
+        pub const Y: Self = Self($inner::UNIT_Y);
+
         /// Creates a new vector.
         #[inline(always)]
         pub fn new(x: $t, y: $t) -> $vec2 {

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -24,6 +24,15 @@ use std::iter::{Product, Sum};
 
 macro_rules! impl_vec3_common_methods {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident, $mask:ident, $inner:ident) => {
+        /// `[1, 0, 0]`: a unit-length vector pointing along the positive X axis.
+        pub const X: Self = Self(Vector3Const::UNIT_X);
+
+        /// `[0, 1, 0]`: a unit-length vector pointing along the positive Y axis.
+        pub const Y: Self = Self(Vector3Const::UNIT_Y);
+
+        /// `[0, 0, 1]`: a unit-length vector pointing along the positive Z axis.
+        pub const Z: Self = Self(Vector3Const::UNIT_Z);
+
         /// Creates a new 3D vector.
         #[inline(always)]
         pub fn new(x: $t, y: $t, z: $t) -> Self {

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -27,6 +27,18 @@ use core::{cmp::Ordering, f32};
 
 macro_rules! impl_vec4_common_methods {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident, $mask:ident, $inner:ident) => {
+        /// `[1, 0, 0, 0]`: a unit-length vector pointing along the positive X axis.
+        pub const X: Self = Self(Vector4Const::UNIT_X);
+
+        /// `[0, 1, 0, 0]`: a unit-length vector pointing along the positive Y axis.
+        pub const Y: Self = Self(Vector4Const::UNIT_Y);
+
+        /// `[0, 0, 1, 0]`: a unit-length vector pointing along the positive Z axis.
+        pub const Z: Self = Self(Vector4Const::UNIT_Z);
+
+        /// `[0, 0, 0, 1]`: a unit-length vector pointing along the positive W axis.
+        pub const W: Self = Self(Vector4Const::UNIT_W);
+
         /// Creates a new 4D vector.
         #[inline(always)]
         pub fn new(x: $t, y: $t, z: $t, w: $t) -> Self {

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -412,6 +412,12 @@ macro_rules! impl_vec2_float_tests {
         use core::$t::NEG_INFINITY;
 
         #[test]
+        fn test_vec2_consts() {
+            assert_eq!($vec2::X, $new(1 as $t, 0 as $t));
+            assert_eq!($vec2::Y, $new(0 as $t, 1 as $t));
+        }
+
+        #[test]
         fn test_length() {
             let x = $new(1.0, 0.0);
             let y = $new(0.0, 1.0);

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -457,6 +457,13 @@ macro_rules! impl_vec3_float_tests {
         use core::$t::NEG_INFINITY;
 
         #[test]
+        fn test_vec3_consts() {
+            assert_eq!($vec3::X, $new(1 as $t, 0 as $t, 0 as $t));
+            assert_eq!($vec3::Y, $new(0 as $t, 1 as $t, 0 as $t));
+            assert_eq!($vec3::Z, $new(0 as $t, 0 as $t, 1 as $t));
+        }
+
+        #[test]
         fn test_funcs() {
             let x = $new(1.0, 0.0, 0.0);
             let y = $new(0.0, 1.0, 0.0);

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -10,6 +10,14 @@ macro_rules! impl_vec4_tests {
         }
 
         #[test]
+        fn test_vec4_consts() {
+            assert_eq!($vec4::X, $new(1 as $t, 0 as $t, 0 as $t, 0 as $t));
+            assert_eq!($vec4::Y, $new(0 as $t, 1 as $t, 0 as $t, 0 as $t));
+            assert_eq!($vec4::Z, $new(0 as $t, 0 as $t, 1 as $t, 0 as $t));
+            assert_eq!($vec4::W, $new(0 as $t, 0 as $t, 0 as $t, 1 as $t));
+        }
+
+        #[test]
         fn test_new() {
             let v = $new(1 as $t, 2 as $t, 3 as $t, 4 as $t);
 


### PR DESCRIPTION
An ergonomic win:

Before: `pos + 5.0 * Vec3::unit_y()`
After: `pos + 5.0 * Vec3::Y`

This is very similar to how one in math uses `Y` as the name of the basis vector, so that `5 * Y` means "A vector in the Y direction of length 5".

Sorry for not creating an issue and jumping straight to a PR - it was such a simple thing to add so I thought it would just be easier to implement and then discuss it in the PR.

If this is appreciated we could also consider adding `Vec3::ZERO` and `Vec3::ONE`, though it is less of a win since it is not that much shorter. We could also consider deprecating `unit_x` etc in favor of these new constants.