### PR TITLE
add euler rotation sequence conversion

### DIFF
--- a/src/core/traits/scalar.rs
+++ b/src/core/traits/scalar.rs
@@ -19,6 +19,7 @@ pub trait Signed: Sized + Num + core::ops::Neg<Output = Self> {
 
 #[cfg(not(feature = "libm"))]
 pub trait Float: Num + Copy + core::ops::Neg<Output = Self> {
+    fn asin(self) -> Self;
     fn acos(self) -> Self;
     fn ceil(self) -> Self;
     fn exp(self) -> Self;
@@ -65,6 +66,10 @@ macro_rules! impl_float_trait {
         impl_signed_trait!($t);
 
         impl Float for $t {
+            #[inline(always)]
+            fn asin(self) -> Self {
+                $t::asin(self)
+            }
             #[inline(always)]
             fn acos(self) -> Self {
                 $t::acos(self)

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -1,0 +1,271 @@
+/*
+Conversion from quaternions to Euler rotation sequences.
+
+From: http://bediyap.com/programming/convert-quaternion-to-euler-rotations/
+*/
+
+use super::quat::{DQuat, Quat};
+use crate::core::traits::scalar::*;
+
+/// Euler rotation sequences.
+///
+/// The angles are applied starting from the right.
+/// E.g. XYZ will first apply the z-axis rotation.
+///
+/// YXZ can be used for yaw (y-axis), pitch (x-axis), role (z-axis).
+///
+/// The two-axis rotations (e.g. ZYZ) are not fully tested and have to be treated with caution.
+#[derive(Debug, Clone, Copy)]
+pub enum EulerRot {
+    /// Intrinsic three-axis rotation ZYX
+    ZYXi,
+    /// Intrinsic three-axis rotation ZXY
+    ZXYi,
+    /// Intrinsic three-axis rotation YXZ
+    YXZi,
+    /// Intrinsic three-axis rotation YZX
+    YZXi,
+    /// Intrinsic three-axis rotation XYZ
+    XYZi,
+    /// Intrinsic three-axis rotation XZY
+    XZYi,
+
+    /// Intrinsic two-axis rotation ZYZ
+    #[deprecated(note = "Untested! Use at own risk!")]
+    ZYZi,
+    /// Intrinsic two-axis rotation ZXZ
+    #[deprecated(note = "Untested! Use at own risk!")]
+    ZXZi,
+    /// Intrinsic two-axis rotation YXY
+    #[deprecated(note = "Untested! Use at own risk!")]
+    YXYi,
+    /// Intrinsic two-axis rotation YZY
+    #[deprecated(note = "Untested! Use at own risk!")]
+    YZYi,
+    /// Intrinsic two-axis rotation XYX
+    #[deprecated(note = "Untested! Use at own risk!")]
+    XYXi,
+    /// Intrinsic two-axis rotation XZX
+    #[deprecated(note = "Untested! Use at own risk!")]
+    XZXi,
+}
+
+impl Default for EulerRot {
+    /// Default YXZi as yaw (y-axis), pitch (x-axis), role (z-axis).
+    fn default() -> Self {
+        Self::YXZi
+    }
+}
+
+/// Conversion from quaternion to euler angles.
+pub trait EulerFromQuaternion<Q: Copy>: Sized + Copy {
+    type Output: FloatEx;
+    /// Compute the angle of the first axis (X-x-x)
+    fn first(self, q: Q) -> Self::Output;
+    /// Compute then angle of the second axis (x-X-x)
+    fn second(self, q: Q) -> Self::Output;
+    /// Compute then angle of the third axis (x-x-X)
+    fn third(self, q: Q) -> Self::Output;
+
+    /// Compute all angles of a rotation in the notation order
+    fn from_quat(self, q: Q) -> (Self::Output, Self::Output, Self::Output) {
+        (self.first(q), self.second(q), self.third(q))
+    }
+}
+
+/// Conversion from euler angles to quaternion.
+pub trait EulerToQuaternion<T> {
+    type Output;
+    /// Create the rotation quaternion for the three angles of this euler rotation sequence.
+    fn to_quat(self, u: T, v: T, w: T) -> Self::Output;
+}
+
+/// Helper, until std::f32::clamp is stable.
+fn clamp<T: PartialOrd>(value: T, min: T, max: T) -> T {
+    assert!(min <= max);
+    if value < min {
+        min
+    } else if value > max {
+        max
+    } else {
+        value
+    }
+}
+
+/// Adds a atan2 that handles the negative zero case.
+/// Basically forces positive zero in the x-argument for atan2.
+pub trait Atan2Fixed<T = Self> {
+    fn atan2_fixed(self, other: T) -> T;
+}
+impl Atan2Fixed for f32 {
+    fn atan2_fixed(self, other: f32) -> f32 {
+        self.atan2(if other == 0.0f32 { 0.0f32 } else { other })
+    }
+}
+impl Atan2Fixed for f64 {
+    fn atan2_fixed(self, other: f64) -> f64 {
+        self.atan2(if other == 0.0f64 { 0.0f64 } else { other })
+    }
+}
+
+macro_rules! impl_from_quat {
+    ($t:ty, $quat:ident) => {
+        impl EulerFromQuaternion<$quat> for EulerRot {
+            type Output = $t;
+            fn first(self, q: $quat) -> $t {
+                use EulerRot::*;
+                match self {
+                    ZYXi => (Self::Output::TWO * (q.x * q.y + q.w * q.z))
+                        .atan2(q.w * q.w + q.x * q.x - q.y * q.y - q.z * q.z),
+                    ZXYi => (-Self::Output::TWO * (q.x * q.y - q.w * q.z))
+                        .atan2(q.w * q.w - q.x * q.x + q.y * q.y - q.z * q.z),
+                    YXZi => (Self::Output::TWO * (q.x * q.z + q.w * q.y))
+                        .atan2(q.w * q.w - q.x * q.x - q.y * q.y + q.z * q.z),
+                    YZXi => (-Self::Output::TWO * (q.x * q.z - q.w * q.y))
+                        .atan2(q.w * q.w + q.x * q.x - q.y * q.y - q.z * q.z),
+                    XYZi => (-Self::Output::TWO * (q.y * q.z - q.w * q.x))
+                        .atan2(q.w * q.w - q.x * q.x - q.y * q.y + q.z * q.z),
+                    XZYi => (Self::Output::TWO * (q.y * q.z + q.w * q.x))
+                        .atan2(q.w * q.w - q.x * q.x + q.y * q.y - q.z * q.z),
+                    #[allow(deprecated)]
+                    ZYZi => (Self::Output::TWO * (q.y * q.z + q.w * q.x))
+                        .atan2_fixed(-Self::Output::TWO * (q.x * q.z - q.w * q.y)),
+                    #[allow(deprecated)]
+                    ZXZi => (Self::Output::TWO * (q.x * q.z - q.w * q.y))
+                        .atan2_fixed(Self::Output::TWO * (q.y * q.z + q.w * q.x)),
+                    #[allow(deprecated)]
+                    YXYi => (Self::Output::TWO * (q.x * q.y + q.w * q.z))
+                        .atan2_fixed(-Self::Output::TWO * (q.y * q.z - q.w * q.x)),
+                    #[allow(deprecated)]
+                    YZYi => (Self::Output::TWO * (q.y * q.z - q.w * q.x))
+                        .atan2_fixed(Self::Output::TWO * (q.x * q.y + q.w * q.z)),
+                    #[allow(deprecated)]
+                    XYXi => (Self::Output::TWO * (q.x * q.y - q.w * q.z))
+                        .atan2_fixed(Self::Output::TWO * (q.x * q.z + q.w * q.y)),
+                    #[allow(deprecated)]
+                    XZXi => (Self::Output::TWO * (q.x * q.z + q.w * q.y))
+                        .atan2_fixed(-Self::Output::TWO * (q.x * q.y - q.w * q.z)),
+                }
+            }
+
+            fn second(self, q: $quat) -> $t {
+                use EulerRot::*;
+
+                /// Clamp number to range [-1,1](-1,1) for asin() and acos(), else NaN is possible.
+                #[inline(always)]
+                fn arc_clamp<T: FloatEx>(val: T) -> T {
+                    clamp(val, T::NEG_ONE, T::ONE)
+                }
+                match self {
+                    ZYXi => arc_clamp(-Self::Output::TWO * (q.x * q.z - q.w * q.y)).asin(),
+                    ZXYi => arc_clamp(Self::Output::TWO * (q.y * q.z + q.w * q.x)).asin(),
+                    YXZi => arc_clamp(-Self::Output::TWO * (q.y * q.z - q.w * q.x)).asin(),
+                    YZXi => arc_clamp(Self::Output::TWO * (q.x * q.y + q.w * q.z)).asin(),
+                    XYZi => arc_clamp(Self::Output::TWO * (q.x * q.z + q.w * q.y)).asin(),
+                    XZYi => arc_clamp(-Self::Output::TWO * (q.x * q.y - q.w * q.z)).asin(),
+                    #[allow(deprecated)]
+                    ZYZi => arc_clamp(q.w * q.w - q.x * q.x - q.y * q.y + q.z * q.z).acos(),
+                    #[allow(deprecated)]
+                    ZXZi => arc_clamp(q.w * q.w - q.x * q.x - q.y * q.y + q.z * q.z).acos(),
+                    #[allow(deprecated)]
+                    YXYi => arc_clamp(q.w * q.w - q.x * q.x + q.y * q.y - q.z * q.z).acos(),
+                    #[allow(deprecated)]
+                    YZYi => arc_clamp(q.w * q.w - q.x * q.x + q.y * q.y - q.z * q.z).acos(),
+                    #[allow(deprecated)]
+                    XYXi => arc_clamp(q.w * q.w + q.x * q.x - q.y * q.y - q.z * q.z).acos(),
+                    #[allow(deprecated)]
+                    XZXi => arc_clamp(q.w * q.w + q.x * q.x - q.y * q.y - q.z * q.z).acos(),
+                }
+            }
+
+            fn third(self, q: $quat) -> $t {
+                use EulerRot::*;
+                #[allow(deprecated)]
+                match self {
+                    ZYXi => (Self::Output::TWO * (q.y * q.z + q.w * q.x))
+                        .atan2(q.w * q.w - q.x * q.x - q.y * q.y + q.z * q.z),
+                    ZXYi => (-Self::Output::TWO * (q.x * q.z - q.w * q.y))
+                        .atan2(q.w * q.w - q.x * q.x - q.y * q.y + q.z * q.z),
+                    YXZi => (Self::Output::TWO * (q.x * q.y + q.w * q.z))
+                        .atan2(q.w * q.w - q.x * q.x + q.y * q.y - q.z * q.z),
+                    YZXi => (-Self::Output::TWO * (q.y * q.z - q.w * q.x))
+                        .atan2(q.w * q.w - q.x * q.x + q.y * q.y - q.z * q.z),
+                    XYZi => (-Self::Output::TWO * (q.x * q.y - q.w * q.z))
+                        .atan2(q.w * q.w + q.x * q.x - q.y * q.y - q.z * q.z),
+                    XZYi => (Self::Output::TWO * (q.x * q.z + q.w * q.y))
+                        .atan2(q.w * q.w + q.x * q.x - q.y * q.y - q.z * q.z),
+                    #[allow(deprecated)]
+                    ZYZi => (Self::Output::TWO * (q.y * q.z - q.w * q.x))
+                        .atan2_fixed(Self::Output::TWO * (q.x * q.z + q.w * q.y)),
+                    #[allow(deprecated)]
+                    ZXZi => (Self::Output::TWO * (q.x * q.z + q.w * q.y))
+                        .atan2_fixed(-Self::Output::TWO * (q.y * q.z - q.w * q.x)),
+                    #[allow(deprecated)]
+                    YXYi => (Self::Output::TWO * (q.x * q.y - q.w * q.z))
+                        .atan2_fixed(Self::Output::TWO * (q.y * q.z + q.w * q.x)),
+                    #[allow(deprecated)]
+                    YZYi => (Self::Output::TWO * (q.y * q.z + q.w * q.x))
+                        .atan2_fixed(-Self::Output::TWO * (q.x * q.y - q.w * q.z)),
+                    #[allow(deprecated)]
+                    XYXi => (Self::Output::TWO * (q.x * q.y + q.w * q.z))
+                        .atan2_fixed(-Self::Output::TWO * (q.x * q.z - q.w * q.y)),
+                    #[allow(deprecated)]
+                    XZXi => (Self::Output::TWO * (q.x * q.z - q.w * q.y))
+                        .atan2_fixed(Self::Output::TWO * (q.x * q.y + q.w * q.z)),
+                }
+            }
+        }
+        // End - impl EulerFromQuaternion
+    };
+}
+
+macro_rules! impl_to_quat {
+    ($t:ty, $quat:ident) => {
+        impl EulerToQuaternion<$t> for EulerRot {
+            type Output = $quat;
+            #[inline(always)]
+            fn to_quat(self, u: $t, v: $t, w: $t) -> $quat {
+                use EulerRot::*;
+                #[inline(always)]
+                fn rot_x(a: $t) -> $quat {
+                    $quat::from_rotation_x(a)
+                }
+                #[inline(always)]
+                fn rot_y(a: $t) -> $quat {
+                    $quat::from_rotation_y(a)
+                }
+                #[inline(always)]
+                fn rot_z(a: $t) -> $quat {
+                    $quat::from_rotation_z(a)
+                }
+                match self {
+                    ZYXi => rot_z(u) * rot_y(v) * rot_x(w),
+                    ZXYi => rot_z(u) * rot_x(v) * rot_y(w),
+                    YXZi => rot_y(u) * rot_x(v) * rot_z(w),
+                    YZXi => rot_y(u) * rot_z(v) * rot_x(w),
+                    XYZi => rot_x(u) * rot_y(v) * rot_z(w),
+                    XZYi => rot_x(u) * rot_z(v) * rot_y(w),
+                    #[allow(deprecated)]
+                    ZYZi => rot_z(u) * rot_y(v) * rot_z(w),
+                    #[allow(deprecated)]
+                    ZXZi => rot_z(u) * rot_x(v) * rot_z(w),
+                    #[allow(deprecated)]
+                    YXYi => rot_y(u) * rot_x(v) * rot_y(w),
+                    #[allow(deprecated)]
+                    YZYi => rot_y(u) * rot_z(v) * rot_y(w),
+                    #[allow(deprecated)]
+                    XYXi => rot_x(u) * rot_y(v) * rot_x(w),
+                    #[allow(deprecated)]
+                    XZXi => rot_x(u) * rot_z(v) * rot_x(w),
+                }
+                .normalize()
+            }
+        }
+        // End - impl EulerToQuaternion
+    };
+}
+
+impl_from_quat!(f32, Quat);
+impl_from_quat!(f64, DQuat);
+impl_to_quat!(f32, Quat);
+impl_to_quat!(f64, DQuat);

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -68,7 +68,7 @@ pub trait EulerFromQuaternion<Q: Copy>: Sized + Copy {
     fn third(self, q: Q) -> Self::Output;
 
     /// Compute all angles of a rotation in the notation order
-    fn from_quat(self, q: Q) -> (Self::Output, Self::Output, Self::Output) {
+    fn convert_quat(self, q: Q) -> (Self::Output, Self::Output, Self::Output) {
         (self.first(q), self.second(q), self.third(q))
     }
 }
@@ -77,7 +77,7 @@ pub trait EulerFromQuaternion<Q: Copy>: Sized + Copy {
 pub trait EulerToQuaternion<T>: Copy {
     type Output;
     /// Create the rotation quaternion for the three angles of this euler rotation sequence.
-    fn to_quat(self, u: T, v: T, w: T) -> Self::Output;
+    fn new_quat(self, u: T, v: T, w: T) -> Self::Output;
 }
 
 /// Helper, until std::f32::clamp is stable.
@@ -224,7 +224,7 @@ macro_rules! impl_to_quat {
         impl EulerToQuaternion<$t> for EulerRot {
             type Output = $quat;
             #[inline(always)]
-            fn to_quat(self, u: $t, v: $t, w: $t) -> $quat {
+            fn new_quat(self, u: $t, v: $t, w: $t) -> $quat {
                 use EulerRot::*;
                 #[inline(always)]
                 fn rot_x(a: $t) -> $quat {

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -74,7 +74,7 @@ pub trait EulerFromQuaternion<Q: Copy>: Sized + Copy {
 }
 
 /// Conversion from euler angles to quaternion.
-pub trait EulerToQuaternion<T> {
+pub trait EulerToQuaternion<T>: Copy {
     type Output;
     /// Create the rotation quaternion for the three angles of this euler rotation sequence.
     fn to_quat(self, u: T, v: T, w: T) -> Self::Output;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,4 +272,4 @@ pub mod swizzles;
 pub use self::swizzles::{Vec2Swizzles, Vec3Swizzles, Vec4Swizzles};
 
 /** Rotation Helper */
-pub use euler::{EulerFromQuaternion, EulerRot, EulerToQuaternion};
+pub use euler::EulerRot;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,7 @@ mod vec2;
 mod vec3;
 mod vec4;
 mod vec_mask;
+mod euler;
 
 mod features;
 #[cfg(feature = "spirv-std")]
@@ -269,3 +270,6 @@ pub use self::u32::*;
 pub mod swizzles;
 
 pub use self::swizzles::{Vec2Swizzles, Vec3Swizzles, Vec4Swizzles};
+
+/** Rotation Helper */
+pub use euler::{EulerRot, EulerFromQuaternion, EulerToQuaternion};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,7 @@ mod vec;
 pub mod cast;
 
 mod core;
+mod euler;
 mod mat2;
 mod mat3;
 mod mat4;
@@ -205,7 +206,6 @@ mod vec2;
 mod vec3;
 mod vec4;
 mod vec_mask;
-mod euler;
 
 mod features;
 #[cfg(feature = "spirv-std")]
@@ -272,4 +272,4 @@ pub mod swizzles;
 pub use self::swizzles::{Vec2Swizzles, Vec3Swizzles, Vec4Swizzles};
 
 /** Rotation Helper */
-pub use euler::{EulerRot, EulerFromQuaternion, EulerToQuaternion};
+pub use euler::{EulerFromQuaternion, EulerRot, EulerToQuaternion};

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -3,6 +3,7 @@ use crate::core::traits::{
     vector::{FloatVector4, MaskVector4, Vector, Vector4, Vector4Const},
 };
 use crate::{DMat3, DMat4, DVec3, DVec4};
+use crate::{EulerFromQuaternion, EulerRot, EulerToQuaternion};
 use crate::{Mat3, Mat4, Vec3, Vec3A, Vec4};
 
 #[cfg(not(feature = "std"))]
@@ -126,6 +127,12 @@ macro_rules! impl_quat_methods {
             Self($inner::from_rotation_ypr(yaw, pitch, roll))
         }
 
+        #[inline(always)]
+        /// Create a quaternion from the given euler rotation sequence and the angles in radians.
+        pub fn from_euler(euler: EulerRot, a: $t, b: $t, c: $t) -> Self {
+            euler.new_quat(a, b, c)
+        }
+
         /// Creates a quaternion from a 3x3 rotation matrix.
         #[inline]
         pub fn from_rotation_mat3(mat: &$mat3) -> Self {
@@ -206,6 +213,12 @@ macro_rules! impl_quat_methods {
         pub fn to_scaled_axis(self) -> $vec3 {
             let (axis, angle) = self.0.to_axis_angle();
             $vec3(axis) * angle
+        }
+
+        /// Returns the rotation angles for the given euler rotation sequence.
+        #[inline(always)]
+        pub fn to_euler(self, euler: EulerRot) -> ($t, $t, $t) {
+            euler.convert_quat(self)
         }
 
         /// Returns the quaternion conjugate of `self`. For a unit quaternion the

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -2,8 +2,8 @@ use crate::core::traits::{
     quaternion::Quaternion,
     vector::{FloatVector4, MaskVector4, Vector, Vector4, Vector4Const},
 };
-use crate::{DMat3, DMat4, DVec3, DVec4};
 use crate::euler::{EulerFromQuaternion, EulerRot, EulerToQuaternion};
+use crate::{DMat3, DMat4, DVec3, DVec4};
 use crate::{Mat3, Mat4, Vec3, Vec3A, Vec4};
 
 #[cfg(not(feature = "std"))]

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -3,7 +3,7 @@ use crate::core::traits::{
     vector::{FloatVector4, MaskVector4, Vector, Vector4, Vector4Const},
 };
 use crate::{DMat3, DMat4, DVec3, DVec4};
-use crate::{EulerFromQuaternion, EulerRot, EulerToQuaternion};
+use crate::euler::{EulerFromQuaternion, EulerRot, EulerToQuaternion};
 use crate::{Mat3, Mat4, Vec3, Vec3A, Vec4};
 
 #[cfg(not(feature = "std"))]

--- a/tests/euler.rs
+++ b/tests/euler.rs
@@ -116,7 +116,7 @@ macro_rules! impl_3axis_test {
 
                         // Test angle reconstruction
                         let (u2, v2, w2) = q1.to_euler(euler);
-                        let q3 = euler.new_quat(u2, v2, w2).normalize();
+                        let q3 = $quat::from_euler(euler, u2, v2, w2).normalize();
 
                         assert_approx_angle!(u1, u2, 1e-4 as $t);
                         assert_approx_angle!(v1, v2, 1e-4 as $t);
@@ -167,7 +167,7 @@ macro_rules! impl_2axis_test {
 
                         // Test angle reconstruction
                         let (u2, v2, w2) = q1.to_euler(euler);
-                        let _q3 = euler.new_quat(u2, v2, w2).normalize();
+                        let _q3 = $quat::from_euler(euler, u2, v2, w2).normalize();
 
                         // Disabled tests, since no generic tests for ambiguous results in the two-axis results...
                         // assert_approx_angle!(u1, u2, 1e-4 as $t);

--- a/tests/euler.rs
+++ b/tests/euler.rs
@@ -111,12 +111,12 @@ macro_rules! impl_three_axis_test {
                         .normalize();
 
                         // Test if the rotation is the expected
-                        let q2: $quat = euler.to_quat(u1, v1, w1).normalize();
+                        let q2: $quat = $quat::from_euler(euler, u1, v1, w1).normalize();
                         assert_approx_eq!(q1, q2, 1e-5);
 
                         // Test angle reconstruction
-                        let (u2, v2, w2) = euler.from_quat(q1);
-                        let q3 = euler.to_quat(u2, v2, w2).normalize();
+                        let (u2, v2, w2) = q1.to_euler(euler);
+                        let q3 = euler.new_quat(u2, v2, w2).normalize();
 
                         assert_approx_angle!(u1, u2, 1e-4 as $t);
                         assert_approx_angle!(v1, v2, 1e-4 as $t);
@@ -162,15 +162,14 @@ macro_rules! impl_two_axis_test {
                         .normalize();
 
                         // Test if the rotation is the expected
-                        let q2: $quat = euler.to_quat(u1, v1, w1).normalize();
+                        let q2 = $quat::from_euler(euler, u1, v1, w1).normalize();
                         assert_approx_eq!(q1, q2, 1e-5);
 
                         // Test angle reconstruction
-                        let (u2, v2, w2) = euler.from_quat(q1);
-                        let _q3 = euler.to_quat(u2, v2, w2).normalize();
+                        let (u2, v2, w2) = q1.to_euler(euler);
+                        let _q3 = euler.new_quat(u2, v2, w2).normalize();
 
-                        //
-
+                        // Disabled tests, since no generic tests for ambiguous results in the two-axis results...
                         // assert_approx_angle!(u1, u2, 1e-4 as $t);
                         // assert_approx_angle!(v1, v2, 1e-4 as $t);
                         // assert_approx_angle!(w1, w2, 1e-4 as $t);

--- a/tests/euler.rs
+++ b/tests/euler.rs
@@ -83,7 +83,7 @@ impl_eq_approx!(f32, Quat, std::f32::consts::PI);
 impl_eq_approx!(f64, DQuat, std::f64::consts::PI);
 
 #[macro_export]
-macro_rules! impl_three_axis_test {
+macro_rules! impl_3axis_test {
     ($name:ident, $t:ty, $quat:ident, $euler:path, $U:path, $V:path, $W:path, $vec:ident) => {
         #[test]
         fn $name() {
@@ -133,7 +133,7 @@ macro_rules! impl_three_axis_test {
 }
 
 #[macro_export]
-macro_rules! impl_two_axis_test {
+macro_rules! impl_2axis_test {
     ($name:ident, $t:ty, $quat:ident, $euler:path, $U:path, $V:path, $W:path, $vec:ident) => {
         #[test]
         fn $name() {
@@ -186,41 +186,43 @@ macro_rules! impl_two_axis_test {
 
 macro_rules! impl_all_quat_tests_three_axis {
     ($t:ty, $q:ident, $v:ident) => {
-        impl_three_axis_test!(test_zyx, $t, $q, EulerRot::ZYXi, $v::Z, $v::Y, $v::X, $v);
-        impl_three_axis_test!(test_zxy, $t, $q, EulerRot::ZXYi, $v::Z, $v::X, $v::Y, $v);
-        impl_three_axis_test!(test_yxz, $t, $q, EulerRot::YXZi, $v::Y, $v::X, $v::Z, $v);
-        impl_three_axis_test!(test_yzx, $t, $q, EulerRot::YZXi, $v::Y, $v::Z, $v::X, $v);
-        impl_three_axis_test!(test_xyz, $t, $q, EulerRot::XYZi, $v::X, $v::Y, $v::Z, $v);
-        impl_three_axis_test!(test_xzy, $t, $q, EulerRot::XZYi, $v::X, $v::Z, $v::Y, $v);
+        impl_3axis_test!(test_euler_zyx, $t, $q, ER::ZYXi, $v::Z, $v::Y, $v::X, $v);
+        impl_3axis_test!(test_euler_zxy, $t, $q, ER::ZXYi, $v::Z, $v::X, $v::Y, $v);
+        impl_3axis_test!(test_euler_yxz, $t, $q, ER::YXZi, $v::Y, $v::X, $v::Z, $v);
+        impl_3axis_test!(test_euler_yzx, $t, $q, ER::YZXi, $v::Y, $v::Z, $v::X, $v);
+        impl_3axis_test!(test_euler_xyz, $t, $q, ER::XYZi, $v::X, $v::Y, $v::Z, $v);
+        impl_3axis_test!(test_euler_xzy, $t, $q, ER::XZYi, $v::X, $v::Z, $v::Y, $v);
     };
 }
 
 macro_rules! impl_all_quat_tests_two_axis {
     ($t:ty, $q:ident, $v:ident) => {
-        impl_two_axis_test!(test_zyz, $t, $q, EulerRot::ZYZi, $v::Z, $v::Y, $v::Z, $v);
-        impl_two_axis_test!(test_zxz, $t, $q, EulerRot::ZXZi, $v::Z, $v::X, $v::Z, $v);
-        impl_two_axis_test!(test_yxy, $t, $q, EulerRot::YXYi, $v::Y, $v::X, $v::Y, $v);
-        impl_two_axis_test!(test_yzy, $t, $q, EulerRot::YZYi, $v::Y, $v::Z, $v::Y, $v);
-        impl_two_axis_test!(test_xyx, $t, $q, EulerRot::XYXi, $v::X, $v::Y, $v::X, $v);
-        impl_two_axis_test!(test_xzx, $t, $q, EulerRot::XZXi, $v::X, $v::Z, $v::X, $v);
+        impl_2axis_test!(test_euler_zyz, $t, $q, ER::ZYZi, $v::Z, $v::Y, $v::Z, $v);
+        impl_2axis_test!(test_euler_zxz, $t, $q, ER::ZXZi, $v::Z, $v::X, $v::Z, $v);
+        impl_2axis_test!(test_euler_yxy, $t, $q, ER::YXYi, $v::Y, $v::X, $v::Y, $v);
+        impl_2axis_test!(test_euler_yzy, $t, $q, ER::YZYi, $v::Y, $v::Z, $v::Y, $v);
+        impl_2axis_test!(test_euler_xyx, $t, $q, ER::XYXi, $v::X, $v::Y, $v::X, $v);
+        impl_2axis_test!(test_euler_xzx, $t, $q, ER::XZXi, $v::X, $v::Z, $v::X, $v);
     };
 }
 
-#[cfg(test)]
-mod quat {
+mod euler {
     use super::AngleDiff;
     use glam::*;
+    type ER = EulerRot;
 
-    impl_all_quat_tests_three_axis!(f32, Quat, Vec3);
+    mod quat {
+        use super::*;
 
-    impl_all_quat_tests_two_axis!(f32, Quat, Vec3);
-}
+        impl_all_quat_tests_three_axis!(f32, Quat, Vec3);
 
-#[cfg(test)]
-mod dquat {
-    use super::AngleDiff;
-    use glam::*;
+        impl_all_quat_tests_two_axis!(f32, Quat, Vec3);
+    }
 
-    impl_all_quat_tests_three_axis!(f64, DQuat, DVec3);
-    impl_all_quat_tests_two_axis!(f64, DQuat, DVec3);
+    mod dquat {
+        use super::*;
+
+        impl_all_quat_tests_three_axis!(f64, DQuat, DVec3);
+        impl_all_quat_tests_two_axis!(f64, DQuat, DVec3);
+    }
 }

--- a/tests/euler.rs
+++ b/tests/euler.rs
@@ -1,0 +1,227 @@
+use glam::{DQuat, Quat};
+
+#[macro_use]
+mod support;
+
+/// Helper to calculate the inner angle in the range [0, 2*PI)
+trait AngleDiff {
+    type Output;
+    fn angle_diff(self, other: Self) -> Self::Output;
+}
+#[macro_export]
+macro_rules! impl_angle_diff {
+    ($t:ty, $pi:expr) => {
+        impl AngleDiff for $t {
+            type Output = $t;
+            fn angle_diff(self, other: $t) -> $t {
+                const PI2: $t = $pi + $pi;
+                let s = self.rem_euclid(PI2);
+                let o = other.rem_euclid(PI2);
+                if s > o {
+                    (s - o).min(PI2 + o - s)
+                } else {
+                    (o - s).min(PI2 + s - o)
+                }
+            }
+        }
+    };
+}
+impl_angle_diff!(f32, std::f32::consts::PI);
+impl_angle_diff!(f64, std::f64::consts::PI);
+
+#[macro_export]
+macro_rules! assert_approx_angle {
+    ($a:expr, $b:expr, $eps:expr) => {{
+        let (a, b) = ($a, $b);
+        let eps = $eps;
+        let diff = a.angle_diff(b);
+        assert!(
+            diff < $eps,
+            "assertion failed: `(left !== right)` \
+             (left: `{:?}`, right: `{:?}`, expect diff: `{:?}`, real diff: `{:?}`)",
+            a,
+            b,
+            eps,
+            diff
+        );
+    }};
+}
+
+trait EqApprox {
+    type EPS;
+    fn eq_approx(self, other: Self, axis_eps: Self::EPS, rot_axis: Self::EPS) -> bool;
+}
+
+macro_rules! impl_eq_approx {
+    ($t:ty, $quat:ident, $pi:expr) => {
+        impl EqApprox for $quat {
+            type EPS = $t;
+            fn eq_approx(self, other: Self, axis_eps: Self::EPS, rot_axis: Self::EPS) -> bool {
+                let (s_axis, s_angle) = self.to_axis_angle();
+                let (o_axis, o_angle) = other.to_axis_angle();
+                if s_angle.abs() < rot_axis && o_angle.abs() < rot_axis {
+                    // No rotation
+                    true
+                } else {
+                    let a = s_axis.angle_between(o_axis);
+                    if a < axis_eps {
+                        // Same axes
+                        (s_angle - o_angle).abs() < rot_axis
+                    } else if ($pi - a).abs() < axis_eps {
+                        // Inverted axes (180°)
+                        (s_angle + o_angle).abs() < rot_axis
+                    } else {
+                        // Other
+                        false
+                    }
+                }
+            }
+        }
+    };
+}
+impl_eq_approx!(f32, Quat, std::f32::consts::PI);
+impl_eq_approx!(f64, DQuat, std::f64::consts::PI);
+
+#[macro_export]
+macro_rules! impl_three_axis_test {
+    ($name:ident, $t:ty, $quat:ident, $euler:path, $U:path, $V:path, $W:path, $vec:ident) => {
+        #[test]
+        fn $name() {
+            let euler = $euler;
+            assert!($U != $W); // First and last axis must be different for three axis
+            for u in -179..=179 {
+                if u % 2 != 0 {
+                    continue;
+                }
+                for v in -89..=89 {
+                    if v % 2 != 0 {
+                        continue;
+                    }
+                    for w in -179..=179 {
+                        if w % 2 != 0 {
+                            continue;
+                        }
+                        let u1 = (u as $t).to_radians();
+                        let v1 = (v as $t).to_radians();
+                        let w1 = (w as $t).to_radians();
+
+                        let q1: $quat = ($quat::from_axis_angle($U, u1)
+                            * $quat::from_axis_angle($V, v1)
+                            * $quat::from_axis_angle($W, w1))
+                        .normalize();
+
+                        // Test if the rotation is the expected
+                        let q2: $quat = euler.to_quat(u1, v1, w1).normalize();
+                        assert_approx_eq!(q1, q2, 1e-5);
+
+                        // Test angle reconstruction
+                        let (u2, v2, w2) = euler.from_quat(q1);
+                        let q3 = euler.to_quat(u2, v2, w2).normalize();
+
+                        assert_approx_angle!(u1, u2, 1e-4 as $t);
+                        assert_approx_angle!(v1, v2, 1e-4 as $t);
+                        assert_approx_angle!(w1, w2, 1e-4 as $t);
+
+                        assert_approx_eq!(q1 * $vec::X, q3 * $vec::X, 1e-4);
+                        assert_approx_eq!(q1 * $vec::Y, q3 * $vec::Y, 1e-4);
+                        assert_approx_eq!(q1 * $vec::Z, q3 * $vec::Z, 1e-4);
+                    }
+                }
+            }
+        }
+    };
+}
+
+#[macro_export]
+macro_rules! impl_two_axis_test {
+    ($name:ident, $t:ty, $quat:ident, $euler:path, $U:path, $V:path, $W:path, $vec:ident) => {
+        #[test]
+        fn $name() {
+            #[allow(deprecated)]
+            let euler = $euler;
+            assert!($U == $W); // First and last axis must be different for three axis
+            for u in -179..=179 {
+                if u % 2 != 0 {
+                    continue;
+                }
+                for v in -89..=89 {
+                    if v % 2 != 0 {
+                        continue;
+                    }
+                    for w in -179..=179 {
+                        if w % 2 != 0 {
+                            continue;
+                        }
+                        let u1 = (u as $t).to_radians();
+                        let v1 = (v as $t).to_radians();
+                        let w1 = (w as $t).to_radians();
+
+                        let q1: $quat = ($quat::from_axis_angle($U, u1)
+                            * $quat::from_axis_angle($V, v1)
+                            * $quat::from_axis_angle($W, w1))
+                        .normalize();
+
+                        // Test if the rotation is the expected
+                        let q2: $quat = euler.to_quat(u1, v1, w1).normalize();
+                        assert_approx_eq!(q1, q2, 1e-5);
+
+                        // Test angle reconstruction
+                        let (u2, v2, w2) = euler.from_quat(q1);
+                        let _q3 = euler.to_quat(u2, v2, w2).normalize();
+
+                        //
+
+                        // assert_approx_angle!(u1, u2, 1e-4 as $t);
+                        // assert_approx_angle!(v1, v2, 1e-4 as $t);
+                        // assert_approx_angle!(w1, w2, 1e-4 as $t);
+
+                        // assert_approx_eq!(q1 * $vec::X, q3 * $vec::X, 1e-4);
+                        // assert_approx_eq!(q1 * $vec::Y, q3 * $vec::Y, 1e-4);
+                        // assert_approx_eq!(q1 * $vec::Z, q3 * $vec::Z, 1e-4);
+                    }
+                }
+            }
+        }
+    };
+}
+
+macro_rules! impl_all_quat_tests_three_axis {
+    ($t:ty, $q:ident, $v:ident) => {
+        impl_three_axis_test!(test_zyx, $t, $q, EulerRot::ZYXi, $v::Z, $v::Y, $v::X, $v);
+        impl_three_axis_test!(test_zxy, $t, $q, EulerRot::ZXYi, $v::Z, $v::X, $v::Y, $v);
+        impl_three_axis_test!(test_yxz, $t, $q, EulerRot::YXZi, $v::Y, $v::X, $v::Z, $v);
+        impl_three_axis_test!(test_yzx, $t, $q, EulerRot::YZXi, $v::Y, $v::Z, $v::X, $v);
+        impl_three_axis_test!(test_xyz, $t, $q, EulerRot::XYZi, $v::X, $v::Y, $v::Z, $v);
+        impl_three_axis_test!(test_xzy, $t, $q, EulerRot::XZYi, $v::X, $v::Z, $v::Y, $v);
+    };
+}
+
+macro_rules! impl_all_quat_tests_two_axis {
+    ($t:ty, $q:ident, $v:ident) => {
+        impl_two_axis_test!(test_zyz, $t, $q, EulerRot::ZYZi, $v::Z, $v::Y, $v::Z, $v);
+        impl_two_axis_test!(test_zxz, $t, $q, EulerRot::ZXZi, $v::Z, $v::X, $v::Z, $v);
+        impl_two_axis_test!(test_yxy, $t, $q, EulerRot::YXYi, $v::Y, $v::X, $v::Y, $v);
+        impl_two_axis_test!(test_yzy, $t, $q, EulerRot::YZYi, $v::Y, $v::Z, $v::Y, $v);
+        impl_two_axis_test!(test_xyx, $t, $q, EulerRot::XYXi, $v::X, $v::Y, $v::X, $v);
+        impl_two_axis_test!(test_xzx, $t, $q, EulerRot::XZXi, $v::X, $v::Z, $v::X, $v);
+    };
+}
+
+#[cfg(test)]
+mod quat {
+    use super::AngleDiff;
+    use glam::*;
+
+    impl_all_quat_tests_three_axis!(f32, Quat, Vec3);
+
+    impl_all_quat_tests_two_axis!(f32, Quat, Vec3);
+}
+
+#[cfg(test)]
+mod dquat {
+    use super::AngleDiff;
+    use glam::*;
+
+    impl_all_quat_tests_three_axis!(f64, DQuat, DVec3);
+    impl_all_quat_tests_two_axis!(f64, DQuat, DVec3);
+}

--- a/tests/euler.rs
+++ b/tests/euler.rs
@@ -206,6 +206,37 @@ macro_rules! impl_all_quat_tests_two_axis {
     };
 }
 
+macro_rules! impl_ypr_test {
+    ($t:ty, $quat:ident, $euler:path) => {
+        #[test]
+        fn test_ypr() {
+            let euler = $euler;
+            for u in -179..=179 {
+                if u % 2 != 0 {
+                    continue;
+                }
+                for v in -89..=89 {
+                    if v % 2 != 0 {
+                        continue;
+                    }
+                    for w in -179..=179 {
+                        if w % 2 != 0 {
+                            continue;
+                        }
+                        let u1 = (u as $t).to_radians();
+                        let v1 = (v as $t).to_radians();
+                        let w1 = (w as $t).to_radians();
+
+                        let q1: $quat = $quat::from_euler(euler, u1, v1, w1);
+                        let q2: $quat = $quat::from_rotation_ypr(u1, v1, w1);
+                        assert_approx_eq!(q1, q2, 1e-5);
+                    }
+                }
+            }
+        }
+    };
+}
+
 mod euler {
     use super::AngleDiff;
     use glam::*;
@@ -217,12 +248,17 @@ mod euler {
         impl_all_quat_tests_three_axis!(f32, Quat, Vec3);
 
         impl_all_quat_tests_two_axis!(f32, Quat, Vec3);
+
+        impl_ypr_test!(f32, Quat, ER::YXZi);
     }
 
     mod dquat {
         use super::*;
 
         impl_all_quat_tests_three_axis!(f64, DQuat, DVec3);
+
         impl_all_quat_tests_two_axis!(f64, DQuat, DVec3);
+
+        impl_ypr_test!(f64, DQuat, ER::YXZi);
     }
 }


### PR DESCRIPTION
Rust-port to convert quaternions to Euler rotation sequences.
Equations from: http://bediyap.com/programming/convert-quaternion-to-euler-rotations/

The two-axis Euler rotations (e.g. ZYZ) are not fully tested have to be treated with caution.
This is due how the test-implementation works and I haven't found a better generic way to test it.

### Usage
```rust
let q = Quat::from_euler(EulerRot::YXZi, 0.3, 0.1, 0.0);
let (y, x, z) = q.to_euler(EulerRot::YXZi);  // the "i" indicates intrinsic
```

```rust
let q = DQuat::from_euler(EulerRot::YXZi, 0.3, 0.1, 0.0);
let (y, x, z) = q.to_euler(EulerRot::YXZi);  // the "i" indicates intrinsic
```