### PR TITLE
Add ZERO, ONE and IDENTITY constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ The format is based on [Keep a Changelog], and this project adheres to
 ## [Unreleased]
 ### Added
 * Added `Vec2::X`, `Vec4::W` etc as a shorter versions of `unit_x()` and friends.
-
-### Added
-
+* Added `Vec2::ONE`, `Vec3::ONE` and `Vec4::ONE`.
+* Added `IDENTITY` constants for `Mat2`, `Mat3`, `Mat4` and `Quat`.
+* Added `ZERO` constant for vectors and matrices.
 * Added `clamp_length()`, `clamp_length_max()`, and `clamp_length_min` methods for `Vec2`, `Vec3`,
   and `Vec4` for `f32` and `f64`.
+
+### Changed
+* Deprecated `::unit_x/y/z()`, `::zero()`, `::one()`, `::identity()` functions in favor of constants.
 
 ## [0.12.0] - 2021-01-15
 

--- a/benches/vec2.rs
+++ b/benches/vec2.rs
@@ -13,7 +13,7 @@ euler!(
     "vec2 euler",
     ty => Vec2,
     storage => Vec2,
-    zero => Vec2::zero(),
+    zero => Vec2::ZERO,
     rand => random_vec2);
 
 bench_binop!(

--- a/benches/vec3.rs
+++ b/benches/vec3.rs
@@ -50,7 +50,7 @@ bench_binop!(
 
 #[inline]
 fn vec3_to_rgb_op(v: Vec3) -> u32 {
-    let (red, green, blue) = (v.min(Vec3::one()).max(Vec3::ZERO) * 255.0).into();
+    let (red, green, blue) = (v.min(Vec3::ONE).max(Vec3::ZERO) * 255.0).into();
     ((red as u32) << 16 | (green as u32) << 8 | (blue as u32)).into()
 }
 

--- a/benches/vec3.rs
+++ b/benches/vec3.rs
@@ -50,7 +50,7 @@ bench_binop!(
 
 #[inline]
 fn vec3_to_rgb_op(v: Vec3) -> u32 {
-    let (red, green, blue) = (v.min(Vec3::one()).max(Vec3::zero()) * 255.0).into();
+    let (red, green, blue) = (v.min(Vec3::one()).max(Vec3::ZERO) * 255.0).into();
     ((red as u32) << 16 | (green as u32) << 8 | (blue as u32)).into()
 }
 
@@ -97,7 +97,7 @@ op => vec3_into_tuple,
 from => random_vec3
 );
 
-euler!(vec3_euler, "vec3 euler", ty => Vec3, storage => Vec3, zero => Vec3::zero(), rand => random_vec3);
+euler!(vec3_euler, "vec3 euler", ty => Vec3, storage => Vec3, zero => Vec3::ZERO, rand => random_vec3);
 
 bench_binop!(
     vec3_angle_between,

--- a/benches/vec3a.rs
+++ b/benches/vec3a.rs
@@ -26,7 +26,7 @@ bench_binop!(
 
 #[inline]
 fn vec3a_to_rgb_op(v: Vec3A) -> u32 {
-    let (red, green, blue) = (v.min(Vec3A::one()).max(Vec3A::zero()) * 255.0).into();
+    let (red, green, blue) = (v.min(Vec3A::one()).max(Vec3A::ZERO) * 255.0).into();
     ((red as u32) << 16 | (green as u32) << 8 | (blue as u32)).into()
 }
 
@@ -85,7 +85,7 @@ op => vec3a_into_tuple,
 from => random_vec3a
 );
 
-euler!(vec3a_euler, "vec3a euler", ty => Vec3A, storage => Vec3A, zero => Vec3A::zero(), rand => random_vec3a);
+euler!(vec3a_euler, "vec3a euler", ty => Vec3A, storage => Vec3A, zero => Vec3A::ZERO, rand => random_vec3a);
 
 bench_binop!(
     vec3a_angle_between,

--- a/benches/vec3a.rs
+++ b/benches/vec3a.rs
@@ -26,7 +26,7 @@ bench_binop!(
 
 #[inline]
 fn vec3a_to_rgb_op(v: Vec3A) -> u32 {
-    let (red, green, blue) = (v.min(Vec3A::one()).max(Vec3A::ZERO) * 255.0).into();
+    let (red, green, blue) = (v.min(Vec3A::ONE).max(Vec3A::ZERO) * 255.0).into();
     ((red as u32) << 16 | (green as u32) << 8 | (blue as u32)).into()
 }
 

--- a/src/core/scalar/matrix.rs
+++ b/src/core/scalar/matrix.rs
@@ -17,8 +17,8 @@ impl<T: NumEx> MatrixConst for Vector2x2<XY<T>> {
         y_axis: XY::ZERO,
     };
     const IDENTITY: Self = Self {
-        x_axis: XY::UNIT_X,
-        y_axis: XY::UNIT_Y,
+        x_axis: XY::X,
+        y_axis: XY::Y,
     };
 }
 
@@ -103,9 +103,9 @@ impl<T: NumEx> MatrixConst for Vector3x3<XYZ<T>> {
         z_axis: XYZ::ZERO,
     };
     const IDENTITY: Self = Self {
-        x_axis: XYZ::UNIT_X,
-        y_axis: XYZ::UNIT_Y,
-        z_axis: XYZ::UNIT_Z,
+        x_axis: XYZ::X,
+        y_axis: XYZ::Y,
+        z_axis: XYZ::Z,
     };
 }
 
@@ -234,10 +234,10 @@ impl<T: NumEx> MatrixConst for Vector4x4<XYZW<T>> {
         w_axis: XYZW::ZERO,
     };
     const IDENTITY: Self = Self {
-        x_axis: XYZW::UNIT_X,
-        y_axis: XYZW::UNIT_Y,
-        z_axis: XYZW::UNIT_Z,
-        w_axis: XYZW::UNIT_W,
+        x_axis: XYZW::X,
+        y_axis: XYZW::Y,
+        z_axis: XYZW::Z,
+        w_axis: XYZW::W,
     };
 }
 

--- a/src/core/scalar/vector.rs
+++ b/src/core/scalar/vector.rs
@@ -15,11 +15,11 @@ impl<T: NumEx> VectorConst for XY<T> {
 }
 
 impl<T: NumEx> Vector2Const for XY<T> {
-    const UNIT_X: Self = Self {
+    const X: Self = Self {
         x: <T as NumConstEx>::ONE,
         y: <T as NumConstEx>::ZERO,
     };
-    const UNIT_Y: Self = Self {
+    const Y: Self = Self {
         x: <T as NumConstEx>::ZERO,
         y: <T as NumConstEx>::ONE,
     };
@@ -39,17 +39,17 @@ impl<T: NumEx> VectorConst for XYZ<T> {
 }
 
 impl<T: NumEx> Vector3Const for XYZ<T> {
-    const UNIT_X: Self = Self {
+    const X: Self = Self {
         x: <T as NumConstEx>::ONE,
         y: <T as NumConstEx>::ZERO,
         z: <T as NumConstEx>::ZERO,
     };
-    const UNIT_Y: Self = Self {
+    const Y: Self = Self {
         x: <T as NumConstEx>::ZERO,
         y: <T as NumConstEx>::ONE,
         z: <T as NumConstEx>::ZERO,
     };
-    const UNIT_Z: Self = Self {
+    const Z: Self = Self {
         x: <T as NumConstEx>::ZERO,
         y: <T as NumConstEx>::ZERO,
         z: <T as NumConstEx>::ONE,
@@ -71,25 +71,25 @@ impl<T: NumEx> VectorConst for XYZW<T> {
     };
 }
 impl<T: NumEx> Vector4Const for XYZW<T> {
-    const UNIT_X: Self = Self {
+    const X: Self = Self {
         x: <T as NumConstEx>::ONE,
         y: <T as NumConstEx>::ZERO,
         z: <T as NumConstEx>::ZERO,
         w: <T as NumConstEx>::ZERO,
     };
-    const UNIT_Y: Self = Self {
+    const Y: Self = Self {
         x: <T as NumConstEx>::ZERO,
         y: <T as NumConstEx>::ONE,
         z: <T as NumConstEx>::ZERO,
         w: <T as NumConstEx>::ZERO,
     };
-    const UNIT_Z: Self = Self {
+    const Z: Self = Self {
         x: <T as NumConstEx>::ZERO,
         y: <T as NumConstEx>::ZERO,
         z: <T as NumConstEx>::ONE,
         w: <T as NumConstEx>::ZERO,
     };
-    const UNIT_W: Self = Self {
+    const W: Self = Self {
         x: <T as NumConstEx>::ZERO,
         y: <T as NumConstEx>::ZERO,
         z: <T as NumConstEx>::ZERO,

--- a/src/core/sse2/matrix.rs
+++ b/src/core/sse2/matrix.rs
@@ -140,10 +140,10 @@ impl MatrixConst for Vector4x4<__m128> {
         w_axis: __m128::ZERO,
     };
     const IDENTITY: Vector4x4<__m128> = Vector4x4 {
-        x_axis: __m128::UNIT_X,
-        y_axis: __m128::UNIT_Y,
-        z_axis: __m128::UNIT_Z,
-        w_axis: __m128::UNIT_W,
+        x_axis: __m128::X,
+        y_axis: __m128::Y,
+        z_axis: __m128::Z,
+        w_axis: __m128::W,
     };
 }
 

--- a/src/core/sse2/vector.rs
+++ b/src/core/sse2/vector.rs
@@ -162,16 +162,16 @@ impl VectorConst for __m128 {
 }
 
 impl Vector3Const for __m128 {
-    const UNIT_X: __m128 = const_m128!([1.0, 0.0, 0.0, 0.0]);
-    const UNIT_Y: __m128 = const_m128!([0.0, 1.0, 0.0, 0.0]);
-    const UNIT_Z: __m128 = const_m128!([0.0, 0.0, 1.0, 0.0]);
+    const X: __m128 = const_m128!([1.0, 0.0, 0.0, 0.0]);
+    const Y: __m128 = const_m128!([0.0, 1.0, 0.0, 0.0]);
+    const Z: __m128 = const_m128!([0.0, 0.0, 1.0, 0.0]);
 }
 
 impl Vector4Const for __m128 {
-    const UNIT_X: __m128 = const_m128!([1.0, 0.0, 0.0, 0.0]);
-    const UNIT_Y: __m128 = const_m128!([0.0, 1.0, 0.0, 0.0]);
-    const UNIT_Z: __m128 = const_m128!([0.0, 0.0, 1.0, 0.0]);
-    const UNIT_W: __m128 = const_m128!([0.0, 0.0, 0.0, 1.0]);
+    const X: __m128 = const_m128!([1.0, 0.0, 0.0, 0.0]);
+    const Y: __m128 = const_m128!([0.0, 1.0, 0.0, 0.0]);
+    const Z: __m128 = const_m128!([0.0, 0.0, 1.0, 0.0]);
+    const W: __m128 = const_m128!([0.0, 0.0, 0.0, 1.0]);
 }
 
 impl Vector<f32> for __m128 {

--- a/src/core/traits/matrix.rs
+++ b/src/core/traits/matrix.rs
@@ -387,16 +387,16 @@ pub trait Matrix4x4<T: NumEx, V4: Vector4<T>>: Matrix<T> {
             V4::new(scale.x, T::ZERO, T::ZERO, T::ZERO),
             V4::new(T::ZERO, scale.y, T::ZERO, T::ZERO),
             V4::new(T::ZERO, T::ZERO, scale.z, T::ZERO),
-            V4::UNIT_W,
+            V4::W,
         )
     }
 
     #[inline(always)]
     fn from_translation(translation: XYZ<T>) -> Self {
         Self::from_cols(
-            V4::UNIT_X,
-            V4::UNIT_Y,
-            V4::UNIT_Z,
+            V4::X,
+            V4::Y,
+            V4::Z,
             V4::new(translation.x, translation.y, translation.z, T::ONE),
         )
     }
@@ -500,7 +500,7 @@ pub trait FloatMatrix4x4<T: FloatEx, V4: FloatVector4<T> + Quaternion<T>>:
     fn from_quaternion(rotation: V4) -> Self {
         glam_assert!(rotation.is_normalized());
         let (x_axis, y_axis, z_axis) = Self::quaternion_to_axes(rotation);
-        Self::from_cols(x_axis, y_axis, z_axis, V4::UNIT_W)
+        Self::from_cols(x_axis, y_axis, z_axis, V4::W)
     }
 
     fn to_scale_quaternion_translation(&self) -> (XYZ<T>, V4, XYZ<T>) {
@@ -576,7 +576,7 @@ pub trait FloatMatrix4x4<T: FloatEx, V4: FloatVector4<T> + Quaternion<T>>:
                 axis_sq.z * omc + cos,
                 T::ZERO,
             ),
-            V4::UNIT_W,
+            V4::W,
         )
     }
 
@@ -584,10 +584,10 @@ pub trait FloatMatrix4x4<T: FloatEx, V4: FloatVector4<T> + Quaternion<T>>:
     fn from_rotation_x(angle: T) -> Self {
         let (sina, cosa) = angle.sin_cos();
         Self::from_cols(
-            V4::UNIT_X,
+            V4::X,
             V4::new(T::ZERO, cosa, sina, T::ZERO),
             V4::new(T::ZERO, -sina, cosa, T::ZERO),
-            V4::UNIT_W,
+            V4::W,
         )
     }
 
@@ -596,9 +596,9 @@ pub trait FloatMatrix4x4<T: FloatEx, V4: FloatVector4<T> + Quaternion<T>>:
         let (sina, cosa) = angle.sin_cos();
         Self::from_cols(
             V4::new(cosa, T::ZERO, -sina, T::ZERO),
-            V4::UNIT_Y,
+            V4::Y,
             V4::new(sina, T::ZERO, cosa, T::ZERO),
-            V4::UNIT_W,
+            V4::W,
         )
     }
 
@@ -608,8 +608,8 @@ pub trait FloatMatrix4x4<T: FloatEx, V4: FloatVector4<T> + Quaternion<T>>:
         Self::from_cols(
             V4::new(cosa, sina, T::ZERO, T::ZERO),
             V4::new(-sina, cosa, T::ZERO, T::ZERO),
-            V4::UNIT_Z,
-            V4::UNIT_W,
+            V4::Z,
+            V4::W,
         )
     }
 

--- a/src/core/traits/quaternion.rs
+++ b/src/core/traits/quaternion.rs
@@ -125,7 +125,7 @@ pub trait Quaternion<T: FloatEx>: FloatVector4<T> {
         if scale_sq >= T::from_f32(1.0e-8 * 1.0e-8) {
             (XYZ { x, y, z }.mul_scalar(scale_sq.sqrt().recip()), angle)
         } else {
-            (Vector3Const::UNIT_X, angle)
+            (Vector3Const::X, angle)
         }
     }
 

--- a/src/core/traits/vector.rs
+++ b/src/core/traits/vector.rs
@@ -44,21 +44,21 @@ pub trait VectorConst {
 }
 
 pub trait Vector2Const: VectorConst {
-    const UNIT_X: Self;
-    const UNIT_Y: Self;
+    const X: Self;
+    const Y: Self;
 }
 
 pub trait Vector3Const: VectorConst {
-    const UNIT_X: Self;
-    const UNIT_Y: Self;
-    const UNIT_Z: Self;
+    const X: Self;
+    const Y: Self;
+    const Z: Self;
 }
 
 pub trait Vector4Const: VectorConst {
-    const UNIT_X: Self;
-    const UNIT_Y: Self;
-    const UNIT_Z: Self;
-    const UNIT_W: Self;
+    const X: Self;
+    const Y: Self;
+    const Z: Self;
+    const W: Self;
 }
 
 pub trait Vector<T>: Sized + Copy + Clone {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ meaning when transforming a vector with a matrix the matrix goes on the left.
 
 ```
 use glam::{Mat3, Vec3};
-let m = Mat3::identity();
+let m = Mat3::IDENTITY;
 let x = Vec3::X;
 let v = m * x;
 assert_eq!(v, x);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ meaning when transforming a vector with a matrix the matrix goes on the left.
 ```
 use glam::{Mat3, Vec3};
 let m = Mat3::identity();
-let x = Vec3::unit_x();
+let x = Vec3::X;
 let v = m * x;
 assert_eq!(v, x);
 ```

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -26,7 +26,7 @@ macro_rules! const_m128 {
 /// ```
 /// use glam::{const_vec2, Vec2};
 /// const ONE: Vec2 = const_vec2!([1.0; 2]);
-/// const UNIT_X: Vec2 = const_vec2!([1.0, 0.0]);
+/// const X: Vec2 = const_vec2!([1.0, 0.0]);
 /// ```
 #[macro_export]
 macro_rules! const_vec2 {
@@ -40,7 +40,7 @@ macro_rules! const_vec2 {
 /// ```
 /// use glam::{const_vec3, Vec3};
 /// const ONE: Vec3 = const_vec3!([1.0; 3]);
-/// const UNIT_X: Vec3 = const_vec3!([1.0, 0.0, 0.0]);
+/// const X: Vec3 = const_vec3!([1.0, 0.0, 0.0]);
 /// ```
 #[macro_export]
 macro_rules! const_vec3 {
@@ -54,7 +54,7 @@ macro_rules! const_vec3 {
 /// ```
 /// use glam::{const_vec3a, Vec3A};
 /// const ONE: Vec3A = const_vec3a!([1.0; 3]);
-/// const UNIT_X: Vec3A = const_vec3a!([1.0, 0.0, 0.0]);
+/// const X: Vec3A = const_vec3a!([1.0, 0.0, 0.0]);
 /// ```
 #[macro_export]
 macro_rules! const_vec3a {
@@ -73,7 +73,7 @@ macro_rules! const_vec3a {
 /// ```
 /// use glam::{const_vec4, Vec4};
 /// const ONE: Vec4 = const_vec4!([1.0; 4]);
-/// const UNIT_X: Vec4 = const_vec4!([1.0, 0.0, 0.0, 0.0]);
+/// const X: Vec4 = const_vec4!([1.0, 0.0, 0.0, 0.0]);
 /// ```
 #[macro_export]
 macro_rules! const_vec4 {
@@ -193,7 +193,7 @@ macro_rules! const_quat {
 /// ```
 /// use glam::{const_dvec2, DVec2};
 /// const ONE: DVec2 = const_dvec2!([1.0; 2]);
-/// const UNIT_X: DVec2 = const_dvec2!([1.0, 0.0]);
+/// const X: DVec2 = const_dvec2!([1.0, 0.0]);
 /// ```
 #[macro_export]
 macro_rules! const_dvec2 {
@@ -207,7 +207,7 @@ macro_rules! const_dvec2 {
 /// ```
 /// use glam::{const_dvec3, DVec3};
 /// const ONE: DVec3 = const_dvec3!([1.0; 3]);
-/// const UNIT_X: DVec3 = const_dvec3!([1.0, 0.0, 0.0]);
+/// const X: DVec3 = const_dvec3!([1.0, 0.0, 0.0]);
 /// ```
 #[macro_export]
 macro_rules! const_dvec3 {
@@ -221,7 +221,7 @@ macro_rules! const_dvec3 {
 /// ```
 /// use glam::{const_dvec4, DVec4};
 /// const ONE: DVec4 = const_dvec4!([1.0; 4]);
-/// const UNIT_X: DVec4 = const_dvec4!([1.0, 0.0, 0.0, 0.0]);
+/// const X: DVec4 = const_dvec4!([1.0, 0.0, 0.0, 0.0]);
 /// ```
 #[macro_export]
 macro_rules! const_dvec4 {
@@ -342,7 +342,7 @@ macro_rules! const_dquat {
 /// ```
 /// use glam::{const_ivec2, IVec2};
 /// const ONE: IVec2 = const_ivec2!([1; 2]);
-/// const UNIT_X: IVec2 = const_ivec2!([1, 0]);
+/// const X: IVec2 = const_ivec2!([1, 0]);
 /// ```
 #[macro_export]
 macro_rules! const_ivec2 {
@@ -356,7 +356,7 @@ macro_rules! const_ivec2 {
 /// ```
 /// use glam::{const_ivec3, IVec3};
 /// const ONE: IVec3 = const_ivec3!([1; 3]);
-/// const UNIT_X: IVec3 = const_ivec3!([1, 0, 0]);
+/// const X: IVec3 = const_ivec3!([1, 0, 0]);
 /// ```
 #[macro_export]
 macro_rules! const_ivec3 {
@@ -370,7 +370,7 @@ macro_rules! const_ivec3 {
 /// ```
 /// use glam::{const_ivec4, IVec4};
 /// const ONE: IVec4 = const_ivec4!([1; 4]);
-/// const UNIT_X: IVec4 = const_ivec4!([1, 0, 0, 0]);
+/// const X: IVec4 = const_ivec4!([1, 0, 0, 0]);
 /// ```
 #[macro_export]
 macro_rules! const_ivec4 {
@@ -384,7 +384,7 @@ macro_rules! const_ivec4 {
 /// ```
 /// use glam::{const_uvec2, UVec2};
 /// const ONE: UVec2 = const_uvec2!([1; 2]);
-/// const UNIT_X: UVec2 = const_uvec2!([1, 0]);
+/// const X: UVec2 = const_uvec2!([1, 0]);
 /// ```
 #[macro_export]
 macro_rules! const_uvec2 {
@@ -398,7 +398,7 @@ macro_rules! const_uvec2 {
 /// ```
 /// use glam::{const_uvec3, UVec3};
 /// const ONE: UVec3 = const_uvec3!([1; 3]);
-/// const UNIT_X: UVec3 = const_uvec3!([1, 0, 0]);
+/// const X: UVec3 = const_uvec3!([1, 0, 0]);
 /// ```
 #[macro_export]
 macro_rules! const_uvec3 {
@@ -412,7 +412,7 @@ macro_rules! const_uvec3 {
 /// ```
 /// use glam::{const_uvec4, UVec4};
 /// const ONE: UVec4 = const_uvec4!([1; 4]);
-/// const UNIT_X: UVec4 = const_uvec4!([1, 0, 0, 0]);
+/// const X: UVec4 = const_uvec4!([1, 0, 0, 0]);
 /// ```
 #[macro_export]
 macro_rules! const_uvec4 {

--- a/src/mat2.rs
+++ b/src/mat2.rs
@@ -28,6 +28,12 @@ use std::iter::{Product, Sum};
 
 macro_rules! impl_mat2_methods {
     ($t:ty, $vec2:ident, $inner:ident) => {
+        /// A 2x2 matrix with all elements set to `0.0`.
+        pub const ZERO: Self = Self($inner::ZERO);
+
+        /// A 2x2 identity matrix, where all diagonal elements are `1`, and all off-diagonal elements are `0`.
+        pub const IDENTITY: Self = Self($inner::IDENTITY);
+
         /// Creates a 2x2 matrix with all elements set to `0.0`.
         #[inline(always)]
         pub const fn zero() -> Self {

--- a/src/mat2.rs
+++ b/src/mat2.rs
@@ -334,7 +334,7 @@ macro_rules! impl_mat2_traits {
             where
                 I: Iterator<Item = &'a Self>,
             {
-                iter.fold(Self::zero(), |a, &b| Self::add(a, b))
+                iter.fold(Self::ZERO, |a, &b| Self::add(a, b))
             }
         }
 

--- a/src/mat2.rs
+++ b/src/mat2.rs
@@ -42,6 +42,7 @@ macro_rules! impl_mat2_methods {
         }
 
         /// Creates a 2x2 identity matrix.
+        #[deprecated = "use Mat2::IDENTITY instead"]
         #[inline(always)]
         pub const fn identity() -> Self {
             Self::IDENTITY

--- a/src/mat2.rs
+++ b/src/mat2.rs
@@ -35,15 +35,16 @@ macro_rules! impl_mat2_methods {
         pub const IDENTITY: Self = Self($inner::IDENTITY);
 
         /// Creates a 2x2 matrix with all elements set to `0.0`.
+        #[deprecated = "use Mat2::ZERO instead"]
         #[inline(always)]
         pub const fn zero() -> Self {
-            Self($inner::ZERO)
+            Self::ZERO
         }
 
         /// Creates a 2x2 identity matrix.
         #[inline(always)]
         pub const fn identity() -> Self {
-            Self($inner::IDENTITY)
+            Self::IDENTITY
         }
 
         /// Creates a 2x2 matrix from two column vectors.

--- a/src/mat2.rs
+++ b/src/mat2.rs
@@ -216,7 +216,7 @@ macro_rules! impl_mat2_traits {
         impl Default for $mat2 {
             #[inline(always)]
             fn default() -> Self {
-                Self::identity()
+                Self::IDENTITY
             }
         }
 
@@ -344,7 +344,7 @@ macro_rules! impl_mat2_traits {
             where
                 I: Iterator<Item = &'a Self>,
             {
-                iter.fold(Self::identity(), |a, &b| Self::mul(a, b))
+                iter.fold(Self::IDENTITY, |a, &b| Self::mul(a, b))
             }
         }
     };

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -29,6 +29,7 @@ macro_rules! impl_mat3_methods {
         }
 
         /// Creates a 3x3 identity matrix.
+        #[deprecated = "use Mat3::IDENTITY instead"]
         #[inline(always)]
         pub const fn identity() -> Self {
             Self::IDENTITY

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -399,7 +399,7 @@ macro_rules! impl_mat3_traits {
             where
                 I: Iterator<Item = &'a Self>,
             {
-                iter.fold($mat3::zero(), |a, &b| Self::add(a, b))
+                iter.fold($mat3::ZERO, |a, &b| Self::add(a, b))
             }
         }
 

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -279,7 +279,7 @@ macro_rules! impl_mat3_traits {
         impl Default for $mat3 {
             #[inline(always)]
             fn default() -> Self {
-                Self::identity()
+                Self::IDENTITY
             }
         }
 
@@ -409,7 +409,7 @@ macro_rules! impl_mat3_traits {
             where
                 I: Iterator<Item = &'a Self>,
             {
-                iter.fold($mat3::identity(), |a, &b| Self::mul(a, b))
+                iter.fold($mat3::IDENTITY, |a, &b| Self::mul(a, b))
             }
         }
     };

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -22,15 +22,16 @@ macro_rules! impl_mat3_methods {
         pub const IDENTITY: Self = Self($inner::IDENTITY);
 
         /// Creates a 3x3 matrix with all elements set to `0.0`.
+        #[deprecated = "use Mat3::ZERO instead"]
         #[inline(always)]
         pub const fn zero() -> Self {
-            Self($inner::ZERO)
+            Self::ZERO
         }
 
         /// Creates a 3x3 identity matrix.
         #[inline(always)]
         pub const fn identity() -> Self {
-            Self($inner::IDENTITY)
+            Self::IDENTITY
         }
 
         /// Creates a 3x3 matrix from three column vectors.

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -15,6 +15,12 @@ use std::iter::{Product, Sum};
 
 macro_rules! impl_mat3_methods {
     ($t:ty, $vec3: ident, $vec2:ident, $quat:ident, $inner:ident) => {
+        /// A 3x3 matrix with all elements set to `0.0`.
+        pub const ZERO: Self = Self($inner::ZERO);
+
+        /// A 3x3 identity matrix, where all diagonal elements are `1`, and all off-diagonal elements are `0`.
+        pub const IDENTITY: Self = Self($inner::IDENTITY);
+
         /// Creates a 3x3 matrix with all elements set to `0.0`.
         #[inline(always)]
         pub const fn zero() -> Self {

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -587,7 +587,7 @@ macro_rules! impl_mat4_traits {
             where
                 I: Iterator<Item = &'a Self>,
             {
-                iter.fold(Self::zero(), |a, &b| Self::add(a, b))
+                iter.fold(Self::ZERO, |a, &b| Self::add(a, b))
             }
         }
 

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -464,7 +464,7 @@ macro_rules! impl_mat4_traits {
         impl Default for $mat4 {
             #[inline(always)]
             fn default() -> Self {
-                Self::identity()
+                Self::IDENTITY
             }
         }
 
@@ -597,7 +597,7 @@ macro_rules! impl_mat4_traits {
             where
                 I: Iterator<Item = &'a Self>,
             {
-                iter.fold(Self::identity(), |a, &b| Self::mul(a, b))
+                iter.fold(Self::IDENTITY, |a, &b| Self::mul(a, b))
             }
         }
     };

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -39,15 +39,16 @@ macro_rules! impl_mat4_methods {
         pub const IDENTITY: Self = Self($inner::IDENTITY);
 
         /// Creates a 4x4 matrix with all elements set to `0.0`.
+        #[deprecated = "use Mat4::ZERO instead"]
         #[inline(always)]
         pub const fn zero() -> Self {
-            Self($inner::ZERO)
+            Self::ZERO
         }
 
         /// Creates a 4x4 identity matrix.
         #[inline(always)]
         pub const fn identity() -> Self {
-            Self($inner::IDENTITY)
+            Self::IDENTITY
         }
 
         /// Creates a 4x4 matrix from four column vectors.

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -46,6 +46,7 @@ macro_rules! impl_mat4_methods {
         }
 
         /// Creates a 4x4 identity matrix.
+        #[deprecated = "use Mat4::IDENTITY instead"]
         #[inline(always)]
         pub const fn identity() -> Self {
             Self::IDENTITY

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -32,6 +32,12 @@ use std::iter::{Product, Sum};
 
 macro_rules! impl_mat4_methods {
     ($t:ty, $vec4:ident, $vec3:ident, $quat:ident, $inner:ident) => {
+        /// A 4x4 matrix with all elements set to `0.0`.
+        pub const ZERO: Self = Self($inner::ZERO);
+
+        /// A 4x4 identity matrix, where all diagonal elements are `1`, and all off-diagonal elements are `0`.
+        pub const IDENTITY: Self = Self($inner::IDENTITY);
+
         /// Creates a 4x4 matrix with all elements set to `0.0`.
         #[inline(always)]
         pub const fn zero() -> Self {

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -368,7 +368,7 @@ macro_rules! impl_quat_traits {
         impl Default for $quat {
             #[inline]
             fn default() -> Self {
-                Self::identity()
+                Self::IDENTITY
             }
         }
 
@@ -482,7 +482,7 @@ macro_rules! impl_quat_traits {
             where
                 I: Iterator<Item = &'a Self>,
             {
-                iter.fold(Self::identity(), |a, &b| Self::mul(a, b))
+                iter.fold(Self::IDENTITY, |a, &b| Self::mul(a, b))
             }
         }
     };

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -30,6 +30,9 @@ use std::iter::{Product, Sum};
 
 macro_rules! impl_quat_methods {
     ($t:ty, $quat:ident, $vec3:ident, $mat3:ident, $mat4:ident, $inner:ident) => {
+        /// The identity quaternion. Corresponds to no rotation.
+        pub const IDENTITY: Self = Self($inner::W);
+
         /// Creates a new rotation quaternion.
         ///
         /// This should generally not be called manually unless you know what you are doing.
@@ -43,7 +46,7 @@ macro_rules! impl_quat_methods {
 
         #[inline(always)]
         pub const fn identity() -> Self {
-            Self($inner::W)
+            Self::IDENTITY
         }
 
         /// Creates a rotation quaternion from an unaligned slice.

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -44,6 +44,7 @@ macro_rules! impl_quat_methods {
             Self(Vector4::new(x, y, z, w))
         }
 
+        #[deprecated = "use Quat::IDENTITY instead"]
         #[inline(always)]
         pub const fn identity() -> Self {
             Self::IDENTITY

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -43,7 +43,7 @@ macro_rules! impl_quat_methods {
 
         #[inline(always)]
         pub const fn identity() -> Self {
-            Self($inner::UNIT_W)
+            Self($inner::W)
         }
 
         /// Creates a rotation quaternion from an unaligned slice.

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -21,7 +21,7 @@ impl Default for TransformSRT {
         Self {
             scale: Vec3::one(),
             rotation: Quat::identity(),
-            translation: Vec3::zero(),
+            translation: Vec3::ZERO,
         }
     }
 }
@@ -38,7 +38,7 @@ impl Default for TransformRT {
     fn default() -> Self {
         Self {
             rotation: Quat::identity(),
-            translation: Vec3::zero(),
+            translation: Vec3::ZERO,
         }
     }
 }
@@ -67,7 +67,7 @@ impl TransformSRT {
         Self {
             scale: Vec3::one(),
             rotation: Quat::identity(),
-            translation: Vec3::zero(),
+            translation: Vec3::ZERO,
         }
     }
 
@@ -130,7 +130,7 @@ fn mul_srt_srt(lhs: &TransformSRT, rhs: &TransformSRT) -> TransformSRT {
     let min_scale = lhs_scale.min(rhs_scale);
     let scale = lhs_scale * rhs_scale;
 
-    if min_scale.cmplt(Vec3A::zero()).any() {
+    if min_scale.cmplt(Vec3A::ZERO).any() {
         // If negative scale, we go through a matrix
         let lhs_mtx =
             Mat4::from_scale_rotation_translation(lhs.scale, lhs.rotation, lhs.translation);
@@ -189,7 +189,7 @@ impl TransformRT {
     pub fn identity() -> Self {
         Self {
             rotation: Quat::identity(),
-            translation: Vec3::zero(),
+            translation: Vec3::ZERO,
         }
     }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -44,6 +44,13 @@ impl Default for TransformRT {
 }
 
 impl TransformSRT {
+    /// The identity transforms that does nothing.
+    pub const IDENTITY: Self = Self {
+        scale: Vec3::ONE,
+        rotation: Quat::IDENTITY,
+        translation: Vec3::ZERO,
+    };
+
     #[inline]
     pub fn from_scale_rotation_translation(scale: Vec3, rotation: Quat, translation: Vec3) -> Self {
         Self {
@@ -63,12 +70,8 @@ impl TransformSRT {
     }
 
     #[inline]
-    pub fn identity() -> Self {
-        Self {
-            scale: Vec3::ONE,
-            rotation: Quat::IDENTITY,
-            translation: Vec3::ZERO,
-        }
+    pub const fn identity() -> Self {
+        Self::IDENTITY
     }
 
     #[inline]
@@ -177,6 +180,12 @@ fn mul_rt_rt(lhs: &TransformRT, rhs: &TransformRT) -> TransformRT {
 }
 
 impl TransformRT {
+    /// The identity transforms that does nothing.
+    pub const IDENTITY: Self = Self {
+        rotation: Quat::IDENTITY,
+        translation: Vec3::ZERO,
+    };
+
     #[inline]
     pub fn from_rotation_translation(rotation: Quat, translation: Vec3) -> Self {
         Self {
@@ -186,11 +195,8 @@ impl TransformRT {
     }
 
     #[inline]
-    pub fn identity() -> Self {
-        Self {
-            rotation: Quat::IDENTITY,
-            translation: Vec3::ZERO,
-        }
+    pub const fn identity() -> Self {
+        Self::IDENTITY
     }
 
     /// Returns `true` if, and only if, all elements are finite.

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -19,7 +19,7 @@ impl Default for TransformSRT {
     #[inline]
     fn default() -> Self {
         Self {
-            scale: Vec3::one(),
+            scale: Vec3::ONE,
             rotation: Quat::identity(),
             translation: Vec3::ZERO,
         }
@@ -65,7 +65,7 @@ impl TransformSRT {
     #[inline]
     pub fn identity() -> Self {
         Self {
-            scale: Vec3::one(),
+            scale: Vec3::ONE,
             rotation: Quat::identity(),
             translation: Vec3::ZERO,
         }
@@ -320,7 +320,7 @@ impl From<TransformRT> for TransformSRT {
         Self {
             translation: tr.translation,
             rotation: tr.rotation,
-            scale: Vec3::one(),
+            scale: Vec3::ONE,
         }
     }
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -20,7 +20,7 @@ impl Default for TransformSRT {
     fn default() -> Self {
         Self {
             scale: Vec3::ONE,
-            rotation: Quat::identity(),
+            rotation: Quat::IDENTITY,
             translation: Vec3::ZERO,
         }
     }
@@ -37,7 +37,7 @@ impl Default for TransformRT {
     #[inline]
     fn default() -> Self {
         Self {
-            rotation: Quat::identity(),
+            rotation: Quat::IDENTITY,
             translation: Vec3::ZERO,
         }
     }
@@ -66,7 +66,7 @@ impl TransformSRT {
     pub fn identity() -> Self {
         Self {
             scale: Vec3::ONE,
-            rotation: Quat::identity(),
+            rotation: Quat::IDENTITY,
             translation: Vec3::ZERO,
         }
     }
@@ -188,7 +188,7 @@ impl TransformRT {
     #[inline]
     pub fn identity() -> Self {
         Self {
-            rotation: Quat::identity(),
+            rotation: Quat::IDENTITY,
             translation: Vec3::ZERO,
         }
     }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -69,6 +69,7 @@ impl TransformSRT {
         }
     }
 
+    #[deprecated = "use TransformSRT::IDENTITY instead"]
     #[inline]
     pub const fn identity() -> Self {
         Self::IDENTITY
@@ -194,6 +195,7 @@ impl TransformRT {
         }
     }
 
+    #[deprecated = "use TransformRT::IDENTITY instead"]
     #[inline]
     pub const fn identity() -> Self {
         Self::IDENTITY

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -3,9 +3,10 @@
 macro_rules! impl_vecn_common_methods {
     ($t:ty, $vecn:ident, $mask:ident, $inner:ident, $vectrait:ident) => {
         /// Creates a vector with all elements set to `0.0`.
+        #[deprecated = "use ZERO constant instead"]
         #[inline(always)]
         pub const fn zero() -> Self {
-            Self($inner::ZERO)
+            Self::ZERO
         }
 
         /// Creates a vector with all elements set to `1.0`.

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -551,7 +551,7 @@ macro_rules! impl_vecn_common_traits {
             where
                 I: Iterator<Item = &'a Self>,
             {
-                iter.fold(Self::zero(), |a, &b| Self::add(a, b))
+                iter.fold(Self::ZERO, |a, &b| Self::add(a, b))
             }
         }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -10,9 +10,10 @@ macro_rules! impl_vecn_common_methods {
         }
 
         /// Creates a vector with all elements set to `1.0`.
+        #[deprecated = "use ONE constant instead"]
         #[inline(always)]
         pub const fn one() -> Self {
-            Self($inner::ONE)
+            Self::ONE
         }
 
         /// Creates a vector with all elements set to `v`.

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -562,7 +562,7 @@ macro_rules! impl_vecn_common_traits {
             where
                 I: Iterator<Item = &'a Self>,
             {
-                iter.fold(Self::one(), |a, &b| Self::mul(a, b))
+                iter.fold(Self::ONE, |a, &b| Self::mul(a, b))
             }
         }
     };

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -9,6 +9,9 @@ use std::iter::{Product, Sum};
 
 macro_rules! impl_vec2_common_methods {
     ($t:ty, $vec2:ident, $vec3:ident, $mask:ident, $inner:ident) => {
+        /// All zeroes.
+        pub const ZERO: Self = Self($inner::ZERO);
+
         /// `[1, 0]`: a unit-length vector pointing along the positive X axis.
         pub const X: Self = Self($inner::X);
 

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -10,10 +10,10 @@ use std::iter::{Product, Sum};
 macro_rules! impl_vec2_common_methods {
     ($t:ty, $vec2:ident, $vec3:ident, $mask:ident, $inner:ident) => {
         /// `[1, 0]`: a unit-length vector pointing along the positive X axis.
-        pub const X: Self = Self($inner::UNIT_X);
+        pub const X: Self = Self($inner::X);
 
         /// `[0, 1]`: a unit-length vector pointing along the positive Y axis.
-        pub const Y: Self = Self($inner::UNIT_Y);
+        pub const Y: Self = Self($inner::Y);
 
         /// Creates a new vector.
         #[inline(always)]
@@ -24,13 +24,13 @@ macro_rules! impl_vec2_common_methods {
         /// Creates a vector with values `[x: 1.0, y: 0.0]`.
         #[inline(always)]
         pub const fn unit_x() -> $vec2 {
-            Self($inner::UNIT_X)
+            Self($inner::X)
         }
 
         /// Creates a vector with values `[x: 0.0, y: 1.0]`.
         #[inline(always)]
         pub const fn unit_y() -> $vec2 {
-            Self($inner::UNIT_Y)
+            Self($inner::Y)
         }
 
         /// Creates a 3D vector from `self` and the given `z` value.

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -28,12 +28,14 @@ macro_rules! impl_vec2_common_methods {
         }
 
         /// Creates a vector with values `[x: 1.0, y: 0.0]`.
+        #[deprecated = "Use Vec2::X instead"]
         #[inline(always)]
         pub const fn unit_x() -> $vec2 {
             Self($inner::X)
         }
 
         /// Creates a vector with values `[x: 0.0, y: 1.0]`.
+        #[deprecated = "Use Vec2::Y instead"]
         #[inline(always)]
         pub const fn unit_y() -> $vec2 {
             Self($inner::Y)

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -12,6 +12,9 @@ macro_rules! impl_vec2_common_methods {
         /// All zeroes.
         pub const ZERO: Self = Self($inner::ZERO);
 
+        /// All ones.
+        pub const ONE: Self = Self($inner::ONE);
+
         /// `[1, 0]`: a unit-length vector pointing along the positive X axis.
         pub const X: Self = Self($inner::X);
 

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -27,6 +27,9 @@ macro_rules! impl_vec3_common_methods {
         /// All zeroes.
         pub const ZERO: Self = Self(VectorConst::ZERO);
 
+        /// All ones.
+        pub const ONE: Self = Self(VectorConst::ONE);
+
         /// `[1, 0, 0]`: a unit-length vector pointing along the positive X axis.
         pub const X: Self = Self(Vector3Const::X);
 

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -24,6 +24,9 @@ use std::iter::{Product, Sum};
 
 macro_rules! impl_vec3_common_methods {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident, $mask:ident, $inner:ident) => {
+        /// All zeroes.
+        pub const ZERO: Self = Self(VectorConst::ZERO);
+
         /// `[1, 0, 0]`: a unit-length vector pointing along the positive X axis.
         pub const X: Self = Self(Vector3Const::X);
 

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -25,13 +25,13 @@ use std::iter::{Product, Sum};
 macro_rules! impl_vec3_common_methods {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident, $mask:ident, $inner:ident) => {
         /// `[1, 0, 0]`: a unit-length vector pointing along the positive X axis.
-        pub const X: Self = Self(Vector3Const::UNIT_X);
+        pub const X: Self = Self(Vector3Const::X);
 
         /// `[0, 1, 0]`: a unit-length vector pointing along the positive Y axis.
-        pub const Y: Self = Self(Vector3Const::UNIT_Y);
+        pub const Y: Self = Self(Vector3Const::Y);
 
         /// `[0, 0, 1]`: a unit-length vector pointing along the positive Z axis.
-        pub const Z: Self = Self(Vector3Const::UNIT_Z);
+        pub const Z: Self = Self(Vector3Const::Z);
 
         /// Creates a new 3D vector.
         #[inline(always)]
@@ -42,19 +42,19 @@ macro_rules! impl_vec3_common_methods {
         /// Creates a vector with values `[x: 1.0, y: 0.0, z: 0.0]`.
         #[inline(always)]
         pub const fn unit_x() -> Self {
-            Self(Vector3Const::UNIT_X)
+            Self(Vector3Const::X)
         }
 
         /// Creates a vector with values `[x: 0.0, y: 1.0, z: 0.0]`.
         #[inline(always)]
         pub const fn unit_y() -> Self {
-            Self(Vector3Const::UNIT_Y)
+            Self(Vector3Const::Y)
         }
 
         /// Creates a vector with values `[x: 0.0, y: 0.0, z: 1.0]`.
         #[inline(always)]
         pub const fn unit_z() -> Self {
-            Self(Vector3Const::UNIT_Z)
+            Self(Vector3Const::Z)
         }
 
         /// Creates a 4D vector from `self` and the given `w` value.

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -46,6 +46,7 @@ macro_rules! impl_vec3_common_methods {
         }
 
         /// Creates a vector with values `[x: 1.0, y: 0.0, z: 0.0]`.
+        #[deprecated = "Use Vec3::X instead"]
         #[inline(always)]
         pub const fn unit_x() -> Self {
             Self(Vector3Const::X)
@@ -53,12 +54,14 @@ macro_rules! impl_vec3_common_methods {
 
         /// Creates a vector with values `[x: 0.0, y: 1.0, z: 0.0]`.
         #[inline(always)]
+        #[deprecated = "Use Vec3::Y instead"]
         pub const fn unit_y() -> Self {
             Self(Vector3Const::Y)
         }
 
         /// Creates a vector with values `[x: 0.0, y: 0.0, z: 1.0]`.
         #[inline(always)]
+        #[deprecated = "Use Vec3::Z instead"]
         pub const fn unit_z() -> Self {
             Self(Vector3Const::Z)
         }

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -30,6 +30,9 @@ macro_rules! impl_vec4_common_methods {
         /// All zeroes.
         pub const ZERO: Self = Self(VectorConst::ZERO);
 
+        /// All ones.
+        pub const ONE: Self = Self(VectorConst::ONE);
+
         /// `[1, 0, 0, 0]`: a unit-length vector pointing along the positive X axis.
         pub const X: Self = Self(Vector4Const::X);
 

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -27,6 +27,9 @@ use core::{cmp::Ordering, f32};
 
 macro_rules! impl_vec4_common_methods {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident, $mask:ident, $inner:ident) => {
+        /// All zeroes.
+        pub const ZERO: Self = Self(VectorConst::ZERO);
+
         /// `[1, 0, 0, 0]`: a unit-length vector pointing along the positive X axis.
         pub const X: Self = Self(Vector4Const::X);
 

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -28,16 +28,16 @@ use core::{cmp::Ordering, f32};
 macro_rules! impl_vec4_common_methods {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident, $mask:ident, $inner:ident) => {
         /// `[1, 0, 0, 0]`: a unit-length vector pointing along the positive X axis.
-        pub const X: Self = Self(Vector4Const::UNIT_X);
+        pub const X: Self = Self(Vector4Const::X);
 
         /// `[0, 1, 0, 0]`: a unit-length vector pointing along the positive Y axis.
-        pub const Y: Self = Self(Vector4Const::UNIT_Y);
+        pub const Y: Self = Self(Vector4Const::Y);
 
         /// `[0, 0, 1, 0]`: a unit-length vector pointing along the positive Z axis.
-        pub const Z: Self = Self(Vector4Const::UNIT_Z);
+        pub const Z: Self = Self(Vector4Const::Z);
 
         /// `[0, 0, 0, 1]`: a unit-length vector pointing along the positive W axis.
-        pub const W: Self = Self(Vector4Const::UNIT_W);
+        pub const W: Self = Self(Vector4Const::W);
 
         /// Creates a new 4D vector.
         #[inline(always)]
@@ -48,25 +48,25 @@ macro_rules! impl_vec4_common_methods {
         /// Creates a 4D vector with values `[x: 1.0, y: 0.0, z: 0.0, w: 0.0]`.
         #[inline(always)]
         pub const fn unit_x() -> Self {
-            Self(Vector4Const::UNIT_X)
+            Self(Vector4Const::X)
         }
 
         /// Creates a 4D vector with values `[x: 0.0, y: 1.0, z: 0.0, w: 0.0]`.
         #[inline(always)]
         pub const fn unit_y() -> Self {
-            Self(Vector4Const::UNIT_Y)
+            Self(Vector4Const::Y)
         }
 
         /// Creates a 4D vector with values `[x: 0.0, y: 0.0, z: 1.0, w: 0.0]`.
         #[inline(always)]
         pub const fn unit_z() -> Self {
-            Self(Vector4Const::UNIT_Z)
+            Self(Vector4Const::Z)
         }
 
         /// Creates a 4D vector with values `[x: 0.0, y: 0.0, z: 0.0, w: 1.0]`.
         #[inline(always)]
         pub const fn unit_w() -> Self {
-            Self(Vector4Const::UNIT_W)
+            Self(Vector4Const::W)
         }
 
         /// Creates a `Vec3` from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -52,24 +52,28 @@ macro_rules! impl_vec4_common_methods {
         }
 
         /// Creates a 4D vector with values `[x: 1.0, y: 0.0, z: 0.0, w: 0.0]`.
+        #[deprecated = "Use Vec4::X instead"]
         #[inline(always)]
         pub const fn unit_x() -> Self {
             Self(Vector4Const::X)
         }
 
         /// Creates a 4D vector with values `[x: 0.0, y: 1.0, z: 0.0, w: 0.0]`.
+        #[deprecated = "Use Vec4::Y instead"]
         #[inline(always)]
         pub const fn unit_y() -> Self {
             Self(Vector4Const::Y)
         }
 
         /// Creates a 4D vector with values `[x: 0.0, y: 0.0, z: 1.0, w: 0.0]`.
+        #[deprecated = "Use Vec4::Z instead"]
         #[inline(always)]
         pub const fn unit_z() -> Self {
             Self(Vector4Const::Z)
         }
 
         /// Creates a 4D vector with values `[x: 0.0, y: 0.0, z: 0.0, w: 1.0]`.
+        #[deprecated = "Use Vec4::W instead"]
         #[inline(always)]
         pub const fn unit_w() -> Self {
             Self(Vector4Const::W)

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -7,8 +7,6 @@ macro_rules! impl_mat2_tests {
 
         const MATRIX: [[$t; 2]; 2] = [[1.0, 2.0], [3.0, 4.0]];
 
-        const ZERO: [[$t; 2]; 2] = [[0.0; 2]; 2];
-
         #[test]
         fn test_const() {
             const M0: $mat2 = $const_new!([0.0; 4]);
@@ -32,7 +30,6 @@ macro_rules! impl_mat2_tests {
         #[test]
         fn test_mat2_zero() {
             assert_eq!($mat2::ZERO, $mat2::from_cols_array(&[0., 0., 0., 0.]));
-            assert_eq!($mat2::from_cols_array_2d(&ZERO), $mat2::zero());
         }
 
         #[test]

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -14,7 +14,7 @@ macro_rules! impl_mat2_tests {
             const M0: $mat2 = $const_new!([0.0; 4]);
             const M1: $mat2 = $const_new!([1.0, 2.0, 3.0, 4.0]);
             const M2: $mat2 = $const_new!([1.0, 2.0], [3.0, 4.0]);
-            assert_eq!($mat2::zero(), M0);
+            assert_eq!($mat2::ZERO, M0);
             assert_eq!($mat2::from_cols_array(&[1.0, 2.0, 3.0, 4.0]), M1);
             assert_eq!($mat2::from_cols_array(&[1.0, 2.0, 3.0, 4.0]), M2);
         }
@@ -37,7 +37,7 @@ macro_rules! impl_mat2_tests {
 
         #[test]
         fn test_mat2_accessors() {
-            let mut m = $mat2::zero();
+            let mut m = $mat2::ZERO;
             m.x_axis = $vec2::new(1.0, 2.0);
             m.y_axis = $vec2::new(3.0, 4.0);
             assert_eq!($mat2::from_cols_array_2d(&MATRIX), m);
@@ -89,7 +89,7 @@ macro_rules! impl_mat2_tests {
 
         #[test]
         fn test_mat2_det() {
-            assert_eq!(0.0, $mat2::zero().determinant());
+            assert_eq!(0.0, $mat2::ZERO.determinant());
             assert_eq!(1.0, $mat2::identity().determinant());
             assert_eq!(1.0, $mat2::from_angle(deg(90.0)).determinant());
             assert_eq!(1.0, $mat2::from_angle(deg(180.0)).determinant());
@@ -141,7 +141,7 @@ macro_rules! impl_mat2_tests {
                 $mat2::from_cols_array_2d(&[[2.0, 4.0], [6.0, 8.0]]),
                 m0 + m0
             );
-            assert_eq!($mat2::zero(), m0 - m0);
+            assert_eq!($mat2::ZERO, m0 - m0);
             assert_approx_eq!(
                 $mat2::from_cols_array_2d(&[[1.0, 2.0], [3.0, 4.0]]),
                 m0 * $mat2::identity()

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -21,6 +21,7 @@ macro_rules! impl_mat2_tests {
 
         #[test]
         fn test_mat2_identity() {
+            assert_eq!($mat2::IDENTITY, $mat2::from_cols_array(&[1., 0., 0., 1.]));
             let identity = $mat2::identity();
             assert_eq!(IDENTITY, identity.to_cols_array_2d());
             assert_eq!($mat2::from_cols_array_2d(&IDENTITY), identity);
@@ -30,6 +31,7 @@ macro_rules! impl_mat2_tests {
 
         #[test]
         fn test_mat2_zero() {
+            assert_eq!($mat2::ZERO, $mat2::from_cols_array(&[0., 0., 0., 0.]));
             assert_eq!($mat2::from_cols_array_2d(&ZERO), $mat2::zero());
         }
 

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -61,9 +61,9 @@ macro_rules! impl_mat2_tests {
         #[test]
         fn test_mat2_mul() {
             let mat_a = $mat2::from_angle(deg(90.0));
-            let res_a = mat_a * $vec2::unit_y();
+            let res_a = mat_a * $vec2::Y;
             assert_approx_eq!($newvec2(-1.0, 0.0), res_a);
-            let res_b = mat_a * $vec2::unit_x();
+            let res_b = mat_a * $vec2::X;
             assert_approx_eq!($newvec2(0.0, 1.0), res_b);
         }
 
@@ -71,12 +71,12 @@ macro_rules! impl_mat2_tests {
         fn test_from_scale() {
             let m = $mat2::from_scale($vec2::new(2.0, 4.0));
             assert_approx_eq!(m * $vec2::new(1.0, 1.0), $vec2::new(2.0, 4.0));
-            assert_approx_eq!($vec2::unit_x() * 2.0, m.x_axis);
-            assert_approx_eq!($vec2::unit_y() * 4.0, m.y_axis);
+            assert_approx_eq!($vec2::X * 2.0, m.x_axis);
+            assert_approx_eq!($vec2::Y * 4.0, m.y_axis);
 
             let rot = $mat2::from_scale_angle($vec2::new(4.0, 2.0), deg(180.0));
-            assert_approx_eq!($vec2::unit_x() * -4.0, rot * $vec2::unit_x(), 1.0e-6);
-            assert_approx_eq!($vec2::unit_y() * -2.0, rot * $vec2::unit_y(), 1.0e-6);
+            assert_approx_eq!($vec2::X * -4.0, rot * $vec2::X, 1.0e-6);
+            assert_approx_eq!($vec2::Y * -2.0, rot * $vec2::Y, 1.0e-6);
         }
 
         #[test]

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -22,7 +22,7 @@ macro_rules! impl_mat2_tests {
         #[test]
         fn test_mat2_identity() {
             assert_eq!($mat2::IDENTITY, $mat2::from_cols_array(&[1., 0., 0., 1.]));
-            let identity = $mat2::identity();
+            let identity = $mat2::IDENTITY;
             assert_eq!(IDENTITY, identity.to_cols_array_2d());
             assert_eq!($mat2::from_cols_array_2d(&IDENTITY), identity);
             assert_eq!(identity, identity * identity);
@@ -90,7 +90,7 @@ macro_rules! impl_mat2_tests {
         #[test]
         fn test_mat2_det() {
             assert_eq!(0.0, $mat2::ZERO.determinant());
-            assert_eq!(1.0, $mat2::identity().determinant());
+            assert_eq!(1.0, $mat2::IDENTITY.determinant());
             assert_eq!(1.0, $mat2::from_angle(deg(90.0)).determinant());
             assert_eq!(1.0, $mat2::from_angle(deg(180.0)).determinant());
             assert_eq!(1.0, $mat2::from_angle(deg(270.0)).determinant());
@@ -106,23 +106,23 @@ macro_rules! impl_mat2_tests {
 
         #[test]
         fn test_mat2_inverse() {
-            let inv = $mat2::identity().inverse();
-            assert_approx_eq!($mat2::identity(), inv);
+            let inv = $mat2::IDENTITY.inverse();
+            assert_approx_eq!($mat2::IDENTITY, inv);
 
             let rot = $mat2::from_angle(deg(90.0));
             let rot_inv = rot.inverse();
-            assert_approx_eq!($mat2::identity(), rot * rot_inv);
-            assert_approx_eq!($mat2::identity(), rot_inv * rot);
+            assert_approx_eq!($mat2::IDENTITY, rot * rot_inv);
+            assert_approx_eq!($mat2::IDENTITY, rot_inv * rot);
 
             let scale = $mat2::from_scale($newvec2(4.0, 5.0));
             let scale_inv = scale.inverse();
-            assert_approx_eq!($mat2::identity(), scale * scale_inv);
-            assert_approx_eq!($mat2::identity(), scale_inv * scale);
+            assert_approx_eq!($mat2::IDENTITY, scale * scale_inv);
+            assert_approx_eq!($mat2::IDENTITY, scale_inv * scale);
 
             let m = scale * rot;
             let m_inv = m.inverse();
-            assert_approx_eq!($mat2::identity(), m * m_inv);
-            assert_approx_eq!($mat2::identity(), m_inv * m);
+            assert_approx_eq!($mat2::IDENTITY, m * m_inv);
+            assert_approx_eq!($mat2::IDENTITY, m_inv * m);
             assert_approx_eq!(m_inv, rot_inv * scale_inv);
         }
 
@@ -144,11 +144,11 @@ macro_rules! impl_mat2_tests {
             assert_eq!($mat2::ZERO, m0 - m0);
             assert_approx_eq!(
                 $mat2::from_cols_array_2d(&[[1.0, 2.0], [3.0, 4.0]]),
-                m0 * $mat2::identity()
+                m0 * $mat2::IDENTITY
             );
             assert_approx_eq!(
                 $mat2::from_cols_array_2d(&[[1.0, 2.0], [3.0, 4.0]]),
-                $mat2::identity() * m0
+                $mat2::IDENTITY * m0
             );
         }
 
@@ -161,14 +161,14 @@ macro_rules! impl_mat2_tests {
         #[cfg(feature = "std")]
         #[test]
         fn test_sum() {
-            let id = $mat2::identity();
+            let id = $mat2::IDENTITY;
             assert_eq!(vec![id, id].iter().sum::<$mat2>(), id + id);
         }
 
         #[cfg(feature = "std")]
         #[test]
         fn test_product() {
-            let two = $mat2::identity() + $mat2::identity();
+            let two = $mat2::IDENTITY + $mat2::IDENTITY;
             assert_eq!(vec![two, two].iter().product::<$mat2>(), two * two);
         }
 
@@ -177,10 +177,10 @@ macro_rules! impl_mat2_tests {
             use std::$t::INFINITY;
             use std::$t::NAN;
             use std::$t::NEG_INFINITY;
-            assert!($mat2::identity().is_finite());
-            assert!(!($mat2::identity() * INFINITY).is_finite());
-            assert!(!($mat2::identity() * NEG_INFINITY).is_finite());
-            assert!(!($mat2::identity() * NAN).is_finite());
+            assert!($mat2::IDENTITY.is_finite());
+            assert!(!($mat2::IDENTITY * INFINITY).is_finite());
+            assert!(!($mat2::IDENTITY * NEG_INFINITY).is_finite());
+            assert!(!($mat2::IDENTITY * NAN).is_finite());
         }
     };
 }

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -91,21 +91,21 @@ macro_rules! impl_mat3_tests {
         #[test]
         fn test_from_rotation() {
             let rot_x1 = $mat3::from_rotation_x(deg(180.0));
-            let rot_x2 = $mat3::from_axis_angle($vec3::unit_x(), deg(180.0));
+            let rot_x2 = $mat3::from_axis_angle($vec3::X, deg(180.0));
             assert_approx_eq!(rot_x1, rot_x2);
             let rot_y1 = $mat3::from_rotation_y(deg(180.0));
-            let rot_y2 = $mat3::from_axis_angle($vec3::unit_y(), deg(180.0));
+            let rot_y2 = $mat3::from_axis_angle($vec3::Y, deg(180.0));
             assert_approx_eq!(rot_y1, rot_y2);
             let rot_z1 = $mat3::from_rotation_z(deg(180.0));
-            let rot_z2 = $mat3::from_axis_angle($vec3::unit_z(), deg(180.0));
+            let rot_z2 = $mat3::from_axis_angle($vec3::Z, deg(180.0));
             assert_approx_eq!(rot_z1, rot_z2);
         }
 
         #[test]
         fn test_mat3_mul() {
-            let mat_a = $mat3::from_axis_angle($vec3::unit_z(), deg(90.0));
-            assert_approx_eq!($newvec3(-1.0, 0.0, 0.0), mat_a * $vec3::unit_y());
-            assert_approx_eq!($newvec3(-1.0, 0.0, 0.0), mat_a.mul_vec3($vec3::unit_y()));
+            let mat_a = $mat3::from_axis_angle($vec3::Z, deg(90.0));
+            assert_approx_eq!($newvec3(-1.0, 0.0, 0.0), mat_a * $vec3::Y);
+            assert_approx_eq!($newvec3(-1.0, 0.0, 0.0), mat_a.mul_vec3($vec3::Y));
         }
 
         #[test]
@@ -115,13 +115,13 @@ macro_rules! impl_mat3_tests {
                 $t::to_radians(90.0),
                 $vec2::new(1.0, 2.0),
             );
-            let result2 = mat_b.transform_vector2($vec2::unit_y());
+            let result2 = mat_b.transform_vector2($vec2::Y);
             assert_approx_eq!($vec2::new(-1.5, 0.0), result2, 1.0e-6);
-            assert_approx_eq!(result2, (mat_b * $vec2::unit_y().extend(0.0)).truncate());
+            assert_approx_eq!(result2, (mat_b * $vec2::Y.extend(0.0)).truncate());
 
-            let result2 = mat_b.transform_point2($vec2::unit_y());
+            let result2 = mat_b.transform_point2($vec2::Y);
             assert_approx_eq!($vec2::new(-0.5, 2.0), result2, 1.0e-6);
-            assert_approx_eq!(result2, (mat_b * $vec2::unit_y().extend(1.0)).truncate());
+            assert_approx_eq!(result2, (mat_b * $vec2::Y.extend(1.0)).truncate());
         }
 
         #[test]
@@ -155,9 +155,9 @@ macro_rules! impl_mat3_tests {
         fn test_from_scale() {
             let m = $mat3::from_scale($vec3::new(2.0, 4.0, 8.0));
             assert_approx_eq!(m * $vec3::new(1.0, 1.0, 1.0), $vec3::new(2.0, 4.0, 8.0));
-            assert_approx_eq!($vec3::unit_x() * 2.0, m.x_axis);
-            assert_approx_eq!($vec3::unit_y() * 4.0, m.y_axis);
-            assert_approx_eq!($vec3::unit_z() * 8.0, m.z_axis);
+            assert_approx_eq!($vec3::X * 2.0, m.x_axis);
+            assert_approx_eq!($vec3::Y * 4.0, m.y_axis);
+            assert_approx_eq!($vec3::Z * 8.0, m.z_axis);
         }
 
         #[test]
@@ -275,9 +275,9 @@ mod mat3 {
 
     #[test]
     fn test_mul_vec3a() {
-        let mat_a = Mat3::from_axis_angle(Vec3::unit_z(), deg(90.0));
-        assert_approx_eq!(vec3a(-1.0, 0.0, 0.0), mat_a * Vec3A::unit_y());
-        assert_approx_eq!(vec3a(-1.0, 0.0, 0.0), mat_a.mul_vec3a(Vec3A::unit_y()));
+        let mat_a = Mat3::from_axis_angle(Vec3::Z, deg(90.0));
+        assert_approx_eq!(vec3a(-1.0, 0.0, 0.0), mat_a * Vec3A::Y);
+        assert_approx_eq!(vec3a(-1.0, 0.0, 0.0), mat_a.mul_vec3a(Vec3A::Y));
     }
 
     #[test]

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -31,6 +31,14 @@ macro_rules! impl_mat3_tests {
 
         #[test]
         fn test_mat3_identity() {
+            assert_eq!(
+                $mat3::IDENTITY,
+                $mat3::from_cols_array(&[
+                    1., 0., 0., //
+                    0., 1., 0., //
+                    0., 0., 1., //
+                ])
+            );
             let identity = $mat3::identity();
             assert_eq!(IDENTITY, identity.to_cols_array_2d());
             assert_eq!($mat3::from_cols_array_2d(&IDENTITY), identity);
@@ -40,6 +48,10 @@ macro_rules! impl_mat3_tests {
 
         #[test]
         fn test_mat3_zero() {
+            assert_eq!(
+                $mat3::ZERO,
+                $mat3::from_cols_array(&[0., 0., 0., 0., 0., 0., 0., 0., 0.])
+            );
             assert_eq!($mat3::from_cols_array_2d(&ZERO), $mat3::zero());
         }
 

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -39,7 +39,7 @@ macro_rules! impl_mat3_tests {
                     0., 0., 1., //
                 ])
             );
-            let identity = $mat3::identity();
+            let identity = $mat3::IDENTITY;
             assert_eq!(IDENTITY, identity.to_cols_array_2d());
             assert_eq!($mat3::from_cols_array_2d(&IDENTITY), identity);
             assert_eq!(identity, identity * identity);
@@ -176,7 +176,7 @@ macro_rules! impl_mat3_tests {
         #[test]
         fn test_mat3_det() {
             assert_eq!(0.0, $mat3::ZERO.determinant());
-            assert_eq!(1.0, $mat3::identity().determinant());
+            assert_eq!(1.0, $mat3::IDENTITY.determinant());
             assert_eq!(1.0, $mat3::from_rotation_x(deg(90.0)).determinant());
             assert_eq!(1.0, $mat3::from_rotation_y(deg(180.0)).determinant());
             assert_eq!(1.0, $mat3::from_rotation_z(deg(270.0)).determinant());
@@ -189,30 +189,30 @@ macro_rules! impl_mat3_tests {
         #[test]
         fn test_mat3_inverse() {
             // assert_eq!(None, $mat3::ZERO.inverse());
-            let inv = $mat3::identity().inverse();
+            let inv = $mat3::IDENTITY.inverse();
             // assert_ne!(None, inv);
-            assert_approx_eq!($mat3::identity(), inv);
+            assert_approx_eq!($mat3::IDENTITY, inv);
 
             let rotz = $mat3::from_rotation_z(deg(90.0));
             let rotz_inv = rotz.inverse();
             // assert_ne!(None, rotz_inv);
             // let rotz_inv = rotz_inv.unwrap();
-            assert_approx_eq!($mat3::identity(), rotz * rotz_inv);
-            assert_approx_eq!($mat3::identity(), rotz_inv * rotz);
+            assert_approx_eq!($mat3::IDENTITY, rotz * rotz_inv);
+            assert_approx_eq!($mat3::IDENTITY, rotz_inv * rotz);
 
             let scale = $mat3::from_scale($newvec3(4.0, 5.0, 6.0));
             let scale_inv = scale.inverse();
             // assert_ne!(None, scale_inv);
             // let scale_inv = scale_inv.unwrap();
-            assert_approx_eq!($mat3::identity(), scale * scale_inv);
-            assert_approx_eq!($mat3::identity(), scale_inv * scale);
+            assert_approx_eq!($mat3::IDENTITY, scale * scale_inv);
+            assert_approx_eq!($mat3::IDENTITY, scale_inv * scale);
 
             let m = scale * rotz;
             let m_inv = m.inverse();
             // assert_ne!(None, m_inv);
             // let m_inv = m_inv.unwrap();
-            assert_approx_eq!($mat3::identity(), m * m_inv);
-            assert_approx_eq!($mat3::identity(), m_inv * m);
+            assert_approx_eq!($mat3::IDENTITY, m * m_inv);
+            assert_approx_eq!($mat3::IDENTITY, m_inv * m);
             assert_approx_eq!(m_inv, rotz_inv * scale_inv);
         }
 
@@ -228,8 +228,8 @@ macro_rules! impl_mat3_tests {
             assert_eq!(m0x2, 2.0 * m0);
             assert_eq!(m0x2, m0 + m0);
             assert_eq!($mat3::ZERO, m0 - m0);
-            assert_approx_eq!(m0, m0 * $mat3::identity());
-            assert_approx_eq!(m0, $mat3::identity() * m0);
+            assert_approx_eq!(m0, m0 * $mat3::IDENTITY);
+            assert_approx_eq!(m0, $mat3::IDENTITY * m0);
         }
 
         #[test]
@@ -241,23 +241,23 @@ macro_rules! impl_mat3_tests {
         #[cfg(feature = "std")]
         #[test]
         fn test_sum() {
-            let id = $mat3::identity();
+            let id = $mat3::IDENTITY;
             assert_eq!(vec![id, id].iter().sum::<$mat3>(), id + id);
         }
 
         #[cfg(feature = "std")]
         #[test]
         fn test_product() {
-            let two = $mat3::identity() + $mat3::identity();
+            let two = $mat3::IDENTITY + $mat3::IDENTITY;
             assert_eq!(vec![two, two].iter().product::<$mat3>(), two * two);
         }
 
         #[test]
         fn test_mat3_is_finite() {
-            assert!($mat3::identity().is_finite());
-            assert!(!($mat3::identity() * INFINITY).is_finite());
-            assert!(!($mat3::identity() * NEG_INFINITY).is_finite());
-            assert!(!($mat3::identity() * NAN).is_finite());
+            assert!($mat3::IDENTITY.is_finite());
+            assert!(!($mat3::IDENTITY * INFINITY).is_finite());
+            assert!(!($mat3::IDENTITY * NEG_INFINITY).is_finite());
+            assert!(!($mat3::IDENTITY * NAN).is_finite());
         }
     };
 }

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -11,8 +11,6 @@ macro_rules! impl_mat3_tests {
 
         const MATRIX: [[$t; 3]; 3] = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]];
 
-        const ZERO: [[$t; 3]; 3] = [[0.0; 3]; 3];
-
         #[test]
         fn test_const() {
             const M0: $mat3 = $const_new!([0.0; 9]);
@@ -52,7 +50,6 @@ macro_rules! impl_mat3_tests {
                 $mat3::ZERO,
                 $mat3::from_cols_array(&[0., 0., 0., 0., 0., 0., 0., 0., 0.])
             );
-            assert_eq!($mat3::from_cols_array_2d(&ZERO), $mat3::zero());
         }
 
         #[test]

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -18,7 +18,7 @@ macro_rules! impl_mat3_tests {
             const M0: $mat3 = $const_new!([0.0; 9]);
             const M1: $mat3 = $const_new!([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]);
             const M2: $mat3 = $const_new!([1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]);
-            assert_eq!($mat3::zero(), M0);
+            assert_eq!($mat3::ZERO, M0);
             assert_eq!(
                 $mat3::from_cols_array(&[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0]),
                 M1
@@ -57,7 +57,7 @@ macro_rules! impl_mat3_tests {
 
         #[test]
         fn test_mat3_accessors() {
-            let mut m = $mat3::zero();
+            let mut m = $mat3::ZERO;
             m.x_axis = $vec3::new(1.0, 2.0, 3.0);
             m.y_axis = $vec3::new(4.0, 5.0, 6.0);
             m.z_axis = $vec3::new(7.0, 8.0, 9.0);
@@ -175,7 +175,7 @@ macro_rules! impl_mat3_tests {
 
         #[test]
         fn test_mat3_det() {
-            assert_eq!(0.0, $mat3::zero().determinant());
+            assert_eq!(0.0, $mat3::ZERO.determinant());
             assert_eq!(1.0, $mat3::identity().determinant());
             assert_eq!(1.0, $mat3::from_rotation_x(deg(90.0)).determinant());
             assert_eq!(1.0, $mat3::from_rotation_y(deg(180.0)).determinant());
@@ -188,7 +188,7 @@ macro_rules! impl_mat3_tests {
 
         #[test]
         fn test_mat3_inverse() {
-            // assert_eq!(None, $mat3::zero().inverse());
+            // assert_eq!(None, $mat3::ZERO.inverse());
             let inv = $mat3::identity().inverse();
             // assert_ne!(None, inv);
             assert_approx_eq!($mat3::identity(), inv);
@@ -227,7 +227,7 @@ macro_rules! impl_mat3_tests {
             assert_eq!(m0x2, m0 * 2.0);
             assert_eq!(m0x2, 2.0 * m0);
             assert_eq!(m0x2, m0 + m0);
-            assert_eq!($mat3::zero(), m0 - m0);
+            assert_eq!($mat3::ZERO, m0 - m0);
             assert_approx_eq!(m0, m0 * $mat3::identity());
             assert_approx_eq!(m0, $mat3::identity() * m0);
         }

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -299,12 +299,12 @@ macro_rules! impl_mat4_tests {
             // identity
             let (out_scale, out_rotation, out_translation) =
                 $mat4::identity().to_scale_rotation_translation();
-            assert_approx_eq!($vec3::one(), out_scale);
+            assert_approx_eq!($vec3::ONE, out_scale);
             assert!(out_rotation.is_near_identity());
             assert_approx_eq!($vec3::ZERO, out_translation);
 
             // no scale
-            let in_scale = $vec3::one();
+            let in_scale = $vec3::ONE;
             let in_translation = $vec3::new(-2.0, 4.0, -0.125);
             let in_rotation = $quat::from_rotation_ypr(
                 $t::to_radians(-45.0),

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -19,7 +19,6 @@ macro_rules! impl_mat4_tests {
             [9.0, 10.0, 11.0, 12.0],
             [13.0, 14.0, 15.0, 16.0],
         ];
-        const ZERO: [[$t; 4]; 4] = [[0.0; 4]; 4];
 
         #[test]
         fn test_const() {
@@ -84,7 +83,6 @@ macro_rules! impl_mat4_tests {
                     0., 0., 0., 0., //
                 ])
             );
-            assert_eq!($mat4::from_cols_array_2d(&ZERO), $mat4::zero());
         }
 
         #[test]

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -34,7 +34,7 @@ macro_rules! impl_mat4_tests {
                 [9.0, 10.0, 11.0, 12.0],
                 [13.0, 14.0, 15.0, 16.0]
             );
-            assert_eq!($mat4::zero(), M0);
+            assert_eq!($mat4::ZERO, M0);
             assert_eq!(
                 $mat4::from_cols_array_2d(&[
                     [1.0, 2.0, 3.0, 4.0],
@@ -89,7 +89,7 @@ macro_rules! impl_mat4_tests {
 
         #[test]
         fn test_mat4_accessors() {
-            let mut m = $mat4::zero();
+            let mut m = $mat4::ZERO;
             m.x_axis = $vec4::new(1.0, 2.0, 3.0, 4.0);
             m.y_axis = $vec4::new(5.0, 6.0, 7.0, 8.0);
             m.z_axis = $vec4::new(9.0, 10.0, 11.0, 12.0);
@@ -246,7 +246,7 @@ macro_rules! impl_mat4_tests {
 
         #[test]
         fn test_mat4_det() {
-            assert_eq!(0.0, $mat4::zero().determinant());
+            assert_eq!(0.0, $mat4::ZERO.determinant());
             assert_eq!(1.0, $mat4::identity().determinant());
             assert_eq!(1.0, $mat4::from_rotation_x(deg(90.0)).determinant());
             assert_eq!(1.0, $mat4::from_rotation_y(deg(180.0)).determinant());
@@ -259,7 +259,7 @@ macro_rules! impl_mat4_tests {
 
         #[test]
         fn test_mat4_inverse() {
-            // assert_eq!(None, $mat4::zero().inverse());
+            // assert_eq!(None, $mat4::ZERO.inverse());
             let inv = $mat4::identity().inverse();
             // assert_ne!(None, inv);
             assert_approx_eq!($mat4::identity(), inv);
@@ -301,7 +301,7 @@ macro_rules! impl_mat4_tests {
                 $mat4::identity().to_scale_rotation_translation();
             assert_approx_eq!($vec3::one(), out_scale);
             assert!(out_rotation.is_near_identity());
-            assert_approx_eq!($vec3::zero(), out_translation);
+            assert_approx_eq!($vec3::ZERO, out_translation);
 
             // no scale
             let in_scale = $vec3::one();
@@ -517,7 +517,7 @@ macro_rules! impl_mat4_tests {
             assert_eq!(m0x2, m0 * 2.0);
             assert_eq!(m0x2, 2.0 * m0);
             assert_eq!(m0x2, m0 + m0);
-            assert_eq!($mat4::zero(), m0 - m0);
+            assert_eq!($mat4::ZERO, m0 - m0);
             assert_approx_eq!(m0, m0 * $mat4::identity());
             assert_approx_eq!(m0, $mat4::identity() * m0);
         }

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -66,7 +66,7 @@ macro_rules! impl_mat4_tests {
                     0., 0., 0., 1., //
                 ])
             );
-            let identity = $mat4::identity();
+            let identity = $mat4::IDENTITY;
             assert_eq!(IDENTITY, identity.to_cols_array_2d());
             assert_eq!($mat4::from_cols_array_2d(&IDENTITY), identity);
             assert_eq!(identity, identity * identity);
@@ -238,7 +238,7 @@ macro_rules! impl_mat4_tests {
         #[test]
         fn test_mat4_det() {
             assert_eq!(0.0, $mat4::ZERO.determinant());
-            assert_eq!(1.0, $mat4::identity().determinant());
+            assert_eq!(1.0, $mat4::IDENTITY.determinant());
             assert_eq!(1.0, $mat4::from_rotation_x(deg(90.0)).determinant());
             assert_eq!(1.0, $mat4::from_rotation_y(deg(180.0)).determinant());
             assert_eq!(1.0, $mat4::from_rotation_z(deg(270.0)).determinant());
@@ -251,37 +251,37 @@ macro_rules! impl_mat4_tests {
         #[test]
         fn test_mat4_inverse() {
             // assert_eq!(None, $mat4::ZERO.inverse());
-            let inv = $mat4::identity().inverse();
+            let inv = $mat4::IDENTITY.inverse();
             // assert_ne!(None, inv);
-            assert_approx_eq!($mat4::identity(), inv);
+            assert_approx_eq!($mat4::IDENTITY, inv);
 
             let rotz = $mat4::from_rotation_z(deg(90.0));
             let rotz_inv = rotz.inverse();
             // assert_ne!(None, rotz_inv);
             // let rotz_inv = rotz_inv.unwrap();
-            assert_approx_eq!($mat4::identity(), rotz * rotz_inv);
-            assert_approx_eq!($mat4::identity(), rotz_inv * rotz);
+            assert_approx_eq!($mat4::IDENTITY, rotz * rotz_inv);
+            assert_approx_eq!($mat4::IDENTITY, rotz_inv * rotz);
 
             let trans = $mat4::from_translation($newvec3(1.0, 2.0, 3.0));
             let trans_inv = trans.inverse();
             // assert_ne!(None, trans_inv);
             // let trans_inv = trans_inv.unwrap();
-            assert_approx_eq!($mat4::identity(), trans * trans_inv);
-            assert_approx_eq!($mat4::identity(), trans_inv * trans);
+            assert_approx_eq!($mat4::IDENTITY, trans * trans_inv);
+            assert_approx_eq!($mat4::IDENTITY, trans_inv * trans);
 
             let scale = $mat4::from_scale($newvec3(4.0, 5.0, 6.0));
             let scale_inv = scale.inverse();
             // assert_ne!(None, scale_inv);
             // let scale_inv = scale_inv.unwrap();
-            assert_approx_eq!($mat4::identity(), scale * scale_inv);
-            assert_approx_eq!($mat4::identity(), scale_inv * scale);
+            assert_approx_eq!($mat4::IDENTITY, scale * scale_inv);
+            assert_approx_eq!($mat4::IDENTITY, scale_inv * scale);
 
             let m = scale * rotz * trans;
             let m_inv = m.inverse();
             // assert_ne!(None, m_inv);
             // let m_inv = m_inv.unwrap();
-            assert_approx_eq!($mat4::identity(), m * m_inv, 1.0e-5);
-            assert_approx_eq!($mat4::identity(), m_inv * m, 1.0e-5);
+            assert_approx_eq!($mat4::IDENTITY, m * m_inv, 1.0e-5);
+            assert_approx_eq!($mat4::IDENTITY, m_inv * m, 1.0e-5);
             assert_approx_eq!(m_inv, trans_inv * rotz_inv * scale_inv, 1.0e-6);
         }
 
@@ -289,7 +289,7 @@ macro_rules! impl_mat4_tests {
         fn test_mat4_decompose() {
             // identity
             let (out_scale, out_rotation, out_translation) =
-                $mat4::identity().to_scale_rotation_translation();
+                $mat4::IDENTITY.to_scale_rotation_translation();
             assert_approx_eq!($vec3::ONE, out_scale);
             assert!(out_rotation.is_near_identity());
             assert_approx_eq!($vec3::ZERO, out_translation);
@@ -509,8 +509,8 @@ macro_rules! impl_mat4_tests {
             assert_eq!(m0x2, 2.0 * m0);
             assert_eq!(m0x2, m0 + m0);
             assert_eq!($mat4::ZERO, m0 - m0);
-            assert_approx_eq!(m0, m0 * $mat4::identity());
-            assert_approx_eq!(m0, $mat4::identity() * m0);
+            assert_approx_eq!(m0, m0 * $mat4::IDENTITY);
+            assert_approx_eq!(m0, $mat4::IDENTITY * m0);
         }
 
         #[test]
@@ -525,23 +525,23 @@ macro_rules! impl_mat4_tests {
         #[cfg(feature = "std")]
         #[test]
         fn test_sum() {
-            let id = $mat4::identity();
+            let id = $mat4::IDENTITY;
             assert_eq!(vec![id, id].iter().sum::<$mat4>(), id + id);
         }
 
         #[cfg(feature = "std")]
         #[test]
         fn test_product() {
-            let two = $mat4::identity() + $mat4::identity();
+            let two = $mat4::IDENTITY + $mat4::IDENTITY;
             assert_eq!(vec![two, two].iter().product::<$mat4>(), two * two);
         }
 
         #[test]
         fn test_mat4_is_finite() {
-            assert!($mat4::identity().is_finite());
-            assert!(!($mat4::identity() * INFINITY).is_finite());
-            assert!(!($mat4::identity() * NEG_INFINITY).is_finite());
-            assert!(!($mat4::identity() * NAN).is_finite());
+            assert!($mat4::IDENTITY.is_finite());
+            assert!(!($mat4::IDENTITY * INFINITY).is_finite());
+            assert!(!($mat4::IDENTITY * NEG_INFINITY).is_finite());
+            assert!(!($mat4::IDENTITY * NAN).is_finite());
         }
     };
 }

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -57,6 +57,15 @@ macro_rules! impl_mat4_tests {
 
         #[test]
         fn test_mat4_identity() {
+            assert_eq!(
+                $mat4::IDENTITY,
+                $mat4::from_cols_array(&[
+                    1., 0., 0., 0., //
+                    0., 1., 0., 0., //
+                    0., 0., 1., 0., //
+                    0., 0., 0., 1., //
+                ])
+            );
             let identity = $mat4::identity();
             assert_eq!(IDENTITY, identity.to_cols_array_2d());
             assert_eq!($mat4::from_cols_array_2d(&IDENTITY), identity);
@@ -66,6 +75,15 @@ macro_rules! impl_mat4_tests {
 
         #[test]
         fn test_mat4_zero() {
+            assert_eq!(
+                $mat4::ZERO,
+                $mat4::from_cols_array(&[
+                    0., 0., 0., 0., //
+                    0., 0., 0., 0., //
+                    0., 0., 0., 0., //
+                    0., 0., 0., 0., //
+                ])
+            );
             assert_eq!($mat4::from_cols_array_2d(&ZERO), $mat4::zero());
         }
 

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -146,47 +146,38 @@ macro_rules! impl_mat4_tests {
         #[test]
         fn test_from_rotation() {
             let rot_x1 = $mat4::from_rotation_x(deg(180.0));
-            let rot_x2 = $mat4::from_axis_angle($vec3::unit_x(), deg(180.0));
+            let rot_x2 = $mat4::from_axis_angle($vec3::X, deg(180.0));
             assert_approx_eq!(rot_x1, rot_x2);
             let rot_y1 = $mat4::from_rotation_y(deg(180.0));
-            let rot_y2 = $mat4::from_axis_angle($vec3::unit_y(), deg(180.0));
+            let rot_y2 = $mat4::from_axis_angle($vec3::Y, deg(180.0));
             assert_approx_eq!(rot_y1, rot_y2);
             let rot_z1 = $mat4::from_rotation_z(deg(180.0));
-            let rot_z2 = $mat4::from_axis_angle($vec3::unit_z(), deg(180.0));
+            let rot_z2 = $mat4::from_axis_angle($vec3::Z, deg(180.0));
             assert_approx_eq!(rot_z1, rot_z2);
         }
 
         #[test]
         fn test_mat4_mul() {
-            let mat_a = $mat4::from_axis_angle($vec3::unit_z(), deg(90.0));
-            let result3 = mat_a.transform_vector3($vec3::unit_y());
+            let mat_a = $mat4::from_axis_angle($vec3::Z, deg(90.0));
+            let result3 = mat_a.transform_vector3($vec3::Y);
             assert_approx_eq!($newvec3(-1.0, 0.0, 0.0), result3);
-            assert_approx_eq!(
-                result3,
-                (mat_a * $vec3::unit_y().extend(0.0)).truncate().into()
-            );
-            let result4 = mat_a * $vec4::unit_y();
+            assert_approx_eq!(result3, (mat_a * $vec3::Y.extend(0.0)).truncate().into());
+            let result4 = mat_a * $vec4::Y;
             assert_approx_eq!($newvec4(-1.0, 0.0, 0.0, 0.0), result4);
-            assert_approx_eq!(result4, mat_a * $vec4::unit_y());
+            assert_approx_eq!(result4, mat_a * $vec4::Y);
 
             let mat_b = $mat4::from_scale_rotation_translation(
                 $vec3::new(0.5, 1.5, 2.0),
                 $quat::from_rotation_x(deg(90.0)),
                 $vec3::new(1.0, 2.0, 3.0),
             );
-            let result3 = mat_b.transform_vector3($vec3::unit_y());
+            let result3 = mat_b.transform_vector3($vec3::Y);
             assert_approx_eq!($newvec3(0.0, 0.0, 1.5), result3, 1.0e-6);
-            assert_approx_eq!(
-                result3,
-                (mat_b * $vec3::unit_y().extend(0.0)).truncate().into()
-            );
+            assert_approx_eq!(result3, (mat_b * $vec3::Y.extend(0.0)).truncate().into());
 
-            let result3 = mat_b.transform_point3($vec3::unit_y());
+            let result3 = mat_b.transform_point3($vec3::Y);
             assert_approx_eq!($newvec3(1.0, 2.0, 4.5), result3, 1.0e-6);
-            assert_approx_eq!(
-                result3,
-                (mat_b * $vec3::unit_y().extend(1.0)).truncate().into()
-            );
+            assert_approx_eq!(result3, (mat_b * $vec3::Y.extend(1.0)).truncate().into());
         }
 
         #[test]
@@ -219,10 +210,10 @@ macro_rules! impl_mat4_tests {
         #[test]
         fn test_from_scale() {
             let m = $mat4::from_scale($vec3::new(2.0, 4.0, 8.0));
-            assert_approx_eq!($vec4::unit_x() * 2.0, m.x_axis);
-            assert_approx_eq!($vec4::unit_y() * 4.0, m.y_axis);
-            assert_approx_eq!($vec4::unit_z() * 8.0, m.z_axis);
-            assert_approx_eq!($vec4::unit_w(), m.w_axis);
+            assert_approx_eq!($vec4::X * 2.0, m.x_axis);
+            assert_approx_eq!($vec4::Y * 4.0, m.y_axis);
+            assert_approx_eq!($vec4::Z * 8.0, m.z_axis);
+            assert_approx_eq!($vec4::W, m.w_axis);
             assert_approx_eq!(
                 m.transform_point3($vec3::new(1.0, 1.0, 1.0)),
                 $vec3::new(2.0, 4.0, 8.0)

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -62,11 +62,11 @@ macro_rules! impl_quat_tests {
             let y0 = $quat::from_rotation_y(yaw);
             assert!(y0.is_normalized());
             let (axis, angle) = y0.to_axis_angle();
-            assert_approx_eq!(axis, $vec3::unit_y(), 1.0e-6);
+            assert_approx_eq!(axis, $vec3::Y, 1.0e-6);
             assert_approx_eq!(angle, yaw);
             let y1 = $quat::from_rotation_ypr(yaw, zero, zero);
             assert_approx_eq!(y0, y1);
-            let y2 = $quat::from_axis_angle($vec3::unit_y(), yaw);
+            let y2 = $quat::from_axis_angle($vec3::Y, yaw);
             assert_approx_eq!(y0, y2);
             let y3 = $quat::from_rotation_mat3(&$mat3::from_rotation_y(yaw));
             assert_approx_eq!(y0, y3);
@@ -76,11 +76,11 @@ macro_rules! impl_quat_tests {
             let x0 = $quat::from_rotation_x(pitch);
             assert!(x0.is_normalized());
             let (axis, angle) = x0.to_axis_angle();
-            assert_approx_eq!(axis, $vec3::unit_x());
+            assert_approx_eq!(axis, $vec3::X);
             assert_approx_eq!(angle, pitch);
             let x1 = $quat::from_rotation_ypr(zero, pitch, zero);
             assert_approx_eq!(x0, x1);
-            let x2 = $quat::from_axis_angle($vec3::unit_x(), pitch);
+            let x2 = $quat::from_axis_angle($vec3::X, pitch);
             assert_approx_eq!(x0, x2);
             let x3 = $quat::from_rotation_mat4(&$mat4::from_rotation_x(deg(180.0)));
             assert!(x3.is_normalized());
@@ -89,11 +89,11 @@ macro_rules! impl_quat_tests {
             let z0 = $quat::from_rotation_z(roll);
             assert!(z0.is_normalized());
             let (axis, angle) = z0.to_axis_angle();
-            assert_approx_eq!(axis, $vec3::unit_z());
+            assert_approx_eq!(axis, $vec3::Z);
             assert_approx_eq!(angle, roll);
             let z1 = $quat::from_rotation_ypr(zero, zero, roll);
             assert_approx_eq!(z0, z1);
-            let z2 = $quat::from_axis_angle($vec3::unit_z(), roll);
+            let z2 = $quat::from_axis_angle($vec3::Z, roll);
             assert_approx_eq!(z0, z2);
             let z3 = $quat::from_rotation_mat4(&$mat4::from_rotation_z(roll));
             assert_approx_eq!(z0, z3);
@@ -117,70 +117,70 @@ macro_rules! impl_quat_tests {
 
             // if near identity, just returns x axis and 0 rotation
             let (axis, angle) = $quat::identity().to_axis_angle();
-            assert_eq!(axis, $vec3::unit_x());
+            assert_eq!(axis, $vec3::X);
             assert_eq!(angle, rad(0.0));
         }
 
         #[test]
         fn test_mul_vec3() {
             let qrz = $quat::from_rotation_z(deg(90.0));
-            assert_approx_eq!($vec3::unit_y(), qrz * $vec3::unit_x());
-            assert_approx_eq!($vec3::unit_y(), qrz.mul_vec3($vec3::unit_x()));
-            assert_approx_eq!($vec3::unit_y(), -qrz * $vec3::unit_x());
-            assert_approx_eq!($vec3::unit_y(), qrz.neg().mul_vec3($vec3::unit_x()));
-            assert_approx_eq!(-$vec3::unit_x(), qrz * $vec3::unit_y());
-            assert_approx_eq!(-$vec3::unit_x(), qrz.mul_vec3($vec3::unit_y()));
-            assert_approx_eq!(-$vec3::unit_x(), -qrz * $vec3::unit_y());
-            assert_approx_eq!(-$vec3::unit_x(), qrz.neg().mul_vec3($vec3::unit_y()));
+            assert_approx_eq!($vec3::Y, qrz * $vec3::X);
+            assert_approx_eq!($vec3::Y, qrz.mul_vec3($vec3::X));
+            assert_approx_eq!($vec3::Y, -qrz * $vec3::X);
+            assert_approx_eq!($vec3::Y, qrz.neg().mul_vec3($vec3::X));
+            assert_approx_eq!(-$vec3::X, qrz * $vec3::Y);
+            assert_approx_eq!(-$vec3::X, qrz.mul_vec3($vec3::Y));
+            assert_approx_eq!(-$vec3::X, -qrz * $vec3::Y);
+            assert_approx_eq!(-$vec3::X, qrz.neg().mul_vec3($vec3::Y));
 
             // check vec3 * mat3 is the same
             let mrz = $mat3::from_quat(qrz);
-            assert_approx_eq!($vec3::unit_y(), mrz * $vec3::unit_x());
-            assert_approx_eq!($vec3::unit_y(), mrz.mul_vec3($vec3::unit_x()));
-            // assert_approx_eq!($vec3::unit_y(), -mrz * $vec3::unit_x());
-            assert_approx_eq!(-$vec3::unit_x(), mrz * $vec3::unit_y());
-            assert_approx_eq!(-$vec3::unit_x(), mrz.mul_vec3($vec3::unit_y()));
+            assert_approx_eq!($vec3::Y, mrz * $vec3::X);
+            assert_approx_eq!($vec3::Y, mrz.mul_vec3($vec3::X));
+            // assert_approx_eq!($vec3::Y, -mrz * $vec3::X);
+            assert_approx_eq!(-$vec3::X, mrz * $vec3::Y);
+            assert_approx_eq!(-$vec3::X, mrz.mul_vec3($vec3::Y));
 
             let qrx = $quat::from_rotation_x(deg(90.0));
-            assert_approx_eq!($vec3::unit_x(), qrx * $vec3::unit_x());
-            assert_approx_eq!($vec3::unit_x(), qrx.mul_vec3($vec3::unit_x()));
-            assert_approx_eq!($vec3::unit_x(), -qrx * $vec3::unit_x());
-            assert_approx_eq!($vec3::unit_x(), qrx.neg().mul_vec3($vec3::unit_x()));
-            assert_approx_eq!($vec3::unit_z(), qrx * $vec3::unit_y());
-            assert_approx_eq!($vec3::unit_z(), qrx.mul_vec3($vec3::unit_y()));
-            assert_approx_eq!($vec3::unit_z(), -qrx * $vec3::unit_y());
-            assert_approx_eq!($vec3::unit_z(), qrx.neg().mul_vec3($vec3::unit_y()));
+            assert_approx_eq!($vec3::X, qrx * $vec3::X);
+            assert_approx_eq!($vec3::X, qrx.mul_vec3($vec3::X));
+            assert_approx_eq!($vec3::X, -qrx * $vec3::X);
+            assert_approx_eq!($vec3::X, qrx.neg().mul_vec3($vec3::X));
+            assert_approx_eq!($vec3::Z, qrx * $vec3::Y);
+            assert_approx_eq!($vec3::Z, qrx.mul_vec3($vec3::Y));
+            assert_approx_eq!($vec3::Z, -qrx * $vec3::Y);
+            assert_approx_eq!($vec3::Z, qrx.neg().mul_vec3($vec3::Y));
 
             // check vec3 * mat3 is the same
             let mrx = $mat3::from_quat(qrx);
-            assert_approx_eq!($vec3::unit_x(), mrx * $vec3::unit_x());
-            assert_approx_eq!($vec3::unit_x(), mrx.mul_vec3($vec3::unit_x()));
-            assert_approx_eq!($vec3::unit_z(), mrx * $vec3::unit_y());
-            assert_approx_eq!($vec3::unit_z(), mrx.mul_vec3($vec3::unit_y()));
+            assert_approx_eq!($vec3::X, mrx * $vec3::X);
+            assert_approx_eq!($vec3::X, mrx.mul_vec3($vec3::X));
+            assert_approx_eq!($vec3::Z, mrx * $vec3::Y);
+            assert_approx_eq!($vec3::Z, mrx.mul_vec3($vec3::Y));
 
             let qrxz = qrz * qrx;
-            assert_approx_eq!($vec3::unit_y(), qrxz * $vec3::unit_x());
-            assert_approx_eq!($vec3::unit_y(), qrxz.mul_vec3($vec3::unit_x()));
-            assert_approx_eq!($vec3::unit_z(), qrxz * $vec3::unit_y());
-            assert_approx_eq!($vec3::unit_z(), qrxz.mul_vec3($vec3::unit_y()));
+            assert_approx_eq!($vec3::Y, qrxz * $vec3::X);
+            assert_approx_eq!($vec3::Y, qrxz.mul_vec3($vec3::X));
+            assert_approx_eq!($vec3::Z, qrxz * $vec3::Y);
+            assert_approx_eq!($vec3::Z, qrxz.mul_vec3($vec3::Y));
 
             let mrxz = mrz * mrx;
-            assert_approx_eq!($vec3::unit_y(), mrxz * $vec3::unit_x());
-            assert_approx_eq!($vec3::unit_y(), mrxz.mul_vec3($vec3::unit_x()));
-            assert_approx_eq!($vec3::unit_z(), mrxz * $vec3::unit_y());
-            assert_approx_eq!($vec3::unit_z(), mrxz.mul_vec3($vec3::unit_y()));
+            assert_approx_eq!($vec3::Y, mrxz * $vec3::X);
+            assert_approx_eq!($vec3::Y, mrxz.mul_vec3($vec3::X));
+            assert_approx_eq!($vec3::Z, mrxz * $vec3::Y);
+            assert_approx_eq!($vec3::Z, mrxz.mul_vec3($vec3::Y));
 
             let qrzx = qrx * qrz;
-            assert_approx_eq!($vec3::unit_z(), qrzx * $vec3::unit_x());
-            assert_approx_eq!($vec3::unit_z(), qrzx.mul_vec3($vec3::unit_x()));
-            assert_approx_eq!(-$vec3::unit_x(), qrzx * $vec3::unit_y());
-            assert_approx_eq!(-$vec3::unit_x(), qrzx.mul_vec3($vec3::unit_y()));
+            assert_approx_eq!($vec3::Z, qrzx * $vec3::X);
+            assert_approx_eq!($vec3::Z, qrzx.mul_vec3($vec3::X));
+            assert_approx_eq!(-$vec3::X, qrzx * $vec3::Y);
+            assert_approx_eq!(-$vec3::X, qrzx.mul_vec3($vec3::Y));
 
             let mrzx = qrx * qrz;
-            assert_approx_eq!($vec3::unit_z(), mrzx * $vec3::unit_x());
-            assert_approx_eq!($vec3::unit_z(), mrzx.mul_vec3($vec3::unit_x()));
-            assert_approx_eq!(-$vec3::unit_x(), mrzx * $vec3::unit_y());
-            assert_approx_eq!(-$vec3::unit_x(), mrzx.mul_vec3($vec3::unit_y()));
+            assert_approx_eq!($vec3::Z, mrzx * $vec3::X);
+            assert_approx_eq!($vec3::Z, mrzx.mul_vec3($vec3::X));
+            assert_approx_eq!(-$vec3::X, mrzx * $vec3::Y);
+            assert_approx_eq!(-$vec3::X, mrzx.mul_vec3($vec3::Y));
         }
         #[test]
         fn test_lerp() {
@@ -339,63 +339,63 @@ mod quat {
     #[test]
     fn test_mul_vec3a() {
         let qrz = Quat::from_rotation_z(deg(90.0));
-        assert_approx_eq!(Vec3A::unit_y(), qrz * Vec3A::unit_x());
-        assert_approx_eq!(Vec3A::unit_y(), qrz.mul_vec3a(Vec3A::unit_x()));
-        assert_approx_eq!(Vec3A::unit_y(), -qrz * Vec3A::unit_x());
-        assert_approx_eq!(Vec3A::unit_y(), qrz.neg().mul_vec3a(Vec3A::unit_x()));
-        assert_approx_eq!(-Vec3A::unit_x(), qrz * Vec3A::unit_y());
-        assert_approx_eq!(-Vec3A::unit_x(), qrz.mul_vec3a(Vec3A::unit_y()));
-        assert_approx_eq!(-Vec3A::unit_x(), -qrz * Vec3A::unit_y());
-        assert_approx_eq!(-Vec3A::unit_x(), qrz.neg().mul_vec3a(Vec3A::unit_y()));
+        assert_approx_eq!(Vec3A::Y, qrz * Vec3A::X);
+        assert_approx_eq!(Vec3A::Y, qrz.mul_vec3a(Vec3A::X));
+        assert_approx_eq!(Vec3A::Y, -qrz * Vec3A::X);
+        assert_approx_eq!(Vec3A::Y, qrz.neg().mul_vec3a(Vec3A::X));
+        assert_approx_eq!(-Vec3A::X, qrz * Vec3A::Y);
+        assert_approx_eq!(-Vec3A::X, qrz.mul_vec3a(Vec3A::Y));
+        assert_approx_eq!(-Vec3A::X, -qrz * Vec3A::Y);
+        assert_approx_eq!(-Vec3A::X, qrz.neg().mul_vec3a(Vec3A::Y));
 
         // check vec3 * mat3 is the same
         let mrz = Mat3::from_quat(qrz);
-        assert_approx_eq!(Vec3A::unit_y(), mrz * Vec3A::unit_x());
-        assert_approx_eq!(Vec3A::unit_y(), mrz.mul_vec3a(Vec3A::unit_x()));
-        // assert_approx_eq!(Vec3A::unit_y(), -mrz * Vec3A::unit_x());
-        assert_approx_eq!(-Vec3A::unit_x(), mrz * Vec3A::unit_y());
-        assert_approx_eq!(-Vec3A::unit_x(), mrz.mul_vec3a(Vec3A::unit_y()));
+        assert_approx_eq!(Vec3A::Y, mrz * Vec3A::X);
+        assert_approx_eq!(Vec3A::Y, mrz.mul_vec3a(Vec3A::X));
+        // assert_approx_eq!(Vec3A::Y, -mrz * Vec3A::X);
+        assert_approx_eq!(-Vec3A::X, mrz * Vec3A::Y);
+        assert_approx_eq!(-Vec3A::X, mrz.mul_vec3a(Vec3A::Y));
 
         let qrx = Quat::from_rotation_x(deg(90.0));
-        assert_approx_eq!(Vec3A::unit_x(), qrx * Vec3A::unit_x());
-        assert_approx_eq!(Vec3A::unit_x(), qrx.mul_vec3a(Vec3A::unit_x()));
-        assert_approx_eq!(Vec3A::unit_x(), -qrx * Vec3A::unit_x());
-        assert_approx_eq!(Vec3A::unit_x(), qrx.neg().mul_vec3a(Vec3A::unit_x()));
-        assert_approx_eq!(Vec3A::unit_z(), qrx * Vec3A::unit_y());
-        assert_approx_eq!(Vec3A::unit_z(), qrx.mul_vec3a(Vec3A::unit_y()));
-        assert_approx_eq!(Vec3A::unit_z(), -qrx * Vec3A::unit_y());
-        assert_approx_eq!(Vec3A::unit_z(), qrx.neg().mul_vec3a(Vec3A::unit_y()));
+        assert_approx_eq!(Vec3A::X, qrx * Vec3A::X);
+        assert_approx_eq!(Vec3A::X, qrx.mul_vec3a(Vec3A::X));
+        assert_approx_eq!(Vec3A::X, -qrx * Vec3A::X);
+        assert_approx_eq!(Vec3A::X, qrx.neg().mul_vec3a(Vec3A::X));
+        assert_approx_eq!(Vec3A::Z, qrx * Vec3A::Y);
+        assert_approx_eq!(Vec3A::Z, qrx.mul_vec3a(Vec3A::Y));
+        assert_approx_eq!(Vec3A::Z, -qrx * Vec3A::Y);
+        assert_approx_eq!(Vec3A::Z, qrx.neg().mul_vec3a(Vec3A::Y));
 
         // check vec3 * mat3 is the same
         let mrx = Mat3::from_quat(qrx);
-        assert_approx_eq!(Vec3A::unit_x(), mrx * Vec3A::unit_x());
-        assert_approx_eq!(Vec3A::unit_x(), mrx.mul_vec3a(Vec3A::unit_x()));
-        assert_approx_eq!(Vec3A::unit_z(), mrx * Vec3A::unit_y());
-        assert_approx_eq!(Vec3A::unit_z(), mrx.mul_vec3a(Vec3A::unit_y()));
+        assert_approx_eq!(Vec3A::X, mrx * Vec3A::X);
+        assert_approx_eq!(Vec3A::X, mrx.mul_vec3a(Vec3A::X));
+        assert_approx_eq!(Vec3A::Z, mrx * Vec3A::Y);
+        assert_approx_eq!(Vec3A::Z, mrx.mul_vec3a(Vec3A::Y));
 
         let qrxz = qrz * qrx;
-        assert_approx_eq!(Vec3A::unit_y(), qrxz * Vec3A::unit_x());
-        assert_approx_eq!(Vec3A::unit_y(), qrxz.mul_vec3a(Vec3A::unit_x()));
-        assert_approx_eq!(Vec3A::unit_z(), qrxz * Vec3A::unit_y());
-        assert_approx_eq!(Vec3A::unit_z(), qrxz.mul_vec3a(Vec3A::unit_y()));
+        assert_approx_eq!(Vec3A::Y, qrxz * Vec3A::X);
+        assert_approx_eq!(Vec3A::Y, qrxz.mul_vec3a(Vec3A::X));
+        assert_approx_eq!(Vec3A::Z, qrxz * Vec3A::Y);
+        assert_approx_eq!(Vec3A::Z, qrxz.mul_vec3a(Vec3A::Y));
 
         let mrxz = mrz * mrx;
-        assert_approx_eq!(Vec3A::unit_y(), mrxz * Vec3A::unit_x());
-        assert_approx_eq!(Vec3A::unit_y(), mrxz.mul_vec3a(Vec3A::unit_x()));
-        assert_approx_eq!(Vec3A::unit_z(), mrxz * Vec3A::unit_y());
-        assert_approx_eq!(Vec3A::unit_z(), mrxz.mul_vec3a(Vec3A::unit_y()));
+        assert_approx_eq!(Vec3A::Y, mrxz * Vec3A::X);
+        assert_approx_eq!(Vec3A::Y, mrxz.mul_vec3a(Vec3A::X));
+        assert_approx_eq!(Vec3A::Z, mrxz * Vec3A::Y);
+        assert_approx_eq!(Vec3A::Z, mrxz.mul_vec3a(Vec3A::Y));
 
         let qrzx = qrx * qrz;
-        assert_approx_eq!(Vec3A::unit_z(), qrzx * Vec3A::unit_x());
-        assert_approx_eq!(Vec3A::unit_z(), qrzx.mul_vec3a(Vec3A::unit_x()));
-        assert_approx_eq!(-Vec3A::unit_x(), qrzx * Vec3A::unit_y());
-        assert_approx_eq!(-Vec3A::unit_x(), qrzx.mul_vec3a(Vec3A::unit_y()));
+        assert_approx_eq!(Vec3A::Z, qrzx * Vec3A::X);
+        assert_approx_eq!(Vec3A::Z, qrzx.mul_vec3a(Vec3A::X));
+        assert_approx_eq!(-Vec3A::X, qrzx * Vec3A::Y);
+        assert_approx_eq!(-Vec3A::X, qrzx.mul_vec3a(Vec3A::Y));
 
         let mrzx = qrx * qrz;
-        assert_approx_eq!(Vec3A::unit_z(), mrzx * Vec3A::unit_x());
-        assert_approx_eq!(Vec3A::unit_z(), mrzx.mul_vec3a(Vec3A::unit_x()));
-        assert_approx_eq!(-Vec3A::unit_x(), mrzx * Vec3A::unit_y());
-        assert_approx_eq!(-Vec3A::unit_x(), mrzx.mul_vec3a(Vec3A::unit_y()));
+        assert_approx_eq!(Vec3A::Z, mrzx * Vec3A::X);
+        assert_approx_eq!(Vec3A::Z, mrzx.mul_vec3a(Vec3A::X));
+        assert_approx_eq!(-Vec3A::X, mrzx * Vec3A::Y);
+        assert_approx_eq!(-Vec3A::X, mrzx.mul_vec3a(Vec3A::Y));
     }
 
     #[test]

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -116,7 +116,7 @@ macro_rules! impl_quat_tests {
             assert_approx_eq!(yxz0, yxz2);
 
             // if near identity, just returns x axis and 0 rotation
-            let (axis, angle) = $quat::identity().to_axis_angle();
+            let (axis, angle) = $quat::IDENTITY.to_axis_angle();
             assert_eq!(axis, $vec3::X);
             assert_eq!(angle, rad(0.0));
         }
@@ -218,7 +218,7 @@ macro_rules! impl_quat_tests {
 
         #[test]
         fn test_fmt() {
-            let a = $quat::identity();
+            let a = $quat::IDENTITY;
             assert_eq!(
                 format!("{:?}", a),
                 format!("{}(0.0, 0.0, 0.0, 1.0)", stringify!($quat))
@@ -232,7 +232,7 @@ macro_rules! impl_quat_tests {
 
         #[test]
         fn test_identity() {
-            let identity = $quat::identity();
+            let identity = $quat::IDENTITY;
             assert!(identity.is_near_identity());
             assert!(identity.is_normalized());
             assert_eq!(identity, $quat::from_xyzw(0.0, 0.0, 0.0, 1.0));

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -8,19 +8,19 @@ mod transform {
 
     #[test]
     fn test_identity() {
-        let tr = TransformRT::identity();
-        assert_eq!(tr.rotation, Quat::identity());
+        let tr = TransformRT::IDENTITY;
+        assert_eq!(tr.rotation, Quat::IDENTITY);
         assert_eq!(tr.translation, Vec3::ZERO);
 
-        let srt = TransformSRT::identity();
+        let srt = TransformSRT::IDENTITY;
         assert_eq!(srt.scale, Vec3::ONE);
-        assert_eq!(srt.rotation, Quat::identity());
+        assert_eq!(srt.rotation, Quat::IDENTITY);
         assert_eq!(srt.translation, Vec3::ZERO);
 
         assert_eq!(srt, tr.into());
 
-        assert_eq!(TransformRT::identity(), TransformRT::default());
-        assert_eq!(TransformSRT::identity(), TransformSRT::default());
+        assert_eq!(TransformRT::IDENTITY, TransformRT::default());
+        assert_eq!(TransformSRT::IDENTITY, TransformSRT::default());
     }
 
     #[test]
@@ -57,11 +57,11 @@ mod transform {
         let v2 = inv_tr * v1;
         assert_approx_eq!(v0, v2);
 
-        assert_eq!(tr * TransformRT::identity(), tr);
-        assert_approx_eq!(tr * inv_tr, TransformRT::identity());
+        assert_eq!(tr * TransformRT::IDENTITY, tr);
+        assert_approx_eq!(tr * inv_tr, TransformRT::IDENTITY);
 
-        assert_eq!(tr * TransformSRT::identity(), TransformSRT::from(tr));
-        assert_eq!(TransformSRT::identity() * tr, TransformSRT::from(tr));
+        assert_eq!(tr * TransformSRT::IDENTITY, TransformSRT::from(tr));
+        assert_eq!(TransformSRT::IDENTITY * tr, TransformSRT::from(tr));
 
         let s = Vec3::splat(2.0);
         let r = Quat::from_rotation_y(180.0_f32.to_radians());
@@ -75,13 +75,13 @@ mod transform {
         let v2 = inv_srt * v1;
         assert_approx_eq!(v0, v2);
 
-        assert_eq!(srt * TransformSRT::identity(), srt);
-        assert_eq!(srt * inv_srt, TransformSRT::identity());
+        assert_eq!(srt * TransformSRT::IDENTITY, srt);
+        assert_eq!(srt * inv_srt, TransformSRT::IDENTITY);
 
         // negative scale mul test
         let s = Vec3::splat(-2.0);
         let srt = TransformSRT::from_scale_rotation_translation(s, r, t);
         let inv_srt = srt.inverse();
-        assert_eq!(srt * inv_srt, TransformSRT::identity());
+        assert_eq!(srt * inv_srt, TransformSRT::IDENTITY);
     }
 }

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -47,11 +47,11 @@ mod transform {
     fn test_mul() {
         let tr = TransformRT::from_rotation_translation(
             Quat::from_rotation_z(-90.0_f32.to_radians()),
-            Vec3::unit_x(),
+            Vec3::X,
         );
-        let v0 = Vec3::unit_y();
+        let v0 = Vec3::Y;
         let v1 = tr * v0;
-        assert_approx_eq!(v1, Vec3::unit_x() * 2.0);
+        assert_approx_eq!(v1, Vec3::X * 2.0);
         assert_approx_eq!(v1, tr * v0);
         let inv_tr = tr.inverse();
         let v2 = inv_tr * v1;
@@ -65,9 +65,9 @@ mod transform {
 
         let s = Vec3::splat(2.0);
         let r = Quat::from_rotation_y(180.0_f32.to_radians());
-        let t = -Vec3::unit_y();
+        let t = -Vec3::Y;
         let srt = TransformSRT::from_scale_rotation_translation(s, r, t);
-        let v0 = Vec3::unit_x();
+        let v0 = Vec3::X;
         let v1 = srt * v0;
         assert_approx_eq!(v1, (r * (v0 * s)) + t);
         assert_approx_eq!(v1, srt * v0);

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -10,12 +10,12 @@ mod transform {
     fn test_identity() {
         let tr = TransformRT::identity();
         assert_eq!(tr.rotation, Quat::identity());
-        assert_eq!(tr.translation, Vec3::zero());
+        assert_eq!(tr.translation, Vec3::ZERO);
 
         let srt = TransformSRT::identity();
         assert_eq!(srt.scale, Vec3::one());
         assert_eq!(srt.rotation, Quat::identity());
-        assert_eq!(srt.translation, Vec3::zero());
+        assert_eq!(srt.translation, Vec3::ZERO);
 
         assert_eq!(srt, tr.into());
 

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -13,7 +13,7 @@ mod transform {
         assert_eq!(tr.translation, Vec3::ZERO);
 
         let srt = TransformSRT::identity();
-        assert_eq!(srt.scale, Vec3::one());
+        assert_eq!(srt.scale, Vec3::ONE);
         assert_eq!(srt.rotation, Quat::identity());
         assert_eq!(srt.translation, Vec3::ZERO);
 

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -28,8 +28,8 @@ macro_rules! impl_vec2_tests {
             let v = $vec2::new(t.0, t.1);
             assert_eq!(t, v.into());
 
-            assert_eq!($vec2::new(1 as $t, 0 as $t), $vec2::unit_x());
-            assert_eq!($vec2::new(0 as $t, 1 as $t), $vec2::unit_y());
+            assert_eq!($vec2::new(1 as $t, 0 as $t), $vec2::X);
+            assert_eq!($vec2::new(0 as $t, 1 as $t), $vec2::Y);
         }
 
         #[test]

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -413,6 +413,7 @@ macro_rules! impl_vec2_float_tests {
 
         #[test]
         fn test_vec2_consts() {
+            assert_eq!($vec2::ZERO, $new(0 as $t, 0 as $t));
             assert_eq!($vec2::X, $new(1 as $t, 0 as $t));
             assert_eq!($vec2::Y, $new(0 as $t, 1 as $t));
         }

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -45,7 +45,7 @@ macro_rules! impl_vec2_tests {
 
         #[test]
         fn test_zero() {
-            let v = $vec2::zero();
+            let v = $vec2::ZERO;
             assert_eq!($new(0 as $t, 0 as $t), v);
             assert_eq!(v, $vec2::default());
         }
@@ -58,14 +58,14 @@ macro_rules! impl_vec2_tests {
 
         #[test]
         fn test_accessors() {
-            let mut a = $vec2::zero();
+            let mut a = $vec2::ZERO;
             a.x = 1 as $t;
             a.y = 2 as $t;
             assert_eq!(1 as $t, a.x);
             assert_eq!(2 as $t, a.y);
             assert_eq!($vec2::new(1 as $t, 2 as $t), a);
 
-            let mut a = $vec2::zero();
+            let mut a = $vec2::ZERO;
             a[0] = 1 as $t;
             a[1] = 2 as $t;
             assert_eq!(1 as $t, a[0]);
@@ -178,11 +178,11 @@ macro_rules! impl_vec2_tests {
         #[test]
         fn test_vec2mask() {
             // make sure the unused 'z' value doesn't break $vec2 behaviour
-            let a = $vec3::zero();
+            let a = $vec3::ZERO;
             let mut b = a.truncate();
             b.x = 1 as $t;
             b.y = 1 as $t;
-            assert!(!b.cmpeq($vec2::zero()).any());
+            assert!(!b.cmpeq($vec2::ZERO).any());
             assert!(b.cmpeq($vec2::splat(1 as $t)).all());
         }
 
@@ -468,8 +468,8 @@ macro_rules! impl_vec2_float_tests {
 
         #[test]
         fn test_sign() {
-            assert_eq!($vec2::zero().signum(), $vec2::one());
-            assert_eq!(-$vec2::zero().signum(), -$vec2::one());
+            assert_eq!($vec2::ZERO.signum(), $vec2::one());
+            assert_eq!(-$vec2::ZERO.signum(), -$vec2::one());
             assert_eq!($vec2::one().signum(), $vec2::one());
             assert_eq!((-$vec2::one()).signum(), -$vec2::one());
             assert_eq!($vec2::splat(INFINITY).signum(), $vec2::one());
@@ -479,7 +479,7 @@ macro_rules! impl_vec2_float_tests {
 
         #[test]
         fn test_abs() {
-            assert_eq!($vec2::zero().abs(), $vec2::zero());
+            assert_eq!($vec2::ZERO.abs(), $vec2::ZERO);
             assert_eq!($vec2::one().abs(), $vec2::one());
             assert_eq!((-$vec2::one()).abs(), $vec2::one());
         }
@@ -534,7 +534,7 @@ macro_rules! impl_vec2_float_tests {
             let v1 = $vec2::new(1.0, 1.0);
             assert_approx_eq!(v0, v0.lerp(v1, 0.0));
             assert_approx_eq!(v1, v0.lerp(v1, 1.0));
-            assert_approx_eq!($vec2::zero(), v0.lerp(v1, 0.5));
+            assert_approx_eq!($vec2::ZERO, v0.lerp(v1, 0.5));
         }
 
         #[test]

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -414,6 +414,7 @@ macro_rules! impl_vec2_float_tests {
         #[test]
         fn test_vec2_consts() {
             assert_eq!($vec2::ZERO, $new(0 as $t, 0 as $t));
+            assert_eq!($vec2::ONE, $new(1 as $t, 1 as $t));
             assert_eq!($vec2::X, $new(1 as $t, 0 as $t));
             assert_eq!($vec2::Y, $new(0 as $t, 1 as $t));
         }

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -53,7 +53,7 @@ macro_rules! impl_vec2_tests {
         #[test]
         fn test_splat() {
             let v = $vec2::splat(1 as $t);
-            assert_eq!($vec2::one(), v);
+            assert_eq!($vec2::ONE, v);
         }
 
         #[test]
@@ -369,7 +369,7 @@ macro_rules! impl_vec2_tests {
         #[cfg(feature = "std")]
         #[test]
         fn test_sum() {
-            let one = $vec2::one();
+            let one = $vec2::ONE;
             assert_eq!(vec![one, one].iter().sum::<$vec2>(), one + one);
         }
 
@@ -468,20 +468,20 @@ macro_rules! impl_vec2_float_tests {
 
         #[test]
         fn test_sign() {
-            assert_eq!($vec2::ZERO.signum(), $vec2::one());
-            assert_eq!(-$vec2::ZERO.signum(), -$vec2::one());
-            assert_eq!($vec2::one().signum(), $vec2::one());
-            assert_eq!((-$vec2::one()).signum(), -$vec2::one());
-            assert_eq!($vec2::splat(INFINITY).signum(), $vec2::one());
-            assert_eq!($vec2::splat(NEG_INFINITY).signum(), -$vec2::one());
+            assert_eq!($vec2::ZERO.signum(), $vec2::ONE);
+            assert_eq!(-$vec2::ZERO.signum(), -$vec2::ONE);
+            assert_eq!($vec2::ONE.signum(), $vec2::ONE);
+            assert_eq!((-$vec2::ONE).signum(), -$vec2::ONE);
+            assert_eq!($vec2::splat(INFINITY).signum(), $vec2::ONE);
+            assert_eq!($vec2::splat(NEG_INFINITY).signum(), -$vec2::ONE);
             assert!($vec2::splat(NAN).signum().is_nan_mask().all());
         }
 
         #[test]
         fn test_abs() {
             assert_eq!($vec2::ZERO.abs(), $vec2::ZERO);
-            assert_eq!($vec2::one().abs(), $vec2::one());
-            assert_eq!((-$vec2::one()).abs(), $vec2::one());
+            assert_eq!($vec2::ONE.abs(), $vec2::ONE);
+            assert_eq!((-$vec2::ONE).abs(), $vec2::ONE);
         }
 
         #[test]

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -29,9 +29,9 @@ macro_rules! impl_vec3_tests {
             let v = $vec3::new(t.0, t.1, t.2);
             assert_eq!(t, v.into());
 
-            assert_eq!($vec3::new(1 as $t, 0 as $t, 0 as $t), $vec3::unit_x());
-            assert_eq!($vec3::new(0 as $t, 1 as $t, 0 as $t), $vec3::unit_y());
-            assert_eq!($vec3::new(0 as $t, 0 as $t, 1 as $t), $vec3::unit_z());
+            assert_eq!($vec3::new(1 as $t, 0 as $t, 0 as $t), $vec3::X);
+            assert_eq!($vec3::new(0 as $t, 1 as $t, 0 as $t), $vec3::Y);
+            assert_eq!($vec3::new(0 as $t, 0 as $t, 1 as $t), $vec3::Z);
         }
 
         #[test]

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -47,7 +47,7 @@ macro_rules! impl_vec3_tests {
 
         #[test]
         fn test_zero() {
-            let v = $vec3::zero();
+            let v = $vec3::ZERO;
             assert_eq!((0 as $t, 0 as $t, 0 as $t), v.into());
             assert_eq!(v, $vec3::default());
         }
@@ -60,7 +60,7 @@ macro_rules! impl_vec3_tests {
 
         #[test]
         fn test_accessors() {
-            let mut a = $vec3::zero();
+            let mut a = $vec3::ZERO;
             a.x = 1 as $t;
             a.y = 2 as $t;
             a.z = 3 as $t;
@@ -69,7 +69,7 @@ macro_rules! impl_vec3_tests {
             assert_eq!(3 as $t, a.z);
             assert_eq!((1 as $t, 2 as $t, 3 as $t), a.into());
 
-            let mut a = $vec3::zero();
+            let mut a = $vec3::ZERO;
             a[0] = 1 as $t;
             a[1] = 2 as $t;
             a[2] = 3 as $t;
@@ -195,11 +195,11 @@ macro_rules! impl_vec3_tests {
 
         #[test]
         fn test_mask() {
-            let mut a = $vec3::zero();
+            let mut a = $vec3::ZERO;
             a.x = 1 as $t;
             a.y = 1 as $t;
             a.z = 1 as $t;
-            assert!(!a.cmpeq($vec3::zero()).any());
+            assert!(!a.cmpeq($vec3::ZERO).any());
             assert!(a.cmpeq($vec3::one()).all());
         }
 
@@ -510,8 +510,8 @@ macro_rules! impl_vec3_float_tests {
 
         #[test]
         fn test_signum() {
-            assert_eq!($vec3::zero().signum(), $vec3::one());
-            assert_eq!(-$vec3::zero().signum(), -$vec3::one());
+            assert_eq!($vec3::ZERO.signum(), $vec3::one());
+            assert_eq!(-$vec3::ZERO.signum(), -$vec3::one());
             assert_eq!($vec3::one().signum(), $vec3::one());
             assert_eq!((-$vec3::one()).signum(), -$vec3::one());
             assert_eq!($vec3::splat(INFINITY).signum(), $vec3::one());
@@ -521,7 +521,7 @@ macro_rules! impl_vec3_float_tests {
 
         #[test]
         fn test_abs() {
-            assert_eq!($vec3::zero().abs(), $vec3::zero());
+            assert_eq!($vec3::ZERO.abs(), $vec3::ZERO);
             assert_eq!($vec3::one().abs(), $vec3::one());
             assert_eq!((-$vec3::one()).abs(), $vec3::one());
         }
@@ -582,7 +582,7 @@ macro_rules! impl_vec3_float_tests {
             let v1 = $vec3::new(1.0, 1.0, 1.0);
             assert_approx_eq!(v0, v0.lerp(v1, 0.0));
             assert_approx_eq!(v1, v0.lerp(v1, 1.0));
-            assert_approx_eq!($vec3::zero(), v0.lerp(v1, 0.5));
+            assert_approx_eq!($vec3::ZERO, v0.lerp(v1, 0.5));
         }
         #[test]
         fn test_is_finite() {
@@ -749,12 +749,12 @@ mod vec3a {
     #[test]
     fn test_mask_align16() {
         // make sure the unused 'w' value doesn't break Vec3Ab behaviour
-        let a = Vec4::zero();
+        let a = Vec4::ZERO;
         let mut b = Vec3A::from(a);
         b.x = 1.0;
         b.y = 1.0;
         b.z = 1.0;
-        assert!(!b.cmpeq(Vec3A::zero()).any());
+        assert!(!b.cmpeq(Vec3A::ZERO).any());
         assert!(b.cmpeq(Vec3A::splat(1.0)).all());
     }
 

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -55,7 +55,7 @@ macro_rules! impl_vec3_tests {
         #[test]
         fn test_splat() {
             let v = $vec3::splat(1 as $t);
-            assert_eq!($vec3::one(), v);
+            assert_eq!($vec3::ONE, v);
         }
 
         #[test]
@@ -200,7 +200,7 @@ macro_rules! impl_vec3_tests {
             a.y = 1 as $t;
             a.z = 1 as $t;
             assert!(!a.cmpeq($vec3::ZERO).any());
-            assert!(a.cmpeq($vec3::one()).all());
+            assert!(a.cmpeq($vec3::ONE).all());
         }
 
         // #[test]
@@ -413,7 +413,7 @@ macro_rules! impl_vec3_tests {
         #[cfg(feature = "std")]
         #[test]
         fn test_sum() {
-            let one = $vec3::one();
+            let one = $vec3::ONE;
             assert_eq!(vec![one, one].iter().sum::<$vec3>(), one + one);
         }
 
@@ -510,20 +510,20 @@ macro_rules! impl_vec3_float_tests {
 
         #[test]
         fn test_signum() {
-            assert_eq!($vec3::ZERO.signum(), $vec3::one());
-            assert_eq!(-$vec3::ZERO.signum(), -$vec3::one());
-            assert_eq!($vec3::one().signum(), $vec3::one());
-            assert_eq!((-$vec3::one()).signum(), -$vec3::one());
-            assert_eq!($vec3::splat(INFINITY).signum(), $vec3::one());
-            assert_eq!($vec3::splat(NEG_INFINITY).signum(), -$vec3::one());
+            assert_eq!($vec3::ZERO.signum(), $vec3::ONE);
+            assert_eq!(-$vec3::ZERO.signum(), -$vec3::ONE);
+            assert_eq!($vec3::ONE.signum(), $vec3::ONE);
+            assert_eq!((-$vec3::ONE).signum(), -$vec3::ONE);
+            assert_eq!($vec3::splat(INFINITY).signum(), $vec3::ONE);
+            assert_eq!($vec3::splat(NEG_INFINITY).signum(), -$vec3::ONE);
             assert!($vec3::splat(NAN).signum().is_nan_mask().all());
         }
 
         #[test]
         fn test_abs() {
             assert_eq!($vec3::ZERO.abs(), $vec3::ZERO);
-            assert_eq!($vec3::one().abs(), $vec3::one());
-            assert_eq!((-$vec3::one()).abs(), $vec3::one());
+            assert_eq!($vec3::ONE.abs(), $vec3::ONE);
+            assert_eq!((-$vec3::ONE).abs(), $vec3::ONE);
         }
 
         #[test]

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -458,6 +458,7 @@ macro_rules! impl_vec3_float_tests {
 
         #[test]
         fn test_vec3_consts() {
+            assert_eq!($vec3::ZERO, $new(0 as $t, 0 as $t, 0 as $t));
             assert_eq!($vec3::X, $new(1 as $t, 0 as $t, 0 as $t));
             assert_eq!($vec3::Y, $new(0 as $t, 1 as $t, 0 as $t));
             assert_eq!($vec3::Z, $new(0 as $t, 0 as $t, 1 as $t));

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -459,6 +459,7 @@ macro_rules! impl_vec3_float_tests {
         #[test]
         fn test_vec3_consts() {
             assert_eq!($vec3::ZERO, $new(0 as $t, 0 as $t, 0 as $t));
+            assert_eq!($vec3::ONE, $new(1 as $t, 1 as $t, 1 as $t));
             assert_eq!($vec3::X, $new(1 as $t, 0 as $t, 0 as $t));
             assert_eq!($vec3::Y, $new(0 as $t, 1 as $t, 0 as $t));
             assert_eq!($vec3::Z, $new(0 as $t, 0 as $t, 1 as $t));

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -40,22 +40,10 @@ macro_rules! impl_vec4_tests {
             let v = $vec4::new(t.0, t.1, t.2, t.3);
             assert_eq!(t, v.into());
 
-            assert_eq!(
-                $vec4::new(1 as $t, 0 as $t, 0 as $t, 0 as $t),
-                $vec4::unit_x()
-            );
-            assert_eq!(
-                $vec4::new(0 as $t, 1 as $t, 0 as $t, 0 as $t),
-                $vec4::unit_y()
-            );
-            assert_eq!(
-                $vec4::new(0 as $t, 0 as $t, 1 as $t, 0 as $t),
-                $vec4::unit_z()
-            );
-            assert_eq!(
-                $vec4::new(0 as $t, 0 as $t, 0 as $t, 1 as $t),
-                $vec4::unit_w()
-            );
+            assert_eq!($vec4::new(1 as $t, 0 as $t, 0 as $t, 0 as $t), $vec4::X);
+            assert_eq!($vec4::new(0 as $t, 1 as $t, 0 as $t, 0 as $t), $vec4::Y);
+            assert_eq!($vec4::new(0 as $t, 0 as $t, 1 as $t, 0 as $t), $vec4::Z);
+            assert_eq!($vec4::new(0 as $t, 0 as $t, 0 as $t, 1 as $t), $vec4::W);
         }
 
         #[test]

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -89,7 +89,7 @@ macro_rules! impl_vec4_tests {
         #[test]
         fn test_splat() {
             let v = $vec4::splat(1 as $t);
-            assert_eq!($vec4::one(), v);
+            assert_eq!($vec4::ONE, v);
         }
 
         #[test]
@@ -479,7 +479,7 @@ macro_rules! impl_vec4_tests {
         #[cfg(feature = "std")]
         #[test]
         fn test_sum() {
-            let one = $vec4::one();
+            let one = $vec4::ONE;
             assert_eq!(vec![one, one].iter().sum::<$vec4>(), one + one);
         }
 
@@ -574,20 +574,20 @@ macro_rules! impl_vec4_float_tests {
 
         #[test]
         fn test_signum() {
-            assert_eq!($vec4::ZERO.signum(), $vec4::one());
-            assert_eq!(-$vec4::ZERO.signum(), -$vec4::one());
-            assert_eq!($vec4::one().signum(), $vec4::one());
-            assert_eq!((-$vec4::one()).signum(), -$vec4::one());
-            assert_eq!($vec4::splat(INFINITY).signum(), $vec4::one());
-            assert_eq!($vec4::splat(NEG_INFINITY).signum(), -$vec4::one());
+            assert_eq!($vec4::ZERO.signum(), $vec4::ONE);
+            assert_eq!(-$vec4::ZERO.signum(), -$vec4::ONE);
+            assert_eq!($vec4::ONE.signum(), $vec4::ONE);
+            assert_eq!((-$vec4::ONE).signum(), -$vec4::ONE);
+            assert_eq!($vec4::splat(INFINITY).signum(), $vec4::ONE);
+            assert_eq!($vec4::splat(NEG_INFINITY).signum(), -$vec4::ONE);
             assert!($vec4::splat(NAN).signum().is_nan_mask().all());
         }
 
         #[test]
         fn test_abs() {
             assert_eq!($vec4::ZERO.abs(), $vec4::ZERO);
-            assert_eq!($vec4::one().abs(), $vec4::one());
-            assert_eq!((-$vec4::one()).abs(), $vec4::one());
+            assert_eq!($vec4::ONE.abs(), $vec4::ONE);
+            assert_eq!((-$vec4::ONE).abs(), $vec4::ONE);
         }
 
         #[test]

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -11,6 +11,7 @@ macro_rules! impl_vec4_tests {
 
         #[test]
         fn test_vec4_consts() {
+            assert_eq!($vec4::ZERO, $new(0 as $t, 0 as $t, 0 as $t, 0 as $t));
             assert_eq!($vec4::X, $new(1 as $t, 0 as $t, 0 as $t, 0 as $t));
             assert_eq!($vec4::Y, $new(0 as $t, 1 as $t, 0 as $t, 0 as $t));
             assert_eq!($vec4::Z, $new(0 as $t, 0 as $t, 1 as $t, 0 as $t));

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -81,7 +81,7 @@ macro_rules! impl_vec4_tests {
 
         #[test]
         fn test_zero() {
-            let v = $vec4::zero();
+            let v = $vec4::ZERO;
             assert_eq!((0 as $t, 0 as $t, 0 as $t, 0 as $t), v.into());
             assert_eq!(v, $vec4::default());
         }
@@ -94,7 +94,7 @@ macro_rules! impl_vec4_tests {
 
         #[test]
         fn test_accessors() {
-            let mut a = $vec4::zero();
+            let mut a = $vec4::ZERO;
             a.x = 1 as $t;
             a.y = 2 as $t;
             a.z = 3 as $t;
@@ -105,7 +105,7 @@ macro_rules! impl_vec4_tests {
             assert_eq!(4 as $t, a.w);
             assert_eq!((1 as $t, 2 as $t, 3 as $t, 4 as $t), a.into());
 
-            let mut a = $vec4::zero();
+            let mut a = $vec4::ZERO;
             a[0] = 1 as $t;
             a[1] = 2 as $t;
             a[2] = 3 as $t;
@@ -574,8 +574,8 @@ macro_rules! impl_vec4_float_tests {
 
         #[test]
         fn test_signum() {
-            assert_eq!($vec4::zero().signum(), $vec4::one());
-            assert_eq!(-$vec4::zero().signum(), -$vec4::one());
+            assert_eq!($vec4::ZERO.signum(), $vec4::one());
+            assert_eq!(-$vec4::ZERO.signum(), -$vec4::one());
             assert_eq!($vec4::one().signum(), $vec4::one());
             assert_eq!((-$vec4::one()).signum(), -$vec4::one());
             assert_eq!($vec4::splat(INFINITY).signum(), $vec4::one());
@@ -585,7 +585,7 @@ macro_rules! impl_vec4_float_tests {
 
         #[test]
         fn test_abs() {
-            assert_eq!($vec4::zero().abs(), $vec4::zero());
+            assert_eq!($vec4::ZERO.abs(), $vec4::ZERO);
             assert_eq!($vec4::one().abs(), $vec4::one());
             assert_eq!((-$vec4::one()).abs(), $vec4::one());
         }
@@ -646,7 +646,7 @@ macro_rules! impl_vec4_float_tests {
             let v1 = $vec4::new(1.0, 1.0, 1.0, 1.0);
             assert_approx_eq!(v0, v0.lerp(v1, 0.0));
             assert_approx_eq!(v1, v0.lerp(v1, 1.0));
-            assert_approx_eq!($vec4::zero(), v0.lerp(v1, 0.5));
+            assert_approx_eq!($vec4::ZERO, v0.lerp(v1, 0.5));
         }
 
         #[test]

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -12,6 +12,7 @@ macro_rules! impl_vec4_tests {
         #[test]
         fn test_vec4_consts() {
             assert_eq!($vec4::ZERO, $new(0 as $t, 0 as $t, 0 as $t, 0 as $t));
+            assert_eq!($vec4::ONE, $new(1 as $t, 1 as $t, 1 as $t, 1 as $t));
             assert_eq!($vec4::X, $new(1 as $t, 0 as $t, 0 as $t, 0 as $t));
             assert_eq!($vec4::Y, $new(0 as $t, 1 as $t, 0 as $t, 0 as $t));
             assert_eq!($vec4::Z, $new(0 as $t, 0 as $t, 1 as $t, 0 as $t));


### PR DESCRIPTION
Add constants for `ZERO` for vectors and matrices, `ONE` for vectors, and `IDENTITY` for matrices and quaternions.

Deprecates the old `zero()`, `one()` and `identity()` functions.

This is a continuation of https://github.com/bitshifter/glam-rs/pull/120 and especially https://github.com/bitshifter/glam-rs/pull/120#issuecomment-761885989

I omited `ZERO` for quaternion because there were no `zero()` function, and also because I think there is less use for it (most uses of quaternions keep them normalized), which is probably why there was no `zero()` function.

Let me know if you think it is too early to add deprecation notices!