### PR TITLE
Add Vec::normalize_or_zero()

### DIFF
--- a/benches/vec3.rs
+++ b/benches/vec3.rs
@@ -97,6 +97,30 @@ op => vec3_into_tuple,
 from => random_vec3
 );
 
+#[inline]
+fn vec3_normalize(v: Vec3) -> Vec3 {
+    v.normalize()
+}
+
+bench_func!(
+    vec3_normalize_bench,
+    "vec3 normalize",
+    op => vec3_normalize,
+    from => random_vec3
+);
+
+#[inline]
+fn vec3_normalize_or_zero(v: Vec3) -> Vec3 {
+    v.normalize_or_zero()
+}
+
+bench_func!(
+    vec3_normalize_or_zero_bench,
+    "vec3 normalize_or_zero",
+    op => vec3_normalize_or_zero,
+    from => random_vec3
+);
+
 euler!(vec3_euler, "vec3 euler", ty => Vec3, storage => Vec3, zero => Vec3::ZERO, rand => random_vec3);
 
 bench_binop!(
@@ -123,6 +147,8 @@ criterion_group!(
     quat_mul_vec3,
     vec3_add_vec3,
     vec3_angle_between,
+    vec3_normalize_bench,
+    vec3_normalize_or_zero_bench,
     vec3_euler,
     vec3_select,
     vec3_to_array_fields,

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -263,7 +263,7 @@ macro_rules! impl_vecn_float_methods {
             if v.is_finite() {
                 v
             } else {
-                Self::default()
+                Self::ZERO
             }
         }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -259,9 +259,9 @@ macro_rules! impl_vecn_float_methods {
         /// the result of this operation will be zero.
         #[inline(always)]
         pub fn normalize_or_zero(self) -> Self {
-            let v = self.normalize();
-            if v.is_finite() {
-                v
+            let rcp = self.length_recip();
+            if rcp.is_finite() {
+                self * rcp
             } else {
                 Self::ZERO
             }

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -260,7 +260,7 @@ macro_rules! impl_vecn_float_methods {
         #[inline(always)]
         pub fn normalize_or_zero(self) -> Self {
             let rcp = self.length_recip();
-            if rcp.is_finite() {
+            if rcp.is_finite() && rcp > 0.0 {
                 self * rcp
             } else {
                 Self::ZERO

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -246,10 +246,25 @@ macro_rules! impl_vecn_float_methods {
 
         /// Returns `self` normalized to length 1.0.
         ///
-        /// For valid results, `self` must _not_ be of length zero.
+        /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
+        /// You can check the results with [`Self::is_finite`], or use [`Self::normalize_or_zero`].
         #[inline(always)]
         pub fn normalize(self) -> Self {
             Self($flttrait::normalize(self.0))
+        }
+
+        /// Returns `self` normalized to length 1.0 if possible, else returns zero.
+        ///
+        /// In particular, if the input is zero (or very close to zero), or non-finite,
+        /// the result of this operation will be zero.
+        #[inline(always)]
+        pub fn normalize_or_zero(self) -> Self {
+            let v = self.normalize();
+            if v.is_finite() {
+                v
+            } else {
+                Self::default()
+            }
         }
 
         /// Returns whether `self` is length `1.0` or not.

--- a/tests/support/macros.rs
+++ b/tests/support/macros.rs
@@ -38,42 +38,48 @@ macro_rules! impl_vec_float_normalize_tests {
         use core::$t::MAX;
         use core::$t::MIN_POSITIVE;
 
+        /// Works for vec2, vec3, vec4
+        fn from_x_y(x: $t, y: $t) -> $vec {
+            let mut v = $vec::ZERO;
+            v.x = x;
+            v.y = y;
+            v
+        }
+
         #[test]
         fn test_normalize() {
-            let x = $vec::X;
-
-            assert_eq!((-42.0 * x).normalize(), -x);
-            assert_eq!((MAX.sqrt() * x).normalize(), x);
-            // assert_eq!((MAX * x).normalize(), x); // normalize fails for huge vectors and returns zero
+            assert_eq!(from_x_y(-42.0, 0.0).normalize(), from_x_y(-1.0, 0.0));
+            assert_eq!(from_x_y(MAX.sqrt(), 0.0).normalize(), from_x_y(1.0, 0.0));
+            // assert_eq!(from_x_y(MAX, 0.0).normalize(), from_x_y(1.0, 0.0)); // normalize fails for huge vectors and returns zero
 
             // We expect not to be able to normalize small numbers:
-            assert!(!$vec::ZERO.normalize().is_finite());
-            assert!(!(MIN_POSITIVE * x).normalize().is_finite());
+            assert!(!from_x_y(0.0, 0.0).normalize().is_finite());
+            assert!(!from_x_y(MIN_POSITIVE, 0.0).normalize().is_finite());
 
             // We expect not to be able to normalize non-finite vectors:
-            assert!(!(INFINITY * x).normalize().is_finite());
-            assert!(!(NAN * x).normalize().is_finite());
+            assert!(!from_x_y(INFINITY, 0.0).normalize().is_finite());
+            assert!(!from_x_y(NAN, 0.0).normalize().is_finite());
         }
 
         #[test]
         fn test_normalize_or_zero() {
-            let x = $vec::X;
-            let y = $vec::Y;
-
-            assert_eq!((-42.0 * x).normalize(), -x);
-            assert_eq!((MAX.sqrt() * x).normalize_or_zero(), x);
+            assert_eq!(from_x_y(-42.0, 0.0).normalize(), from_x_y(-1.0, 0.0));
+            assert_eq!(
+                from_x_y(MAX.sqrt(), 0.0).normalize_or_zero(),
+                from_x_y(1.0, 0.0)
+            );
 
             // We expect `normalize_or_zero` to return zero when inputs are very small:
-            assert_eq!($vec::ZERO.normalize_or_zero(), $vec::ZERO);
-            assert_eq!((MIN_POSITIVE * x).normalize_or_zero(), $vec::ZERO);
+            assert_eq!(from_x_y(0.0, 0.0).normalize_or_zero(), $vec::ZERO);
+            assert_eq!(from_x_y(MIN_POSITIVE, 0.0).normalize_or_zero(), $vec::ZERO);
 
             // We expect `normalize_or_zero` to return zero when inputs are non-finite:
-            assert_eq!((INFINITY * x).normalize_or_zero(), $vec::ZERO);
-            assert_eq!((NAN * x).normalize_or_zero(), $vec::ZERO);
+            assert_eq!(from_x_y(INFINITY, 0.0).normalize_or_zero(), $vec::ZERO);
+            assert_eq!(from_x_y(NAN, 0.0).normalize_or_zero(), $vec::ZERO);
 
             // We expect `normalize_or_zero` to return zero when inputs are very large:
-            assert_eq!((MAX * x).normalize_or_zero(), $vec::ZERO);
-            assert_eq!((MAX * (x + y)).normalize_or_zero(), $vec::ZERO);
+            assert_eq!(from_x_y(MAX, 0.0).normalize_or_zero(), $vec::ZERO);
+            assert_eq!(from_x_y(MAX, MAX).normalize_or_zero(), $vec::ZERO);
         }
     };
 }

--- a/tests/support/macros.rs
+++ b/tests/support/macros.rs
@@ -42,7 +42,7 @@ macro_rules! impl_vec_float_normalize_tests {
             assert_eq!((-42.0 * $vec::X).normalize(), -$vec::X);
 
             // We expect not to be able to normalize small numbers:
-            assert!(!$vec::default().normalize().is_finite());
+            assert!(!$vec::ZERO.normalize().is_finite());
             assert!(!(MIN_POSITIVE * $vec::X).normalize().is_finite());
 
             // We expect not to be able to normalize non-finite values:
@@ -55,15 +55,12 @@ macro_rules! impl_vec_float_normalize_tests {
             assert_eq!((-42.0 * $vec::X).normalize(), -$vec::X);
 
             // We expect `normalize_or_zero` to return zero when inputs are very small:
-            assert_eq!($vec::default().normalize_or_zero(), $vec::default());
-            assert_eq!(
-                (MIN_POSITIVE * $vec::X).normalize_or_zero(),
-                $vec::default()
-            );
+            assert_eq!($vec::ZERO.normalize_or_zero(), $vec::ZERO);
+            assert_eq!((MIN_POSITIVE * $vec::X).normalize_or_zero(), $vec::ZERO);
 
             // We expect `normalize_or_zero` to return zero when inputs are non-finite:
-            assert_eq!((INFINITY * $vec::X).normalize_or_zero(), $vec::default());
-            assert_eq!((NAN * $vec::X).normalize_or_zero(), $vec::default());
+            assert_eq!((INFINITY * $vec::X).normalize_or_zero(), $vec::ZERO);
+            assert_eq!((NAN * $vec::X).normalize_or_zero(), $vec::ZERO);
         }
     };
 }

--- a/tests/support/macros.rs
+++ b/tests/support/macros.rs
@@ -30,3 +30,40 @@ macro_rules! assert_approx_eq {
         );
     }};
 }
+
+/// Test vector normalization for float vector
+#[macro_export]
+macro_rules! impl_vec_float_normalize_tests {
+    ($t:ident, $vec:ident) => {
+        use core::$t::MIN_POSITIVE;
+
+        #[test]
+        fn test_normalize() {
+            assert_eq!((-42.0 * $vec::X).normalize(), -$vec::X);
+
+            // We expect not to be able to normalize small numbers:
+            assert!(!$vec::default().normalize().is_finite());
+            assert!(!(MIN_POSITIVE * $vec::X).normalize().is_finite());
+
+            // We expect not to be able to normalize non-finite values:
+            assert!(!(INFINITY * $vec::X).normalize().is_finite());
+            assert!(!(NAN * $vec::X).normalize().is_finite());
+        }
+
+        #[test]
+        fn test_normalize_or_zero() {
+            assert_eq!((-42.0 * $vec::X).normalize(), -$vec::X);
+
+            // We expect `normalize_or_zero` to return zero when inputs are very small:
+            assert_eq!($vec::default().normalize_or_zero(), $vec::default());
+            assert_eq!(
+                (MIN_POSITIVE * $vec::X).normalize_or_zero(),
+                $vec::default()
+            );
+
+            // We expect `normalize_or_zero` to return zero when inputs are non-finite:
+            assert_eq!((INFINITY * $vec::X).normalize_or_zero(), $vec::default());
+            assert_eq!((NAN * $vec::X).normalize_or_zero(), $vec::default());
+        }
+    };
+}

--- a/tests/support/macros.rs
+++ b/tests/support/macros.rs
@@ -35,32 +35,45 @@ macro_rules! assert_approx_eq {
 #[macro_export]
 macro_rules! impl_vec_float_normalize_tests {
     ($t:ident, $vec:ident) => {
+        use core::$t::MAX;
         use core::$t::MIN_POSITIVE;
 
         #[test]
         fn test_normalize() {
-            assert_eq!((-42.0 * $vec::X).normalize(), -$vec::X);
+            let x = $vec::X;
+
+            assert_eq!((-42.0 * x).normalize(), -x);
+            assert_eq!((MAX.sqrt() * x).normalize(), x);
+            // assert_eq!((MAX * x).normalize(), x); // normalize fails for huge vectors and returns zero
 
             // We expect not to be able to normalize small numbers:
             assert!(!$vec::ZERO.normalize().is_finite());
-            assert!(!(MIN_POSITIVE * $vec::X).normalize().is_finite());
+            assert!(!(MIN_POSITIVE * x).normalize().is_finite());
 
-            // We expect not to be able to normalize non-finite values:
-            assert!(!(INFINITY * $vec::X).normalize().is_finite());
-            assert!(!(NAN * $vec::X).normalize().is_finite());
+            // We expect not to be able to normalize non-finite vectors:
+            assert!(!(INFINITY * x).normalize().is_finite());
+            assert!(!(NAN * x).normalize().is_finite());
         }
 
         #[test]
         fn test_normalize_or_zero() {
-            assert_eq!((-42.0 * $vec::X).normalize(), -$vec::X);
+            let x = $vec::X;
+            let y = $vec::Y;
+
+            assert_eq!((-42.0 * x).normalize(), -x);
+            assert_eq!((MAX.sqrt() * x).normalize_or_zero(), x);
 
             // We expect `normalize_or_zero` to return zero when inputs are very small:
             assert_eq!($vec::ZERO.normalize_or_zero(), $vec::ZERO);
-            assert_eq!((MIN_POSITIVE * $vec::X).normalize_or_zero(), $vec::ZERO);
+            assert_eq!((MIN_POSITIVE * x).normalize_or_zero(), $vec::ZERO);
 
             // We expect `normalize_or_zero` to return zero when inputs are non-finite:
-            assert_eq!((INFINITY * $vec::X).normalize_or_zero(), $vec::ZERO);
-            assert_eq!((NAN * $vec::X).normalize_or_zero(), $vec::ZERO);
+            assert_eq!((INFINITY * x).normalize_or_zero(), $vec::ZERO);
+            assert_eq!((NAN * x).normalize_or_zero(), $vec::ZERO);
+
+            // We expect `normalize_or_zero` to return zero when inputs are very large:
+            assert_eq!((MAX * x).normalize_or_zero(), $vec::ZERO);
+            assert_eq!((MAX * (x + y)).normalize_or_zero(), $vec::ZERO);
         }
     };
 }

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -406,6 +406,7 @@ macro_rules! impl_vec2_signed_tests {
 macro_rules! impl_vec2_float_tests {
     ($t:ident, $const_new:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident, $mat2:ident) => {
         impl_vec2_signed_tests!($t, $const_new, $new, $vec2, $vec3, $mask);
+        impl_vec_float_normalize_tests!($t, $vec2);
 
         use core::$t::INFINITY;
         use core::$t::NAN;

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -451,6 +451,7 @@ macro_rules! impl_vec3_signed_tests {
 macro_rules! impl_vec3_float_tests {
     ($t:ident, $const_new:ident, $new:ident, $vec3:ident, $mask:ident) => {
         impl_vec3_signed_tests!($t, $const_new, $new, $vec3, $mask);
+        impl_vec_float_normalize_tests!($t, $vec3);
 
         use core::$t::INFINITY;
         use core::$t::NAN;

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -507,6 +507,7 @@ macro_rules! impl_vec4_signed_tests {
 macro_rules! impl_vec4_float_tests {
     ($t:ident, $const_new:ident, $new:ident, $vec4:ident, $mask:ident) => {
         impl_vec4_signed_tests!($t, $const_new, $new, $vec4, $mask);
+        impl_vec_float_normalize_tests!($t, $vec4);
 
         use core::$t::INFINITY;
         use core::$t::NAN;


### PR DESCRIPTION
See discussion in https://github.com/bitshifter/glam-rs/issues/74

This adds the method `normalize_or_zero()` which will either return a unit-length vector or zero, but never a non-finite vector.

On my MacBook Pro 2019 ~I get `4.6 ns` for `Vec3::normalize()` and `8.1 ns` for `Vec3::normalize_or_zero()`.~
**EDIT**: `Vec3::normalize_or_zero()` takes about 40% more time compared to `Vec3::normalize()`.

## Motivation
In many real-world cases, the safe choice is zero when a vector cannot be normalized (regardless of the reason). This PR makes this common use case very ergonomic.

## Alternatives
Instead of normalizing and checking if all values are finite we could take the length, check if it is small or non-finite, and if so return zero. This has the potential of being slightly faster, but the cutoff for "small" must be chosen very carefully.

We could also consider splitting this into two functions: `v.normalize().finite_or_zero()`, i.e. have a special function that returns the zero vector for non-finite vectors. This choice would make it slightly longer than `normalize_or_zero()` and also preclude future optimizations as suggested above. That being said, a `finite_or_zero` might still be a nice separate addition (for another PR).