### PR TITLE
Add vector clamp function

### DIFF
--- a/src/core/scalar/vector.rs
+++ b/src/core/scalar/vector.rs
@@ -232,6 +232,16 @@ impl<T: NumEx> Vector<T> for XY<T> {
             y: self.y.max(other.y),
         }
     }
+
+    #[inline]
+    fn clamp(self, min: Self, max: Self) -> Self {
+        glam_assert!(min.x <= max.x);
+        glam_assert!(min.y <= max.y);
+        Self {
+            x: self.x.max(min.x).min(max.x), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
+            y: self.y.max(min.y).min(max.y), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
+        }
+    }
 }
 
 impl<T: NumEx> Vector<T> for XYZ<T> {
@@ -383,6 +393,18 @@ impl<T: NumEx> Vector<T> for XYZ<T> {
             x: self.x.max(other.x),
             y: self.y.max(other.y),
             z: self.z.max(other.z),
+        }
+    }
+
+    #[inline]
+    fn clamp(self, min: Self, max: Self) -> Self {
+        glam_assert!(min.x <= max.x);
+        glam_assert!(min.y <= max.y);
+        glam_assert!(min.z <= max.z);
+        Self {
+            x: self.x.max(min.x).min(max.x), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
+            y: self.y.max(min.y).min(max.y), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
+            z: self.z.max(min.z).min(max.z), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
         }
     }
 }
@@ -557,6 +579,20 @@ impl<T: NumEx> Vector<T> for XYZW<T> {
             y: self.y.max(other.y),
             z: self.z.max(other.z),
             w: self.w.max(other.w),
+        }
+    }
+
+    #[inline]
+    fn clamp(self, min: Self, max: Self) -> Self {
+        glam_assert!(min.x <= max.x);
+        glam_assert!(min.y <= max.y);
+        glam_assert!(min.z <= max.z);
+        glam_assert!(min.w <= max.w);
+        Self {
+            x: self.x.max(min.x).min(max.x), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
+            y: self.y.max(min.y).min(max.y), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
+            z: self.z.max(min.z).min(max.z), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
+            w: self.w.max(min.w).min(max.w), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
         }
     }
 }

--- a/src/core/scalar/vector.rs
+++ b/src/core/scalar/vector.rs
@@ -237,9 +237,11 @@ impl<T: NumEx> Vector<T> for XY<T> {
     fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.x <= max.x);
         glam_assert!(min.y <= max.y);
+        // we intentionally do not use `f32::clamp` because we don't
+        // want panics unless `glam-assert` feature is on.
         Self {
-            x: self.x.max(min.x).min(max.x), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
-            y: self.y.max(min.y).min(max.y), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
+            x: self.x.max(min.x).min(max.x),
+            y: self.y.max(min.y).min(max.y),
         }
     }
 }
@@ -401,10 +403,12 @@ impl<T: NumEx> Vector<T> for XYZ<T> {
         glam_assert!(min.x <= max.x);
         glam_assert!(min.y <= max.y);
         glam_assert!(min.z <= max.z);
+        // we intentionally do not use `f32::clamp` because we don't
+        // want panics unless `glam-assert` feature is on.
         Self {
-            x: self.x.max(min.x).min(max.x), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
-            y: self.y.max(min.y).min(max.y), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
-            z: self.z.max(min.z).min(max.z), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
+            x: self.x.max(min.x).min(max.x),
+            y: self.y.max(min.y).min(max.y),
+            z: self.z.max(min.z).min(max.z),
         }
     }
 }
@@ -588,11 +592,13 @@ impl<T: NumEx> Vector<T> for XYZW<T> {
         glam_assert!(min.y <= max.y);
         glam_assert!(min.z <= max.z);
         glam_assert!(min.w <= max.w);
+        // we intentionally do not use `f32::clamp` because we don't
+        // want panics unless `glam-assert` feature is on.
         Self {
-            x: self.x.max(min.x).min(max.x), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
-            y: self.y.max(min.y).min(max.y), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
-            z: self.z.max(min.z).min(max.z), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
-            w: self.w.max(min.w).min(max.w), // TODO: use std::f32::clamp when we update the minimal required rustc version to >= 1.50
+            x: self.x.max(min.x).min(max.x),
+            y: self.y.max(min.y).min(max.y),
+            z: self.z.max(min.z).min(max.z),
+            w: self.w.max(min.w).min(max.w),
         }
     }
 }

--- a/src/core/sse2/vector.rs
+++ b/src/core/sse2/vector.rs
@@ -264,6 +264,7 @@ impl Vector<f32> for __m128 {
 
     #[inline(always)]
     fn clamp(self, min: Self, max: Self) -> Self {
+        glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
     }
 }

--- a/src/core/sse2/vector.rs
+++ b/src/core/sse2/vector.rs
@@ -264,7 +264,10 @@ impl Vector<f32> for __m128 {
 
     #[inline(always)]
     fn clamp(self, min: Self, max: Self) -> Self {
-        glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
+        glam_assert!(
+            MaskVector3::all(min.cmple(max)), // TODO: also check .w for Vec4
+            "clamp: expected min <= max"
+        );
         self.max(min).min(max)
     }
 }

