### PR TITLE
Add `Quat::from_scaled_axis` and `to_scaled_axis`

### DIFF
--- a/src/quat.rs
+++ b/src/quat.rs
@@ -87,6 +87,20 @@ macro_rules! impl_quat_methods {
             Self($inner::from_axis_angle(axis.0, angle))
         }
 
+        /// Create a quaternion that rotates `v.length()` radians around `v.normalize()`.
+        ///
+        /// `from_scaled_axis(Vec3::ZERO)` results in the identity quaternion.
+        #[inline(always)]
+        pub fn from_scaled_axis(v: $vec3) -> Self {
+            // Self($inner::from_scaled_axis(v.0))
+            let length = v.length();
+            if length == 0.0 {
+                Self::IDENTITY
+            } else {
+                Self::from_axis_angle(v / length, length)
+            }
+        }
+
         /// Creates a quaternion from the `angle` (in radians) around the x axis.
         #[inline(always)]
         pub fn from_rotation_x(angle: $t) -> Self {
@@ -185,6 +199,13 @@ macro_rules! impl_quat_methods {
         pub fn to_axis_angle(self) -> ($vec3, $t) {
             let (axis, angle) = self.0.to_axis_angle();
             ($vec3(axis), angle)
+        }
+
+        /// Returns the rotation axis scaled by the rotation in radians.
+        #[inline(always)]
+        pub fn to_scaled_axis(self) -> $vec3 {
+            let (axis, angle) = self.0.to_axis_angle();
+            $vec3(axis) * angle
         }
 
         /// Returns the quaternion conjugate of `self`. For a unit quaternion the

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -128,6 +128,33 @@ macro_rules! impl_quat_tests {
         }
 
         #[test]
+        fn test_from_scaled_axis() {
+            assert_eq!($quat::from_scaled_axis($vec3::ZERO), $quat::IDENTITY);
+            assert_eq!(
+                $quat::from_scaled_axis($vec3::Y * 1e-10),
+                $quat::from_axis_angle($vec3::Y, 1e-10)
+            );
+            assert_eq!(
+                $quat::from_scaled_axis($vec3::X * 1.0),
+                $quat::from_axis_angle($vec3::X, 1.0)
+            );
+            assert_eq!(
+                $quat::from_scaled_axis($vec3::Z * 2.0),
+                $quat::from_axis_angle($vec3::Z, 2.0)
+            );
+
+            assert_eq!(
+                $quat::from_scaled_axis($vec3::ZERO).to_scaled_axis(),
+                $vec3::ZERO
+            );
+            for &v in &vec3_float_test_vectors!($vec3) {
+                if v.length() < core::$t::consts::PI {
+                    assert!(($quat::from_scaled_axis(v).to_scaled_axis() - v).length() < 1e-6,);
+                }
+            }
+        }
+
+        #[test]
         fn test_mul_vec3() {
             let qrz = $quat::from_rotation_z(deg(90.0));
             assert_approx_eq!($vec3::Y, qrz * $vec3::X);


### PR DESCRIPTION
The first derivative of a quaternion is the angular velocity, expressed as a scaled axis.

So in physics code you will often want to do something like:

`let delta_rot = Quat::from_scaled_axis(dt * angular_velocity);`