### PR TITLE
Add spirv module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ num-traits = { version = "0.2.14", optional = true, default-features = false }
 rand = { version = "0.7", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
 
+[target.'cfg(target_arch = "spirv")'.dependencies]
+spirv-std = { version = "0.4.0-alpha.0", features = ["const-generics"] }
+
 [dev-dependencies]
 criterion = "0.3"
 # rand_xoshiro is required for tests if rand is enabled

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,25 +181,7 @@ The minimum supported version of Rust for `glam` is `1.36.0`.
 */
 #![doc(html_root_url = "https://docs.rs/glam/0.13.0")]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(target_arch = "spirv", feature(register_attr, repr_simd))]
-
-#[cfg(all(target_arch = "spirv", feature = "std"))]
-compile_error!("`std` feature is not supported when building for SPIRV");
-
-#[cfg(all(target_arch = "spirv", feature = "glam-assert"))]
-compile_error!("`glam-assert` feature is not supported when building for SPIRV");
-
-#[cfg(all(target_arch = "spirv", feature = "debug-glam-assert"))]
-compile_error!("`debug-glam-assert` feature is not supported when building for SPIRV");
-
-#[cfg(all(target_arch = "spirv", feature = "serde"))]
-compile_error!("`serde` feature is not supported when building for SPIRV");
-
-#[cfg(all(target_arch = "spirv", feature = "rand"))]
-compile_error!("`rand` feature is not supported when building for SPIRV");
-
-#[cfg(all(target_arch = "spirv", feature = "bytemuck"))]
-compile_error!("`bytemuck` feature is not supported when building for SPIRV");
+#![cfg_attr(target_arch = "spirv", feature(asm, register_attr, repr_simd))]
 
 #[macro_use]
 mod macros;
@@ -220,6 +202,9 @@ mod vec4;
 mod vec_mask;
 
 mod features;
+
+#[cfg(target_arch = "spirv")]
+mod spirv;
 
 #[cfg(feature = "transform-types")]
 mod transform;

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -5,6 +5,9 @@ use crate::core::traits::{
 use crate::{DMat3, DMat4, DVec3, DVec4};
 use crate::{Mat3, Mat4, Vec3, Vec3A, Vec4};
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 #[cfg(all(
     target_arch = "x86",
     target_feature = "sse2",
@@ -139,6 +142,7 @@ macro_rules! impl_quat_methods {
         ///
         /// For near-singular cases (from≈to and from≈-to) the current implementation
         /// is only accurate to about 0.001 (for `f32`).
+        #[cfg(feature = "std")]
         pub fn from_rotation_arc(from: $vec3, to: $vec3) -> Self {
             glam_assert!(from.is_normalized());
             glam_assert!(to.is_normalized());
@@ -167,6 +171,7 @@ macro_rules! impl_quat_methods {
         /// The input vectors must be normalized (unit-length).
         ///
         /// `to.dot(from_rotation_arc_colinear(from, to) * from).abs() ≈ 1`.
+        #[cfg(feature = "std")]
         pub fn from_rotation_arc_colinear(from: $vec3, to: $vec3) -> Self {
             if from.dot(to) < 0.0 {
                 Self::from_rotation_arc(from, -to)

--- a/src/spirv.rs
+++ b/src/spirv.rs
@@ -1,0 +1,47 @@
+macro_rules! unsupported_features {
+    ($($feature:literal),+ $(,)?) => {
+        $(
+            #[cfg(feature = $feature)]
+            compile_error!(
+                concat!(
+                    "`",
+                    $feature,
+                    "`",
+                    " feature is not supported when building for SPIR-V.",
+                )
+            );
+        )+
+    }
+}
+
+unsupported_features! {
+    "bytemuck",
+    "debug-glam-assert",
+    "glam-assert",
+    "rand",
+    "serde",
+    "std",
+}
+
+use spirv_std::vector::Vector;
+
+unsafe impl Vector<bool, 2> for crate::BVec2 {}
+unsafe impl Vector<bool, 3> for crate::BVec3 {}
+unsafe impl Vector<bool, 4> for crate::BVec4 {}
+
+unsafe impl Vector<f32, 2> for crate::Vec2 {}
+unsafe impl Vector<f32, 3> for crate::Vec3 {}
+unsafe impl Vector<f32, 3> for crate::Vec3A {}
+unsafe impl Vector<f32, 4> for crate::Vec4 {}
+
+unsafe impl Vector<f32, 2> for crate::DVec2 {}
+unsafe impl Vector<f32, 3> for crate::DVec3 {}
+unsafe impl Vector<f32, 4> for crate::DVec4 {}
+
+unsafe impl Vector<u32, 2> for crate::UVec2 {}
+unsafe impl Vector<u32, 3> for crate::UVec3 {}
+unsafe impl Vector<u32, 4> for crate::UVec4 {}
+
+unsafe impl Vector<i32, 2> for crate::IVec2 {}
+unsafe impl Vector<i32, 3> for crate::IVec3 {}
+unsafe impl Vector<i32, 4> for crate::IVec4 {}

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -4,6 +4,9 @@ use crate::{BVec2, DVec3, IVec3, UVec3, Vec3, XY};
 use core::fmt;
 use core::{cmp::Ordering, f32, ops::*};
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 #[cfg(feature = "std")]
 use std::iter::{Product, Sum};
 

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -6,6 +6,9 @@ use crate::{BVec3, DVec2, DVec4, IVec2, IVec4, UVec2, UVec4, Vec2, Vec4, XYZ};
 use core::fmt;
 use core::{cmp::Ordering, f32, ops::*};
 
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
 #[cfg(all(
     target_arch = "x86",
     target_feature = "sse2",
@@ -200,6 +203,7 @@ macro_rules! impl_vec3_float_methods {
         /// The output vector is not necessarily unit-length.
         /// For that use [`Self::any_orthonormal_vector`] instead.
         #[inline]
+        #[cfg(feature = "std")]
         pub fn any_orthogonal_vector(&self) -> Self {
             // This can probably be optimized
             if self.x.abs() > self.y.abs() {
@@ -212,6 +216,7 @@ macro_rules! impl_vec3_float_methods {
         /// Returns any unit-length vector that is orthogonal to the given one.
         /// The input vector must be finite and non-zero.
         #[inline]
+        #[cfg(feature = "std")]
         pub fn any_orthonormal_vector(&self) -> Self {
             glam_assert!(self.is_normalized());
             // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
@@ -224,6 +229,7 @@ macro_rules! impl_vec3_float_methods {
         /// Given a unit-length vector return two other vectors that together form an orthonormal basis.
         /// That is, all three vectors are orthogonal to each other and are normalized.
         #[inline]
+        #[cfg(feature = "std")]
         pub fn any_orthonormal_pair(&self) -> (Self, Self) {
             glam_assert!(self.is_normalized());
             // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -7,6 +7,9 @@ use crate::{BVec4, DVec2, DVec3, IVec2, IVec3, UVec2, UVec3, Vec2, Vec3, Vec3A, 
 use core::fmt;
 use core::ops::*;
 
+#[cfg(all(feature = "libm", not(feature = "std")))]
+use num_traits::Float;
+
 #[cfg(all(
     target_arch = "x86",
     target_feature = "sse2",

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -7,7 +7,7 @@ use crate::{BVec4, DVec2, DVec3, IVec2, IVec3, UVec2, UVec3, Vec2, Vec3, Vec3A, 
 use core::fmt;
 use core::ops::*;
 
-#[cfg(all(feature = "libm", not(feature = "std")))]
+#[cfg(not(feature = "std"))]
 use num_traits::Float;
 
 #[cfg(all(

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -355,6 +355,7 @@ macro_rules! impl_quat_tests {
         }
 
         #[test]
+        #[cfg(feature = "std")]
         fn test_rotation_arc() {
             let eps = 2.0 * core::$t::EPSILON.sqrt();
 

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -703,6 +703,7 @@ macro_rules! impl_vec3_float_tests {
         }
 
         #[test]
+        #[cfg(feature = "std")]
         fn test_any_ortho() {
             let eps = 2.0 * core::$t::EPSILON;
 


### PR DESCRIPTION
This PR adds a spirv module responsible for the integration between `glam` and SPIR-V targets, and also adds dependencies on `spirv-std` and moves the trait implementations previously contained in `spirv-std` into `glam`. This is part of a series changes to allow `spirv-std` to be compatible with multiple vector libraries, and to allow libraries like glam to be able to take advantage of intrinsics provided by `spirv-std` such as using vector operations for add, multiply, etc.

This PR is currently blocked on https://github.com/EmbarkStudios/rust-gpu/pull/476 landing so that we can publish a version of `spirv-std` with those changes and prevent cyclic dependencies issues.