### PR TITLE
Add Vec2::AXES, Vec3::AXES, Vec4::AXES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## Unreleased
+
+### Added
+
+* Added `Vec2::AXES, Vec3::AXES, Vec4::AXES`.
+
 ## [0.13.1] - 2021-03-24
 
 ### Added
 
 * Added vector `clamp()` functions.
-* Addd matrix column and row accessor methods, `col()` and `row()`.
+* Added matrix column and row accessor methods, `col()` and `row()`.
 * Added SPIR-V module and depenency on `spriv-std` for the SPIR-V target.
 * Added matrix truncation from 4x4 to 3x3 and 3x3 to 2x2 via `From` impls.
 

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -24,6 +24,9 @@ macro_rules! impl_vec2_common_methods {
         /// `[0, 1]`: a unit-length vector pointing along the positive Y axis.
         pub const Y: Self = Self($inner::Y);
 
+        /// The unit axes.
+        pub const AXES: [Self; 2] = [Self::X, Self::Y];
+
         /// Creates a new vector.
         #[inline(always)]
         pub fn new(x: $t, y: $t) -> $vec2 {

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -42,6 +42,9 @@ macro_rules! impl_vec3_common_methods {
         /// `[0, 0, 1]`: a unit-length vector pointing along the positive Z axis.
         pub const Z: Self = Self(Vector3Const::Z);
 
+        /// The unit axes.
+        pub const AXES: [Self; 3] = [Self::X, Self::Y, Self::Z];
+
         /// Creates a new 3D vector.
         #[inline(always)]
         pub fn new(x: $t, y: $t, z: $t) -> Self {

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -48,6 +48,9 @@ macro_rules! impl_vec4_common_methods {
         /// `[0, 0, 0, 1]`: a unit-length vector pointing along the positive W axis.
         pub const W: Self = Self(Vector4Const::W);
 
+        /// The unit axes.
+        pub const AXES: [Self; 4] = [Self::X, Self::Y, Self::Z, Self::W];
+
         /// Creates a new 4D vector.
         #[inline(always)]
         pub fn new(x: $t, y: $t, z: $t, w: $t) -> Self {


### PR DESCRIPTION
This is useful when writing code that is generic over the dimensions:


``` rust
for dim in 0..3 {
    let axis = Vec3::from_axis(dim);
    …
}
```

I'm open to suggestions for the name though. `from_unit_dimension`, `from_numbered_axis` etc.