### PR TITLE
Add Vec Partial Negation

### DIFF
--- a/src/core/scalar/vector.rs
+++ b/src/core/scalar/vector.rs
@@ -887,6 +887,14 @@ impl<T: SignedEx> SignedVector<T> for XY<T> {
             y: self.y.neg(),
         }
     }
+
+    #[inline]
+    fn neg_part(self, mask: Self::Mask) -> Self {
+        Self {
+            x: if mask.x { self.x.neg() } else { self.x },
+            y: if mask.y { self.y.neg() } else { self.y },
+        }
+    }
 }
 
 impl<T: SignedEx> SignedVector2<T> for XY<T> {
@@ -929,6 +937,15 @@ impl<T: SignedEx> SignedVector<T> for XYZ<T> {
             z: self.z.neg(),
         }
     }
+
+    #[inline]
+    fn neg_part(self, mask: Self::Mask) -> Self {
+        Self {
+            x: if mask.x { self.x.neg() } else { self.x },
+            y: if mask.y { self.y.neg() } else { self.y },
+            z: if mask.z { self.z.neg() } else { self.z },
+        }
+    }
 }
 
 impl<T: SignedEx> SignedVector3<T> for XYZ<T> {
@@ -959,6 +976,16 @@ impl<T: SignedEx> SignedVector<T> for XYZW<T> {
             y: self.y.neg(),
             z: self.z.neg(),
             w: self.w.neg(),
+        }
+    }
+
+    #[inline]
+    fn neg_part(self, mask: Self::Mask) -> Self {
+        Self {
+            x: if mask.x { self.x.neg() } else { self.x },
+            y: if mask.y { self.y.neg() } else { self.y },
+            z: if mask.z { self.z.neg() } else { self.z },
+            w: if mask.w { self.w.neg() } else { self.w },
         }
     }
 }

--- a/src/core/sse2/float.rs
+++ b/src/core/sse2/float.rs
@@ -56,6 +56,11 @@ _ps_const_ty!(PS_TWO_PI, f32x4, core::f32::consts::PI * 2.0);
 _ps_const_ty!(PS_RECIPROCAL_TWO_PI, f32x4, 0.159154943);
 
 #[inline]
+pub(crate) unsafe fn m128_neg_part(v: __m128, m: __m128) -> __m128 {
+    _mm_xor_ps(v, _mm_and_ps(PS_NEGATIVE_ZERO.m128, m))
+}
+
+#[inline]
 pub(crate) unsafe fn m128_abs(v: __m128) -> __m128 {
     _mm_and_ps(v, _mm_castsi128_ps(_mm_set1_epi32(0x7f_ff_ff_ff)))
 }

--- a/src/core/sse2/vector.rs
+++ b/src/core/sse2/vector.rs
@@ -540,6 +540,11 @@ impl SignedVector<f32> for __m128 {
     fn neg(self) -> Self {
         unsafe { _mm_sub_ps(Self::ZERO, self) }
     }
+
+    #[inline(always)]
+    fn neg_part(self, mask: Self::Mask) -> Self {
+        unsafe { m128_neg_part(self, mask) }
+    }
 }
 
 impl SignedVector3<f32> for __m128 {

--- a/src/core/traits/vector.rs
+++ b/src/core/traits/vector.rs
@@ -200,6 +200,7 @@ pub trait Vector4<T>: Vector<T> + Vector4Const {
 
 pub trait SignedVector<T: SignedEx>: Vector<T> {
     fn neg(self) -> Self;
+    fn neg_part(self, mask: Self::Mask) -> Self;
 }
 
 pub trait SignedVector2<T: SignedEx>: SignedVector<T> + Vector2<T> {

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -165,6 +165,14 @@ macro_rules! impl_vecn_signed_methods {
     ($t:ty, $vecn:ident, $mask:ident, $inner:ident, $sgntrait:ident) => {
         // impl_vecn_common_methods!($t, $vecn, $mask, $inner, $vectrait);
 
+        /// Partially negates elements of the vector according to the given `mask`.
+        ///
+        /// A true element in the mask negates the corresponding element of `self`.
+        #[inline(always)]
+        pub fn neg_part(self, mask: $mask) -> Self {
+            Self(self.0.neg_part(mask.0))
+        }
+
         /// Returns a vector containing the absolute value of each element of `self`.
         #[inline(always)]
         pub fn abs(self) -> Self {

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -387,18 +387,25 @@ macro_rules! impl_vec2_signed_tests {
         impl_vec2_tests!($t, $const_new, $new, $vec2, $vec3, $mask);
 
         #[test]
+        fn test_neg() {
+            let a = $new(1 as $t, 2 as $t);
+            assert_eq!($new(-1 as $t, -2 as $t), (-a));
+        }
+
+        #[test]
+        fn test_neg_part() {
+            let a = $new(1 as $t, 2 as $t);
+            let m = $mask::new(true, false);
+            assert_eq!((-1 as $t, 2 as $t), a.neg_part(m).into());
+        }
+
+        #[test]
         fn test_dot_signed() {
             let x = $new(1 as $t, 0 as $t);
             let y = $new(0 as $t, 1 as $t);
             assert_eq!(1 as $t, x.dot(x));
             assert_eq!(0 as $t, x.dot(y));
             assert_eq!(-1 as $t, x.dot(-x));
-        }
-
-        #[test]
-        fn test_neg() {
-            let a = $new(1 as $t, 2 as $t);
-            assert_eq!($new(-1 as $t, -2 as $t), (-a));
         }
     };
 }

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -437,6 +437,13 @@ macro_rules! impl_vec3_signed_tests {
         }
 
         #[test]
+        fn test_neg_part() {
+            let a = $new(1 as $t, 2 as $t, 3 as $t);
+            let m = $mask::new(true, false, true);
+            assert_eq!((-1 as $t, 2 as $t, -3 as $t), a.neg_part(m).into());
+        }
+
+        #[test]
         fn test_dot_signed() {
             let x = $new(1 as $t, 0 as $t, 0 as $t);
             let y = $new(0 as $t, 1 as $t, 0 as $t);

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -491,6 +491,13 @@ macro_rules! impl_vec4_signed_tests {
         }
 
         #[test]
+        fn test_neg_part() {
+            let a = $new(1 as $t, 2 as $t, 3 as $t, 4 as $t);
+            let m = $mask::new(true, false, true, false);
+            assert_eq!((-1 as $t, 2 as $t, -3 as $t, 4 as $t), a.neg_part(m).into());
+        }
+
+        #[test]
         fn test_dot_signed() {
             let x = $new(1 as $t, 0 as $t, 0 as $t, 0 as $t);
             let y = $new(0 as $t, 1 as $t, 0 as $t, 0 as $t);


### PR DESCRIPTION
I am implementing a [geometric algebra](https://en.wikipedia.org/wiki/Geometric_algebra) lib on top of glam.
And after every swizzle I need to flip the signs of some elements in my vectors.
Thus, I thought it would be nice to have a `neg` that is applied to only some elements, similar to `select`.

As quaternions are a subalgebra of / included in geometric algebra, it is easy to demonstrate the usage of this new `neg_part` in `mul_quaternion`.