--- a/src/core/sse2/vector.rs
+++ b/src/core/sse2/vector.rs
@@ -261,6 +261,11 @@ impl Vector<f32> for __m128 {
     fn max(self, other: Self) -> Self {
         unsafe { _mm_max_ps(self, other) }
     }
+
+    #[inline(always)]
+    fn clamp(self, min: Self, max: Self) -> Self {
+        self.max(min).min(max)
+    }
 }
 
 impl Vector3<f32> for __m128 {

--- a/src/core/traits/vector.rs
+++ b/src/core/traits/vector.rs
@@ -90,6 +90,7 @@ pub trait Vector<T>: Sized + Copy + Clone {
 
     fn min(self, other: Self) -> Self;
     fn max(self, other: Self) -> Self;
+    fn clamp(self, min: Self, max: Self) -> Self;
 }
 
 pub trait Vector2<T>: Vector<T> + Vector2Const {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -57,6 +57,8 @@ macro_rules! impl_vecn_common_methods {
         /// Component-wise clamping of values, similar to [`std::f32::clamp`].
         ///
         /// Each element in `min` must be less-or-equal to the corresponing element in `max`.
+        /// If the `glam-assert` feature is enabled, the function will panic if the contract is not met,
+        /// otherwise the behavior is undefined.
         #[inline(always)]
         pub fn clamp(self, min: Self, max: Self) -> Self {
             Self(self.0.clamp(min.0, max.0))

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -54,6 +54,14 @@ macro_rules! impl_vecn_common_methods {
             Self(self.0.max(other.0))
         }
 
+        /// Component-wise clamping of values, similar to [`std::f32::clamp`].
+        ///
+        /// Each element in `min` must be less-or-equal to the corresponing element in `max`.
+        #[inline(always)]
+        pub fn clamp(self, min: Self, max: Self) -> Self {
+            Self(self.0.clamp(min.0, max.0))
+        }
+
         /// Returns the horizontal minimum of `self`.
         ///
         /// In other words this computes `min(x, y, ..)`.

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -123,6 +123,21 @@ macro_rules! impl_vec2_tests {
         }
 
         #[test]
+        fn test_clamp() {
+            fn vec(x: i32, y: i32) -> $vec2 {
+                $vec2::new(x as $t, y as $t)
+            }
+            let min = vec(1, 3);
+            let max = vec(6, 8);
+            assert_eq!(vec(0, 0).clamp(min, max), vec(1, 3));
+            assert_eq!(vec(2, 2).clamp(min, max), vec(2, 3));
+            assert_eq!(vec(4, 5).clamp(min, max), vec(4, 5));
+            assert_eq!(vec(6, 6).clamp(min, max), vec(6, 6));
+            assert_eq!(vec(7, 7).clamp(min, max), vec(6, 7));
+            assert_eq!(vec(9, 9).clamp(min, max), vec(6, 8));
+        }
+
+        #[test]
         fn test_hmin_hmax() {
             let a = $new(1 as $t, 2 as $t);
             assert_eq!(1 as $t, a.min_element());

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -138,6 +138,21 @@ macro_rules! impl_vec3_tests {
         }
 
         #[test]
+        fn test_clamp() {
+            fn vec(x: i32, y: i32, z: i32) -> $vec3 {
+                $vec3::new(x as $t, y as $t, z as $t)
+            }
+            let min = vec(1, 3, 3);
+            let max = vec(6, 8, 8);
+            assert_eq!(vec(0, 0, 0).clamp(min, max), vec(1, 3, 3));
+            assert_eq!(vec(2, 2, 2).clamp(min, max), vec(2, 3, 3));
+            assert_eq!(vec(4, 5, 5).clamp(min, max), vec(4, 5, 5));
+            assert_eq!(vec(6, 6, 6).clamp(min, max), vec(6, 6, 6));
+            assert_eq!(vec(7, 7, 7).clamp(min, max), vec(6, 7, 7));
+            assert_eq!(vec(9, 9, 9).clamp(min, max), vec(6, 8, 8));
+        }
+
+        #[test]
         fn test_hmin_hmax() {
             let a = $new(2 as $t, 3 as $t, 1 as $t);
             assert_eq!(1 as $t, a.min_element());

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -159,6 +159,21 @@ macro_rules! impl_vec4_tests {
         }
 
         #[test]
+        fn test_clamp() {
+            fn vec(x: i32, y: i32, z: i32, w: i32) -> $vec4 {
+                $vec4::new(x as $t, y as $t, z as $t, w as $t)
+            }
+            let min = vec(1, 1, 3, 3);
+            let max = vec(6, 6, 8, 8);
+            assert_eq!(vec(0, 0, 0, 0).clamp(min, max), vec(1, 1, 3, 3));
+            assert_eq!(vec(2, 2, 2, 2).clamp(min, max), vec(2, 2, 3, 3));
+            assert_eq!(vec(4, 4, 5, 5).clamp(min, max), vec(4, 4, 5, 5));
+            assert_eq!(vec(6, 6, 6, 6).clamp(min, max), vec(6, 6, 6, 6));
+            assert_eq!(vec(7, 7, 7, 7).clamp(min, max), vec(6, 6, 7, 7));
+            assert_eq!(vec(9, 9, 9, 9).clamp(min, max), vec(6, 6, 8, 8));
+        }
+
+        #[test]
         fn test_hmin_hmax() {
             let a = $new(3 as $t, 4 as $t, 1 as $t, 2 as $t);
             assert_eq!(1 as $t, a.min_element());


### PR DESCRIPTION
This mirrors the new https://doc.rust-lang.org/std/primitive.f32.html#method.clamp function, with the differences:

* `assert!` has been replaced with `glam_assert!`
* treatment of `NaN` is undefined