### PR TITLE
Renamed `Affine3` to `Affine3A`, `TransformRT` to `Isometry3A` and `TransformSRT` to `Transform3A`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,12 @@ harness = false
 [[bench]]
 name = "affine2"
 harness = false
+required-features = ["transform-types"]
 
 [[bench]]
 name = "affine3"
 harness = false
+required-features = ["transform-types"]
 
 [[bench]]
 name = "mat4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,10 @@ name = "mat3"
 harness = false
 
 [[bench]]
+name = "mat3a"
+harness = false
+
+[[bench]]
 name = "affine2"
 harness = false
 required-features = ["transform-types"]

--- a/benches/affine2.rs
+++ b/benches/affine2.rs
@@ -8,6 +8,14 @@ use glam::Affine2;
 use std::ops::Mul;
 use support::*;
 
+pub fn random_srt_affine2(rng: &mut PCG32) -> Affine2 {
+    Affine2::from_scale_angle_translation(
+        random_nonzero_vec2(rng),
+        random_radians(rng),
+        random_vec2(rng),
+    )
+}
+
 bench_unop!(affine2_inverse, "affine2 inverse", op => inverse, from => random_srt_affine2);
 bench_binop!(
     affine2_transform_point2,

--- a/benches/affine3.rs
+++ b/benches/affine3.rs
@@ -8,6 +8,14 @@ use glam::Affine3A;
 use std::ops::Mul;
 use support::*;
 
+pub fn random_srt_affine3a(rng: &mut PCG32) -> Affine3A {
+    Affine3A::from_scale_rotation_translation(
+        random_nonzero_vec3(rng),
+        random_quat(rng),
+        random_vec3(rng),
+    )
+}
+
 bench_unop!(affine3a_inverse, "affine3a inverse", op => inverse, from => random_srt_affine3a);
 
 bench_binop!(

--- a/benches/affine3.rs
+++ b/benches/affine3.rs
@@ -4,7 +4,7 @@ mod macros;
 mod support;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use glam::Affine3;
+use glam::Affine3A;
 use std::ops::Mul;
 use support::*;
 
@@ -43,7 +43,7 @@ pub fn affine3_from_srt(c: &mut Criterion) {
             })
             .collect::<Vec<(Vec3, Quat, Vec3)>>(),
     );
-    let mut outputs = vec![Affine3::default(); SIZE];
+    let mut outputs = vec![Affine3A::IDENTITY; SIZE];
     let mut i = 0;
     c.bench_function("affine3 from srt", |b| {
         b.iter(|| {
@@ -51,7 +51,7 @@ pub fn affine3_from_srt(c: &mut Criterion) {
             unsafe {
                 let data = inputs.get_unchecked(i);
                 *outputs.get_unchecked_mut(i) =
-                    Affine3::from_scale_rotation_translation(data.0, data.1, data.2)
+                    Affine3A::from_scale_rotation_translation(data.0, data.1, data.2)
             }
         })
     });

--- a/benches/affine3.rs
+++ b/benches/affine3.rs
@@ -8,27 +8,63 @@ use glam::Affine3A;
 use std::ops::Mul;
 use support::*;
 
-bench_unop!(affine3_inverse, "affine3 inverse", op => inverse, from => random_srt_affine3);
+bench_unop!(affine3a_inverse, "affine3a inverse", op => inverse, from => random_srt_affine3a);
+
 bench_binop!(
-    affine3_transform_point3,
-    "affine3 transform point3",
+    affine3a_transform_point3,
+    "affine3a transform point3",
     op => transform_point3,
-    from1 => random_srt_affine3,
+    from1 => random_srt_affine3a,
     from2 => random_vec3
 );
 
 bench_binop!(
-    affine3_transform_vector3,
-    "affine3 transform vector3",
+    affine3a_transform_vector3,
+    "affine3a transform vector3",
     op => transform_vector3,
-    from1 => random_srt_affine3,
+    from1 => random_srt_affine3a,
     from2 => random_vec3
 );
-bench_binop!(affine3_mul_affine3, "affine3 mul affine3", op => mul, from => random_srt_affine3);
-bench_binop!(affine3_mul_mat4, "affine3 mul mat4", op => mul, from1 => random_srt_affine3, from2 => random_srt_mat4);
-bench_binop!(mat4_mul_affine3, "mat4 mul affine3", op => mul, from1 => random_srt_mat4, from2 => random_srt_affine3);
 
-pub fn affine3_from_srt(c: &mut Criterion) {
+bench_binop!(
+    affine3a_transform_point3a,
+    "affine3a transform point3a",
+    op => transform_point3a,
+    from1 => random_srt_affine3a,
+    from2 => random_vec3a
+);
+
+bench_binop!(
+    affine3a_transform_vector3a,
+    "affine3a transform vector3a",
+    op => transform_vector3a,
+    from1 => random_srt_affine3a,
+    from2 => random_vec3a
+);
+
+bench_binop!(
+    affine3a_mul_affine3a,
+    "affine3a mul affine3a",
+    op => mul,
+    from => random_srt_affine3a
+);
+
+bench_binop!(affine3a_mul_mat4,
+    "affine3a mul mat4",
+    op => mul,
+    from1 => random_srt_affine3a,
+    from2 => random_srt_mat4
+);
+
+bench_binop!(
+    mat4_mul_affine3a,
+    "mat4 mul affine3a",
+    op => mul,
+    from1 => random_srt_mat4,
+    from2 => random_srt_affine3a
+);
+
+pub fn affine3a_from_srt(c: &mut Criterion) {
     use glam::{Quat, Vec3};
     const SIZE: usize = 1 << 13;
     let mut rng = support::PCG32::default();
@@ -45,7 +81,7 @@ pub fn affine3_from_srt(c: &mut Criterion) {
     );
     let mut outputs = vec![Affine3A::IDENTITY; SIZE];
     let mut i = 0;
-    c.bench_function("affine3 from srt", |b| {
+    c.bench_function("affine3a from srt", |b| {
         b.iter(|| {
             i = (i + 1) & (SIZE - 1);
             unsafe {
@@ -59,13 +95,15 @@ pub fn affine3_from_srt(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    affine3_inverse,
-    affine3_transform_point3,
-    affine3_transform_vector3,
-    affine3_mul_affine3,
-    affine3_mul_mat4,
-    mat4_mul_affine3,
-    affine3_from_srt,
+    affine3a_from_srt,
+    affine3a_inverse,
+    affine3a_mul_affine3a,
+    affine3a_mul_mat4,
+    affine3a_transform_point3,
+    affine3a_transform_point3a,
+    affine3a_transform_vector3,
+    affine3a_transform_vector3a,
+    mat4_mul_affine3a,
 );
 
 criterion_main!(benches);

--- a/benches/mat3a.rs
+++ b/benches/mat3a.rs
@@ -1,0 +1,72 @@
+#[path = "support/macros.rs"]
+#[macro_use]
+mod macros;
+mod support;
+
+use criterion::{criterion_group, criterion_main, Criterion};
+use glam::Mat3A;
+use std::ops::Mul;
+use support::*;
+
+bench_unop!(
+    mat3a_transpose,
+    "mat3a transpose",
+    op => transpose,
+    from => random_mat3a
+);
+bench_unop!(
+    mat3a_determinant,
+    "mat3a determinant",
+    op => determinant,
+    from => random_mat3a
+);
+bench_unop!(mat3a_inverse, "mat3a inverse", op => inverse, from => random_mat3a);
+bench_binop!(mat3a_mul_mat3a, "mat3a mul mat3a", op => mul, from => random_mat3a);
+bench_from_ypr!(mat3a_from_ypr, "mat3a from ypr", ty => Mat3A);
+
+bench_binop!(
+    mat3a_mul_vec3,
+    "mat3a mul vec3",
+    op => mul,
+    from1 => random_mat3a,
+    from2 => random_vec3
+);
+
+bench_binop!(
+    mat3a_mul_vec3a,
+    "mat3a mul vec3a",
+    op => mul,
+    from1 => random_mat3a,
+    from2 => random_vec3a
+);
+
+bench_binop!(
+    mat3a_transform_point2,
+    "mat3a transform point2",
+    op => transform_point2,
+    from1 => random_srt_mat3a,
+    from2 => random_vec2
+);
+
+bench_binop!(
+    mat3a_transform_vector2,
+    "mat3a transform vector2",
+    op => transform_vector2,
+    from1 => random_srt_mat3a,
+    from2 => random_vec2
+);
+
+criterion_group!(
+    benches,
+    mat3a_transpose,
+    mat3a_determinant,
+    mat3a_inverse,
+    mat3a_mul_vec3,
+    mat3a_mul_vec3a,
+    mat3a_mul_mat3a,
+    mat3a_from_ypr,
+    mat3a_transform_vector2,
+    mat3a_transform_point2,
+);
+
+criterion_main!(benches);

--- a/benches/mat4.rs
+++ b/benches/mat4.rs
@@ -14,14 +14,29 @@ bench_unop!(
     op => transpose,
     from => random_srt_mat4
 );
+
 bench_unop!(
     mat4_determinant,
     "mat4 determinant",
     op => determinant,
     from => random_srt_mat4
 );
-bench_unop!(mat4_inverse, "mat4 inverse", op => inverse, from => random_srt_mat4);
-bench_binop!(mat4_mul_vec4, "mat4 mul vec4", op => mul, from1 => random_srt_mat4, from2 => random_vec4);
+
+bench_unop!(
+    mat4_inverse,
+    "mat4 inverse",
+    op => inverse,
+    from => random_srt_mat4
+);
+
+bench_binop!(
+    mat4_mul_vec4,
+    "mat4 mul vec4",
+    op => mul,
+    from1 => random_srt_mat4,
+    from2 => random_vec4
+);
+
 bench_binop!(
     mat4_transform_point3,
     "mat4 transform point3",
@@ -37,8 +52,35 @@ bench_binop!(
     from1 => random_srt_mat4,
     from2 => random_vec3
 );
-bench_binop!(mat4_mul_mat4, "mat4 mul mat4", op => mul, from => random_srt_mat4);
-bench_from_ypr!(mat4_from_ypr, "mat4 from ypr", ty => Mat4);
+
+bench_binop!(
+    mat4_transform_point3a,
+    "mat4 transform point3a",
+    op => transform_point3a,
+    from1 => random_srt_mat4,
+    from2 => random_vec3a
+);
+
+bench_binop!(
+    mat4_transform_vector3a,
+    "mat4 transform vector3a",
+    op => transform_vector3a,
+    from1 => random_srt_mat4,
+    from2 => random_vec3a
+);
+
+bench_binop!(
+    mat4_mul_mat4,
+    "mat4 mul mat4",
+    op => mul,
+    from => random_srt_mat4
+);
+
+bench_from_ypr!(
+    mat4_from_ypr,
+    "mat4 from ypr",
+    ty => Mat4
+);
 
 pub fn mat4_from_srt(c: &mut Criterion) {
     use glam::{Quat, Vec3};
@@ -71,15 +113,17 @@ pub fn mat4_from_srt(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    mat4_transpose,
     mat4_determinant,
+    mat4_from_srt,
+    mat4_from_ypr,
     mat4_inverse,
+    mat4_mul_mat4,
     mat4_mul_vec4,
     mat4_transform_point3,
+    mat4_transform_point3a,
     mat4_transform_vector3,
-    mat4_mul_mat4,
-    mat4_from_ypr,
-    mat4_from_srt,
+    mat4_transform_vector3a,
+    mat4_transpose,
 );
 
 criterion_main!(benches);

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -116,7 +116,7 @@ pub fn random_srt_affine2(rng: &mut PCG32) -> Affine2 {
     )
 }
 
-pub fn random_srt_affine3(rng: &mut PCG32) -> Affine3A {
+pub fn random_srt_affine3a(rng: &mut PCG32) -> Affine3A {
     Affine3A::from_scale_rotation_translation(
         random_nonzero_vec3(rng),
         random_quat(rng),

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use core::f32;
-use glam::{Mat2, Mat3, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
+use glam::{Mat2, Mat3, Mat3A, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
 
 pub struct PCG32 {
     state: u64,
@@ -102,6 +102,18 @@ pub fn random_mat3(rng: &mut PCG32) -> Mat3 {
 
 pub fn random_srt_mat3(rng: &mut PCG32) -> Mat3 {
     Mat3::from_scale_angle_translation(
+        random_nonzero_vec2(rng),
+        random_radians(rng),
+        random_vec2(rng),
+    )
+}
+
+pub fn random_mat3a(rng: &mut PCG32) -> Mat3A {
+    Mat3A::from_cols(random_vec3a(rng), random_vec3a(rng), random_vec3a(rng))
+}
+
+pub fn random_srt_mat3a(rng: &mut PCG32) -> Mat3A {
+    Mat3A::from_scale_angle_translation(
         random_nonzero_vec2(rng),
         random_radians(rng),
         random_vec2(rng),

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use core::f32;
-use glam::{Affine2, Affine3, Mat2, Mat3, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
+use glam::{Affine2, Affine3A, Mat2, Mat3, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
 
 pub struct PCG32 {
     state: u64,
@@ -116,8 +116,8 @@ pub fn random_srt_affine2(rng: &mut PCG32) -> Affine2 {
     )
 }
 
-pub fn random_srt_affine3(rng: &mut PCG32) -> Affine3 {
-    Affine3::from_scale_rotation_translation(
+pub fn random_srt_affine3(rng: &mut PCG32) -> Affine3A {
+    Affine3A::from_scale_rotation_translation(
         random_nonzero_vec3(rng),
         random_quat(rng),
         random_vec3(rng),

--- a/benches/support/mod.rs
+++ b/benches/support/mod.rs
@@ -1,6 +1,6 @@
 #![allow(dead_code)]
 use core::f32;
-use glam::{Affine2, Affine3A, Mat2, Mat3, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
+use glam::{Mat2, Mat3, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
 
 pub struct PCG32 {
     state: u64,
@@ -105,22 +105,6 @@ pub fn random_srt_mat3(rng: &mut PCG32) -> Mat3 {
         random_nonzero_vec2(rng),
         random_radians(rng),
         random_vec2(rng),
-    )
-}
-
-pub fn random_srt_affine2(rng: &mut PCG32) -> Affine2 {
-    Affine2::from_scale_angle_translation(
-        random_nonzero_vec2(rng),
-        random_radians(rng),
-        random_vec2(rng),
-    )
-}
-
-pub fn random_srt_affine3a(rng: &mut PCG32) -> Affine3A {
-    Affine3A::from_scale_rotation_translation(
-        random_nonzero_vec3(rng),
-        random_quat(rng),
-        random_vec3(rng),
     )
 }
 

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -4,20 +4,20 @@ mod macros;
 mod support;
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use glam::{TransformRt, TransformSrt};
+use glam::{Isometry3A, Transform3A};
 use std::ops::Mul;
 use support::*;
 
-fn random_transform_srt(rng: &mut PCG32) -> TransformSrt {
-    TransformSrt::from_scale_rotation_translation(
+fn random_transform_srt(rng: &mut PCG32) -> Transform3A {
+    Transform3A::from_scale_rotation_translation(
         random_nonzero_vec3(rng),
         random_quat(rng),
         random_vec3(rng),
     )
 }
 
-fn random_transform_rt(rng: &mut PCG32) -> TransformRt {
-    TransformRt::from_rotation_translation(random_quat(rng), random_vec3(rng))
+fn random_transform_rt(rng: &mut PCG32) -> Isometry3A {
+    Isometry3A::from_rotation_translation(random_quat(rng), random_vec3(rng))
 }
 
 bench_unop!(

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -60,9 +60,9 @@ bench_binop!(
 
 bench_binop!(
     transform3a_transform_point3a,
-    "isometry3a transform point3a",
+    "transform3a transform point3a",
     op => transform_point3a,
-    from1 => random_isometry3a,
+    from1 => random_transform3a,
     from2 => random_vec3a
 );
 

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -51,6 +51,22 @@ bench_binop!(
 );
 
 bench_binop!(
+    isometry3a_transform_vector3,
+    "isometry3a transform vector3",
+    op => transform_vector3,
+    from1 => random_isometry3a,
+    from2 => random_vec3
+);
+
+bench_binop!(
+    isometry3a_transform_vector3a,
+    "isometry3a transform vector3a",
+    op => transform_vector3a,
+    from1 => random_isometry3a,
+    from2 => random_vec3a
+);
+
+bench_binop!(
     transform3a_transform_point3,
     "transform3a transform point3",
     op => transform_point3,
@@ -66,6 +82,21 @@ bench_binop!(
     from2 => random_vec3a
 );
 
+bench_binop!(
+    transform3a_transform_vector3,
+    "transform3a transform vector3",
+    op => transform_vector3,
+    from1 => random_transform3a,
+    from2 => random_vec3
+);
+
+bench_binop!(
+    transform3a_transform_vector3a,
+    "transform3a transform vector3a",
+    op => transform_vector3a,
+    from1 => random_transform3a,
+    from2 => random_vec3a
+);
 bench_binop!(
     transform3a_mul_transform3a,
     "transform3a mul transform3a",
@@ -86,10 +117,14 @@ criterion_group!(
     isometry3a_mul_isometry3a,
     isometry3a_transform_point3,
     isometry3a_transform_point3a,
+    isometry3a_transform_vector3,
+    isometry3a_transform_vector3a,
     transform3a_inverse,
     transform3a_mul_transform3a,
     transform3a_transform_point3,
     transform3a_transform_point3a,
+    transform3a_transform_vector3,
+    transform3a_transform_vector3a,
 );
 
 criterion_main!(benches);

--- a/benches/transform.rs
+++ b/benches/transform.rs
@@ -8,7 +8,7 @@ use glam::{Isometry3A, Transform3A};
 use std::ops::Mul;
 use support::*;
 
-fn random_transform_srt(rng: &mut PCG32) -> Transform3A {
+fn random_transform3a(rng: &mut PCG32) -> Transform3A {
     Transform3A::from_scale_rotation_translation(
         random_nonzero_vec3(rng),
         random_quat(rng),
@@ -16,70 +16,80 @@ fn random_transform_srt(rng: &mut PCG32) -> Transform3A {
     )
 }
 
-fn random_transform_rt(rng: &mut PCG32) -> Isometry3A {
+fn random_isometry3a(rng: &mut PCG32) -> Isometry3A {
     Isometry3A::from_rotation_translation(random_quat(rng), random_vec3(rng))
 }
 
 bench_unop!(
-    srt_inverse,
-    "transform_srt inverse",
+    isometry3a_inverse,
+    "isometry3a inverse",
     op => inverse,
-    from => random_transform_srt
+    from => random_isometry3a
+);
+
+bench_unop!(
+    transform3a_inverse,
+    "transform3a inverse",
+    op => inverse,
+    from => random_transform3a
 );
 
 bench_binop!(
-    srt_transform_point3,
-    "transform_srt transform point3",
+    isometry3a_transform_point3,
+    "isometry3a transform point3",
     op => transform_point3,
-    from1 => random_transform_srt,
+    from1 => random_isometry3a,
     from2 => random_vec3
 );
 
 bench_binop!(
-    rt_transform_point3,
-    "transform_rt transform point3",
+    isometry3a_transform_point3a,
+    "isometry3a transform point3a",
+    op => transform_point3a,
+    from1 => random_isometry3a,
+    from2 => random_vec3a
+);
+
+bench_binop!(
+    transform3a_transform_point3,
+    "transform3a transform point3",
     op => transform_point3,
-    from1 => random_transform_rt,
+    from1 => random_transform3a,
     from2 => random_vec3
 );
 
-// bench_unop!(
-//     transform_srt_inverse_ptv_scale,
-//     "transform_srt inverse (+ve scale)",
-//     op => inverse,
-//     ty => TransformSrt,
-//     from => TransformRt
-// );
-
-// bench_unop!(
-//     rt_inverse,
-//     "transform_rt inverse",
-//     op => inverse,
-//     ty => TransformRt
-// );
-
 bench_binop!(
-    srt_mul_srt,
-    "transform_srt mul transform_srt",
-    op => mul,
-    from => random_transform_srt
+    transform3a_transform_point3a,
+    "isometry3a transform point3a",
+    op => transform_point3a,
+    from1 => random_isometry3a,
+    from2 => random_vec3a
 );
 
 bench_binop!(
-    rt_mul_rt,
-    "transform_rt mul transform_rt",
+    transform3a_mul_transform3a,
+    "transform3a mul transform3a",
     op => mul,
-    from => random_transform_rt
+    from => random_transform3a
+);
+
+bench_binop!(
+    isometry3a_mul_isometry3a,
+    "isometry3a mul isometry3a",
+    op => mul,
+    from => random_isometry3a
 );
 
 criterion_group!(
     benches,
-    // rt_inverse,
-    srt_inverse,
-    rt_mul_rt,
-    srt_mul_srt,
-    rt_transform_point3,
-    srt_transform_point3,
+    isometry3a_inverse,
+    isometry3a_mul_isometry3a,
+    isometry3a_transform_point3,
+    isometry3a_transform_point3a,
+    transform3a_inverse,
+    transform3a_mul_transform3a,
+    transform3a_transform_point3,
+    transform3a_transform_point3a,
 );
 
 criterion_main!(benches);

--- a/src/affine2.rs
+++ b/src/affine2.rs
@@ -178,6 +178,7 @@ macro_rules! impl_affine2_methods {
             /// Return the inverse of this transform.
             ///
             /// Note that if the transform is not invertible the result will be invalid.
+            #[inline]
             pub fn inverse(&self) -> Self {
                 let matrix2 = self.matrix2.inverse();
                 // transform negative translation by the 2x2 inverse:

--- a/src/affine3.rs
+++ b/src/affine3.rs
@@ -193,7 +193,7 @@ macro_rules! impl_affine3_methods {
 
                 let inv_scale = scale.recip();
 
-                let rotation = $quat::from_rotation_mat3(&$mat3::from_cols(
+                let rotation = $quat::from_mat3(&$mat3::from_cols(
                     (self.matrix3.x_axis * inv_scale.x).into(),
                     (self.matrix3.y_axis * inv_scale.y).into(),
                     (self.matrix3.z_axis * inv_scale.z).into(),
@@ -406,14 +406,14 @@ type TransformF32 = Mat3A;
 type TranslateF32 = Vec3A;
 type DerefTargetF32 = Columns4<crate::Vec3A>;
 
-define_affine3_struct!(Affine3, TransformF32, TranslateF32);
+define_affine3_struct!(Affine3A, TransformF32, TranslateF32);
 impl_affine3_methods!(
     f32,
     Mat3,
     Mat4,
     Quat,
     Vec3,
-    Affine3,
+    Affine3A,
     TransformF32,
     TranslateF32
 );
@@ -423,13 +423,13 @@ impl_affine3_traits!(
     Mat4,
     Vec3,
     Vec4,
-    Affine3,
+    Affine3A,
     TransformF32,
     TranslateF32,
     DerefTargetF32
 );
 
-impl Affine3 {
+impl Affine3A {
     /// Transforms the given `Vec3A`, applying shear, scale, rotation and translation.
     #[inline(always)]
     pub fn transform_point3a(&self, other: Vec3A) -> Vec3A {

--- a/src/core/sse2/matrix.rs
+++ b/src/core/sse2/matrix.rs
@@ -508,6 +508,7 @@ impl FloatMatrix4x4<f32, __m128> for Columns4<__m128> {
 impl ProjectionMatrix<f32, __m128> for Columns4<__m128> {}
 
 impl From<Columns3<XYZ<f32>>> for Columns3<__m128> {
+    #[inline(always)]
     fn from(v: Columns3<XYZ<f32>>) -> Columns3<__m128> {
         Self {
             x_axis: v.x_axis.into(),
@@ -518,6 +519,7 @@ impl From<Columns3<XYZ<f32>>> for Columns3<__m128> {
 }
 
 impl From<Columns3<__m128>> for Columns3<XYZ<f32>> {
+    #[inline(always)]
     fn from(v: Columns3<__m128>) -> Columns3<XYZ<f32>> {
         Self {
             x_axis: v.x_axis.into(),

--- a/src/core/sse2/matrix.rs
+++ b/src/core/sse2/matrix.rs
@@ -41,12 +41,12 @@ impl Matrix2x2<f32, XY<f32>> for __m128 {
 
     #[inline(always)]
     fn x_axis(&self) -> &XY<f32> {
-        unsafe { &(&*(self as *const Self as *const Columns2<XY<f32>>)).x_axis }
+        unsafe { &(*(self as *const Self as *const Columns2<XY<f32>>)).x_axis }
     }
 
     #[inline(always)]
     fn y_axis(&self) -> &XY<f32> {
-        unsafe { &(&*(self as *const Self as *const Columns2<XY<f32>>)).y_axis }
+        unsafe { &(*(self as *const Self as *const Columns2<XY<f32>>)).y_axis }
     }
 
     #[inline]

--- a/src/features/impl_bytemuck.rs
+++ b/src/features/impl_bytemuck.rs
@@ -2,8 +2,6 @@ use crate::{
     DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, Quat,
     UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
 };
-#[cfg(feature = "transform-types")]
-use crate::{TransformRt, TransformSrt};
 use bytemuck::{Pod, Zeroable};
 
 unsafe impl Pod for Mat2 {}
@@ -53,15 +51,6 @@ unsafe impl Pod for UVec3 {}
 unsafe impl Zeroable for UVec3 {}
 unsafe impl Pod for UVec4 {}
 unsafe impl Zeroable for UVec4 {}
-
-#[cfg(feature = "transform-types")]
-unsafe impl Pod for TransformRt {}
-#[cfg(feature = "transform-types")]
-unsafe impl Zeroable for TransformRt {}
-#[cfg(feature = "transform-types")]
-unsafe impl Pod for TransformSrt {}
-#[cfg(feature = "transform-types")]
-unsafe impl Zeroable for TransformSrt {}
 
 #[cfg(test)]
 mod test {

--- a/src/features/impl_serde.rs
+++ b/src/features/impl_serde.rs
@@ -608,21 +608,21 @@ mod u32 {
     impl_serde_vec_types!(u32, UVec2, UVec3, UVec4);
 }
 
-mod affine3 {
-    use crate::{Affine3, Mat3, Vec3};
+mod affine3a {
+    use crate::{Affine3A, Mat3, Vec3};
     use core::fmt;
     use serde::{
         de::{self, Deserialize, Deserializer, SeqAccess, Visitor},
         ser::{Serialize, SerializeTupleStruct, Serializer},
     };
 
-    impl Serialize for Affine3 {
+    impl Serialize for Affine3A {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
         {
             // Serialize column-wise as 3x4 matrix:
-            let mut state = serializer.serialize_tuple_struct("Affine3", 12)?;
+            let mut state = serializer.serialize_tuple_struct("Affine3A", 12)?;
             state.serialize_field(&self.x_axis.x)?;
             state.serialize_field(&self.x_axis.y)?;
             state.serialize_field(&self.x_axis.z)?;
@@ -639,7 +639,7 @@ mod affine3 {
         }
     }
 
-    impl<'de> Deserialize<'de> for Affine3 {
+    impl<'de> Deserialize<'de> for Affine3A {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
             D: Deserializer<'de>,
@@ -647,13 +647,13 @@ mod affine3 {
             struct Affine3Visitor;
 
             impl<'de> Visitor<'de> for Affine3Visitor {
-                type Value = Affine3;
+                type Value = Affine3A;
 
                 fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-                    formatter.write_str("struct Affine3")
+                    formatter.write_str("struct Affine3A")
                 }
 
-                fn visit_seq<V>(self, mut seq: V) -> Result<Affine3, V::Error>
+                fn visit_seq<V>(self, mut seq: V) -> Result<Affine3A, V::Error>
                 where
                     V: SeqAccess<'de>,
                 {
@@ -669,11 +669,11 @@ mod affine3 {
                         f[6], f[7], f[8], //
                     ]);
                     let t = Vec3::new(f[9], f[10], f[11]);
-                    Ok(Affine3::from_mat3_translation(m, t))
+                    Ok(Affine3A::from_mat3_translation(m, t))
                 }
             }
 
-            deserializer.deserialize_tuple_struct("Affine3", 12, Affine3Visitor)
+            deserializer.deserialize_tuple_struct("Affine3A", 12, Affine3Visitor)
         }
     }
 
@@ -681,7 +681,7 @@ mod affine3 {
     fn test_affine3_serde() {
         use crate::{Quat, Vec3};
 
-        let a = Affine3::from_scale_rotation_translation(
+        let a = Affine3A::from_scale_rotation_translation(
             Vec3::new(1.0, 2.0, 3.0),
             Quat::IDENTITY,
             Vec3::new(4.0, 5.0, 6.0),
@@ -694,20 +694,20 @@ mod affine3 {
         let deserialized = serde_json::from_str(&serialized).unwrap();
         assert_eq!(a, deserialized);
 
-        let deserialized = serde_json::from_str::<Affine3>("[]");
+        let deserialized = serde_json::from_str::<Affine3A>("[]");
         assert!(deserialized.is_err());
-        let deserialized = serde_json::from_str::<Affine3>("[1.0]");
+        let deserialized = serde_json::from_str::<Affine3A>("[1.0]");
         assert!(deserialized.is_err());
-        let deserialized = serde_json::from_str::<Affine3>("[1.0,2.0]");
+        let deserialized = serde_json::from_str::<Affine3A>("[1.0,2.0]");
         assert!(deserialized.is_err());
-        let deserialized = serde_json::from_str::<Affine3>("[1.0,2.0,3.0]");
+        let deserialized = serde_json::from_str::<Affine3A>("[1.0,2.0,3.0]");
         assert!(deserialized.is_err());
-        let deserialized = serde_json::from_str::<Affine3>("[1.0,2.0,3.0,4.0,5.0]");
+        let deserialized = serde_json::from_str::<Affine3A>("[1.0,2.0,3.0,4.0,5.0]");
         assert!(deserialized.is_err());
         let deserialized =
-            serde_json::from_str::<Affine3>("[[1.0,2.0,3.0],[4.0,5.0,6.0],[7.0,8.0,9.0]]");
+            serde_json::from_str::<Affine3A>("[[1.0,2.0,3.0],[4.0,5.0,6.0],[7.0,8.0,9.0]]");
         assert!(deserialized.is_err());
-        let deserialized = serde_json::from_str::<Affine3>(
+        let deserialized = serde_json::from_str::<Affine3A>(
             "[[1.0,2.0,3.0,4.0],[5.0,6.0,7.0,8.0],[9.0,10.0,11.0,12.0][13.0,14.0,15.0,16.0]]",
         );
         assert!(deserialized.is_err());

--- a/src/features/impl_serde.rs
+++ b/src/features/impl_serde.rs
@@ -608,6 +608,7 @@ mod u32 {
     impl_serde_vec_types!(u32, UVec2, UVec3, UVec4);
 }
 
+#[cfg(feature = "transform-types")]
 mod affine3a {
     use crate::{Affine3A, Mat3, Vec3};
     use core::fmt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ pub use self::bool::*;
 /** `f32` vector, quaternion and matrix types. */
 pub mod f32 {
     pub use super::affine2::Affine2;
-    pub use super::affine3::Affine3;
+    pub use super::affine3::Affine3A;
     pub use super::mat2::{mat2, Mat2};
     pub use super::mat3::{mat3, mat3a, Mat3, Mat3A};
     pub use super::mat4::{mat4, Mat4};
@@ -238,7 +238,7 @@ pub mod f32 {
     pub use super::vec4::{vec4, Vec4};
 
     #[cfg(feature = "transform-types")]
-    pub use super::transform::{TransformRt, TransformSrt};
+    pub use super::transform::{Isometry3A, Transform3A};
 }
 pub use self::f32::*;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -196,8 +196,6 @@ mod vec;
 #[doc(hidden)]
 pub mod cast;
 
-mod affine2;
-mod affine3;
 mod core;
 mod euler;
 mod mat2;
@@ -214,6 +212,10 @@ mod features;
 mod spirv;
 
 #[cfg(feature = "transform-types")]
+mod affine2;
+#[cfg(feature = "transform-types")]
+mod affine3;
+#[cfg(feature = "transform-types")]
 mod transform;
 
 #[doc(hidden)]
@@ -227,7 +229,9 @@ pub use self::bool::*;
 
 /** `f32` vector, quaternion and matrix types. */
 pub mod f32 {
+    #[cfg(feature = "transform-types")]
     pub use super::affine2::Affine2;
+    #[cfg(feature = "transform-types")]
     pub use super::affine3::Affine3A;
     pub use super::mat2::{mat2, Mat2};
     pub use super::mat3::{mat3, mat3a, Mat3, Mat3A};
@@ -244,7 +248,9 @@ pub use self::f32::*;
 
 /** `f64` vector, quaternion and matrix types. */
 pub mod f64 {
+    #[cfg(feature = "transform-types")]
     pub use super::affine2::DAffine2;
+    #[cfg(feature = "transform-types")]
     pub use super::affine3::DAffine3;
     pub use super::mat2::{dmat2, DMat2};
     pub use super::mat3::{dmat3, DMat3};

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -161,7 +161,7 @@ macro_rules! impl_mat3_methods {
         /// Creates an affine transformation matrix from the given 2D `translation`.
         ///
         /// The resulting matrix can be used to transform 2D points and vectors. See
-        /// [`Self::transform_point3()`] and [`Self::transform_vector3()`].
+        /// [`Self::transform_point2()`] and [`Self::transform_vector2()`].
         #[inline(always)]
         pub fn from_translation(translation: $vec2) -> Self {
             Self(Matrix3x3::from_translation(translation.0))

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -285,13 +285,13 @@ macro_rules! impl_mat3_methods {
         /// Transforms a 3D vector.
         #[inline(always)]
         pub fn mul_vec3(&self, other: $vec3) -> $vec3 {
-            $vec3::from_simd(self.to_simd().mul_vector(other.to_simd().into()).into())
+            $vec3(self.0.mul_vector(other.0.into()).into())
         }
 
         /// Multiplies two 3x3 matrices.
         #[inline]
         pub fn mul_mat3(&self, other: &Self) -> Self {
-            Self::from_simd(self.to_simd().mul_matrix(&other.to_simd()))
+            Self(self.0.mul_matrix(&other.0))
         }
 
         /// Adds two 3x3 matrices.
@@ -516,7 +516,7 @@ impl Mat3 {
     /// Transforms a `Vec3A`.
     #[inline]
     pub fn mul_vec3a(&self, other: Vec3A) -> Vec3A {
-        Vec3A::from_simd(self.to_simd().mul_vector(other.to_simd().into()).into())
+        self.mul_vec3(other.into()).into()
     }
 
     #[inline(always)]
@@ -526,38 +526,6 @@ impl Mat3 {
             self.y_axis.as_f64(),
             self.z_axis.as_f64(),
         )
-    }
-
-    #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))]
-    #[inline(always)]
-    fn to_simd(&self) -> Columns3<__m128> {
-        Columns3 {
-            x_axis: self.x_axis.0.into(),
-            y_axis: self.y_axis.0.into(),
-            z_axis: self.z_axis.0.into(),
-        }
-    }
-
-    #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))]
-    #[inline(always)]
-    fn from_simd(m: Columns3<__m128>) -> Self {
-        Self(Matrix3x3::from_cols(
-            m.x_axis.into(),
-            m.y_axis.into(),
-            m.z_axis.into(),
-        ))
-    }
-
-    #[cfg(any(not(target_feature = "sse2"), feature = "scalar-math"))]
-    #[inline(always)]
-    fn to_simd(&self) -> InnerF32 {
-        self.0
-    }
-
-    #[cfg(any(not(target_feature = "sse2"), feature = "scalar-math"))]
-    #[inline(always)]
-    fn from_simd(m: InnerF32) -> Self {
-        Self(m)
     }
 }
 impl_mat3_traits!(f32, mat3, Mat3, Mat4, Vec3, Vec3);
@@ -593,16 +561,6 @@ impl Mat3A {
             self.y_axis.as_f64(),
             self.z_axis.as_f64(),
         )
-    }
-
-    #[inline(always)]
-    fn to_simd(&self) -> InnerF32A {
-        self.0
-    }
-
-    #[inline(always)]
-    fn from_simd(m: InnerF32A) -> Self {
-        Self(m)
     }
 }
 impl_mat3_traits!(f32, mat3a, Mat3A, Mat4, Vec3, Vec3A);
@@ -642,16 +600,6 @@ impl DMat3 {
             self.y_axis.as_f32(),
             self.z_axis.as_f32(),
         )
-    }
-
-    #[inline(always)]
-    fn to_simd(&self) -> InnerF64 {
-        self.0
-    }
-
-    #[inline(always)]
-    fn from_simd(inner: InnerF64) -> Self {
-        Self(inner)
     }
 }
 impl_mat3_traits!(f64, dmat3, DMat3, DMat4, DVec3, DVec3);

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -366,7 +366,7 @@ macro_rules! impl_mat4_methods {
             ))
         }
 
-        /// Creates a left-handed perspective projection matrix with [0,1] depth range.
+        /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
         #[inline(always)]
         pub fn perspective_lh(fov_y_radians: $t, aspect_ratio: $t, z_near: $t, z_far: $t) -> Self {
             Self($inner::perspective_lh(
@@ -377,7 +377,7 @@ macro_rules! impl_mat4_methods {
             ))
         }
 
-        /// Creates a right-handed perspective projection matrix with [0,1] depth range.
+        /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
         #[inline(always)]
         pub fn perspective_rh(fov_y_radians: $t, aspect_ratio: $t, z_near: $t, z_far: $t) -> Self {
             Self($inner::perspective_rh(
@@ -388,7 +388,7 @@ macro_rules! impl_mat4_methods {
             ))
         }
 
-        /// Creates an infinite left-handed perspective projection matrix with [0,1] depth range.
+        /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
         #[inline(always)]
         pub fn perspective_infinite_lh(fov_y_radians: $t, aspect_ratio: $t, z_near: $t) -> Self {
             Self($inner::perspective_infinite_lh(
@@ -398,7 +398,7 @@ macro_rules! impl_mat4_methods {
             ))
         }
 
-        /// Creates an infinite left-handed perspective projection matrix with [0,1] depth range.
+        /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
         #[inline(always)]
         pub fn perspective_infinite_reverse_lh(
             fov_y_radians: $t,
@@ -413,7 +413,7 @@ macro_rules! impl_mat4_methods {
         }
 
         /// Creates an infinite right-handed perspective projection matrix with
-        /// [0,1] depth range.
+        /// `[0,1]` depth range.
         #[inline(always)]
         pub fn perspective_infinite_rh(fov_y_radians: $t, aspect_ratio: $t, z_near: $t) -> Self {
             Self($inner::perspective_infinite_rh(
@@ -424,7 +424,7 @@ macro_rules! impl_mat4_methods {
         }
 
         /// Creates an infinite reverse right-handed perspective projection matrix
-        /// with [0,1] depth range.
+        /// with `[0,1]` depth range.
         #[inline(always)]
         pub fn perspective_infinite_reverse_rh(
             fov_y_radians: $t,
@@ -438,7 +438,7 @@ macro_rules! impl_mat4_methods {
             ))
         }
 
-        /// Creates a right-handed orthographic projection matrix with [-1,1] depth
+        /// Creates a right-handed orthographic projection matrix with `[-1,1]` depth
         /// range.  This is the same as the OpenGL `glOrtho` function in OpenGL.
         /// See
         /// https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glOrtho.xml
@@ -456,7 +456,7 @@ macro_rules! impl_mat4_methods {
             ))
         }
 
-        /// Creates a left-handed orthographic projection matrix with [0,1] depth range.
+        /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.
         #[inline(always)]
         pub fn orthographic_lh(
             left: $t,
@@ -469,7 +469,7 @@ macro_rules! impl_mat4_methods {
             Self($inner::orthographic_lh(left, right, bottom, top, near, far))
         }
 
-        /// Creates a right-handed orthographic projection matrix with [0,1] depth range.
+        /// Creates a right-handed orthographic projection matrix with `[0,1]` depth range.
         #[inline(always)]
         pub fn orthographic_rh(
             left: $t,

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -681,9 +681,9 @@ impl DQuat {
     #[inline]
     pub fn from_affine3(mat: &crate::DAffine3) -> Self {
         Self(Quaternion::from_rotation_axes(
-            mat.x_axis.0.into(),
-            mat.y_axis.0.into(),
-            mat.z_axis.0.into(),
+            mat.x_axis.0,
+            mat.y_axis.0,
+            mat.z_axis.0,
         ))
     }
 }

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -3,8 +3,8 @@ use crate::core::traits::{
     vector::{FloatVector4, MaskVector4, Vector, Vector4, Vector4Const},
 };
 use crate::euler::{EulerFromQuaternion, EulerRot, EulerToQuaternion};
-use crate::{Affine3A, Mat3, Mat4, Vec3, Vec3A, Vec4};
-use crate::{DAffine3, DMat3, DMat4, DVec3, DVec4};
+use crate::{DMat3, DMat4, DVec3, DVec4};
+use crate::{Mat3, Mat4, Vec3, Vec3A, Vec4};
 
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
@@ -33,7 +33,7 @@ use core::{
 use std::iter::{Product, Sum};
 
 macro_rules! impl_quat_methods {
-    ($t:ident, $quat:ident, $vec3:ident, $mat3:ident, $mat4:ident, $affine3:ident, $inner:ident) => {
+    ($t:ident, $quat:ident, $vec3:ident, $mat3:ident, $mat4:ident, $inner:ident) => {
         /// The identity quaternion. Corresponds to no rotation.
         pub const IDENTITY: Self = Self($inner::W);
 
@@ -152,16 +152,6 @@ macro_rules! impl_quat_methods {
         /// Creates a quaternion from a 3x3 rotation matrix inside a homogeneous 4x4 matrix.
         #[inline]
         pub fn from_mat4(mat: &$mat4) -> Self {
-            Self(Quaternion::from_rotation_axes(
-                mat.x_axis.0.into(),
-                mat.y_axis.0.into(),
-                mat.z_axis.0.into(),
-            ))
-        }
-
-        /// Creates a quaternion from a 3x3 rotation matrix inside a 3D affine transform.
-        #[inline]
-        pub fn from_affine3(mat: &$affine3) -> Self {
             Self(Quaternion::from_rotation_axes(
                 mat.x_axis.0.into(),
                 mat.y_axis.0.into(),
@@ -633,7 +623,7 @@ type InnerF32 = crate::XYZW<f32>;
 pub struct Quat(pub(crate) InnerF32);
 
 impl Quat {
-    impl_quat_methods!(f32, Quat, Vec3, Mat3, Mat4, Affine3A, InnerF32);
+    impl_quat_methods!(f32, Quat, Vec3, Mat3, Mat4, InnerF32);
 
     #[inline(always)]
     /// Multiplies a quaternion and a 3D vector, returning the rotated vector.
@@ -644,6 +634,17 @@ impl Quat {
     #[inline(always)]
     pub fn as_f64(self) -> DQuat {
         DQuat::from_xyzw(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
+    }
+
+    /// Creates a quaternion from a 3x3 rotation matrix inside a 3D affine transform.
+    #[cfg(feature = "transform-types")]
+    #[inline]
+    pub fn from_affine3(mat: &crate::Affine3A) -> Self {
+        Self(Quaternion::from_rotation_axes(
+            mat.x_axis.0.into(),
+            mat.y_axis.0.into(),
+            mat.z_axis.0.into(),
+        ))
     }
 }
 impl_quat_traits!(f32, quat, Quat, Vec3, Vec4, InnerF32);
@@ -668,11 +669,22 @@ type InnerF64 = crate::XYZW<f64>;
 pub struct DQuat(pub(crate) InnerF64);
 
 impl DQuat {
-    impl_quat_methods!(f64, DQuat, DVec3, DMat3, DMat4, DAffine3, InnerF64);
+    impl_quat_methods!(f64, DQuat, DVec3, DMat3, DMat4, InnerF64);
 
     #[inline(always)]
     pub fn as_f32(self) -> Quat {
         Quat::from_xyzw(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
+    }
+
+    /// Creates a quaternion from a 3x3 rotation matrix inside a 3D affine transform.
+    #[cfg(feature = "transform-types")]
+    #[inline]
+    pub fn from_affine3(mat: &crate::DAffine3) -> Self {
+        Self(Quaternion::from_rotation_axes(
+            mat.x_axis.0.into(),
+            mat.y_axis.0.into(),
+            mat.z_axis.0.into(),
+        ))
     }
 }
 impl_quat_traits!(f64, dquat, DQuat, DVec3, DVec4, InnerF64);

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -670,17 +670,3 @@ macro_rules! impl_vecn_as_u32 {
         }
     };
 }
-
-macro_rules! impl_vecn_to_simd_noop {
-    ($inner:ident) => {
-        #[inline(always)]
-        pub(crate) fn to_simd(&self) -> $inner {
-            self.0
-        }
-
-        #[inline(always)]
-        pub(crate) fn from_simd(inner: $inner) -> Self {
-            Self(inner)
-        }
-    };
-}

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -40,7 +40,7 @@ macro_rules! impl_vecn_common_methods {
             Self(self.0.max(other.0))
         }
 
-        /// Component-wise clamping of values, similar to [`std::f32::clamp`].
+        /// Component-wise clamping of values, similar to [`f32::clamp`].
         ///
         /// Each element in `min` must be less-or-equal to the corresponing element in `max`.
         ///

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -248,30 +248,6 @@ macro_rules! impl_f32_vec3 {
             impl_vecn_as_f64!(DVec3, x, y, z);
             impl_vecn_as_i32!(IVec3, x, y, z);
             impl_vecn_as_u32!(UVec3, x, y, z);
-
-            #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))]
-            #[inline(always)]
-            pub(crate) fn to_simd(&self) -> __m128 {
-                self.0.into()
-            }
-
-            #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))]
-            #[inline(always)]
-            pub(crate) fn from_simd(v: __m128) -> Self {
-                Self(v.into())
-            }
-
-            #[cfg(any(not(target_feature = "sse2"), feature = "scalar-math"))]
-            #[inline(always)]
-            pub(crate) fn to_simd(&self) -> $inner {
-                self.0
-            }
-
-            #[cfg(any(not(target_feature = "sse2"), feature = "scalar-math"))]
-            #[inline(always)]
-            pub(crate) fn from_simd(v: $inner) -> Self {
-                Self(v)
-            }
         }
         impl_vec3_float_traits!(f32, $new, $vec2, $vec3, $vec4, $mask, $inner);
     };
@@ -333,7 +309,6 @@ impl DVec3 {
     impl_vecn_as_f32!(Vec3, x, y, z);
     impl_vecn_as_i32!(IVec3, x, y, z);
     impl_vecn_as_u32!(UVec3, x, y, z);
-    impl_vecn_to_simd_noop!(XYZF64);
 }
 impl_vec3_float_traits!(f64, dvec3, DVec2, DVec3, DVec4, BVec3, XYZF64);
 

--- a/tests/affine2.rs
+++ b/tests/affine2.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "transform-types")]
 #[macro_use]
 mod support;
 
+#[cfg(feature = "transform-types")]
 macro_rules! impl_affine2_tests {
     ($t:ident, $affine2:ident, $vec2:ident) => {
         use core::$t::NAN;
@@ -112,6 +114,7 @@ macro_rules! impl_affine2_tests {
     };
 }
 
+#[cfg(feature = "transform-types")]
 mod affine2 {
     use super::support::deg;
     use glam::{Affine2, Vec2};
@@ -132,6 +135,7 @@ mod affine2 {
     impl_affine2_tests!(f32, Affine2, Vec2);
 }
 
+#[cfg(feature = "transform-types")]
 mod daffine2 {
     use super::support::deg;
     use glam::{DAffine2, DVec2};

--- a/tests/affine3.rs
+++ b/tests/affine3.rs
@@ -215,24 +215,24 @@ macro_rules! impl_affine3_tests {
     };
 }
 
-mod affine3 {
+mod affine3a {
     use super::support::deg;
-    use glam::{Affine3, Quat, Vec3, Vec3A};
+    use glam::{Affine3A, Quat, Vec3, Vec3A};
 
     #[test]
     fn test_align() {
         use std::mem;
-        assert_eq!(64, mem::size_of::<Affine3>());
-        assert_eq!(16, mem::align_of::<Affine3>());
+        assert_eq!(64, mem::size_of::<Affine3A>());
+        assert_eq!(16, mem::align_of::<Affine3A>());
     }
 
     #[test]
     fn test_affine3_mul_vec3a() {
-        let m = Affine3::from_axis_angle(Vec3::Z, deg(90.0));
+        let m = Affine3A::from_axis_angle(Vec3::Z, deg(90.0));
         let result3 = m.transform_vector3a(Vec3A::Y);
         assert_approx_eq!(Vec3A::new(-1.0, 0.0, 0.0), result3);
 
-        let m = Affine3::from_scale_rotation_translation(
+        let m = Affine3A::from_scale_rotation_translation(
             Vec3::new(0.5, 1.5, 2.0),
             Quat::from_rotation_x(deg(90.0)),
             Vec3::new(1.0, 2.0, 3.0),
@@ -244,7 +244,7 @@ mod affine3 {
         assert_approx_eq!(Vec3A::new(1.0, 2.0, 4.5), result3, 1.0e-6);
     }
 
-    impl_affine3_tests!(f32, Affine3, Quat, Vec3);
+    impl_affine3_tests!(f32, Affine3A, Quat, Vec3);
 }
 
 mod daffine3 {

--- a/tests/affine3.rs
+++ b/tests/affine3.rs
@@ -1,6 +1,8 @@
+#[cfg(feature = "transform-types")]
 #[macro_use]
 mod support;
 
+#[cfg(feature = "transform-types")]
 macro_rules! impl_affine3_tests {
     ($t:ident, $affine3:ident, $quat:ident, $vec3:ident) => {
         use core::$t::NAN;
@@ -215,6 +217,7 @@ macro_rules! impl_affine3_tests {
     };
 }
 
+#[cfg(feature = "transform-types")]
 mod affine3a {
     use super::support::deg;
     use glam::{Affine3A, Quat, Vec3, Vec3A};
@@ -247,6 +250,7 @@ mod affine3a {
     impl_affine3_tests!(f32, Affine3A, Quat, Vec3);
 }
 
+#[cfg(feature = "transform-types")]
 mod daffine3 {
     use super::support::deg;
     use glam::{DAffine3, DQuat, DVec3};

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -68,9 +68,9 @@ macro_rules! impl_quat_tests {
             assert_approx_eq!(y0, y1);
             let y2 = $quat::from_axis_angle($vec3::Y, yaw);
             assert_approx_eq!(y0, y2);
-            let y3 = $quat::from_rotation_mat3(&$mat3::from_rotation_y(yaw));
+            let y3 = $quat::from_mat3(&$mat3::from_rotation_y(yaw));
             assert_approx_eq!(y0, y3);
-            let y4 = $quat::from_rotation_mat3(&$mat3::from_quat(y0));
+            let y4 = $quat::from_mat3(&$mat3::from_quat(y0));
             assert_approx_eq!(y0, y4);
 
             let x0 = $quat::from_rotation_x(pitch);
@@ -82,7 +82,7 @@ macro_rules! impl_quat_tests {
             assert_approx_eq!(x0, x1);
             let x2 = $quat::from_axis_angle($vec3::X, pitch);
             assert_approx_eq!(x0, x2);
-            let x3 = $quat::from_rotation_mat4(&$mat4::from_rotation_x(deg(180.0)));
+            let x3 = $quat::from_mat4(&$mat4::from_rotation_x(deg(180.0)));
             assert!(x3.is_normalized());
             assert_approx_eq!($quat::from_rotation_x(deg(180.0)), x3);
 
@@ -95,7 +95,7 @@ macro_rules! impl_quat_tests {
             assert_approx_eq!(z0, z1);
             let z2 = $quat::from_axis_angle($vec3::Z, roll);
             assert_approx_eq!(z0, z2);
-            let z3 = $quat::from_rotation_mat4(&$mat4::from_rotation_z(roll));
+            let z3 = $quat::from_mat4(&$mat4::from_rotation_z(roll));
             assert_approx_eq!(z0, z3);
 
             let yx0 = y0 * x0;
@@ -118,7 +118,7 @@ macro_rules! impl_quat_tests {
             assert_approx_eq!(yx0, yx2);
             assert!((yxz0 * yxz0.inverse()).is_near_identity());
 
-            let yxz2 = $quat::from_rotation_mat4(&$mat4::from_quat(yxz0));
+            let yxz2 = $quat::from_mat4(&$mat4::from_quat(yxz0));
             assert_approx_eq!(yxz0, yxz2);
 
             // if near identity, just returns x axis and 0 rotation

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -2,12 +2,12 @@
 mod macros;
 
 use glam::{
-    Affine2, Affine3, DAffine2, DAffine3, DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4, Mat2,
+    Affine2, Affine3A, DAffine2, DAffine3, DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4, Mat2,
     Mat3, Mat3A, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4,
 };
 
 #[cfg(feature = "transform-types")]
-use glam::{TransformRt, TransformSrt};
+use glam::{Isometry3A, Transform3A};
 
 pub trait Deg {
     fn to_radians(self) -> Self;
@@ -188,7 +188,7 @@ impl FloatCompare for DAffine2 {
     }
 }
 
-impl FloatCompare for Affine3 {
+impl FloatCompare for Affine3A {
     #[inline]
     fn approx_eq(&self, other: &Self, max_abs_diff: f32) -> bool {
         self.abs_diff_eq(*other, max_abs_diff)
@@ -336,7 +336,7 @@ impl FloatCompare for DVec4 {
 }
 
 #[cfg(feature = "transform-types")]
-impl FloatCompare for TransformSrt {
+impl FloatCompare for Transform3A {
     #[inline]
     fn approx_eq(&self, other: &Self, max_abs_diff: f32) -> bool {
         self.abs_diff_eq(*other, max_abs_diff)
@@ -345,15 +345,15 @@ impl FloatCompare for TransformSrt {
     #[inline]
     fn abs_diff(&self, other: &Self) -> Self {
         Self::from_scale_rotation_translation(
-            self.scale.abs_diff(&other.scale),
+            self.scale.abs_diff(&other.scale).into(),
             self.rotation.abs_diff(&other.rotation),
-            self.translation.abs_diff(&other.translation),
+            self.translation.abs_diff(&other.translation).into(),
         )
     }
 }
 
 #[cfg(feature = "transform-types")]
-impl FloatCompare for TransformRt {
+impl FloatCompare for Isometry3A {
     #[inline]
     fn approx_eq(&self, other: &Self, max_abs_diff: f32) -> bool {
         self.abs_diff_eq(*other, max_abs_diff)
@@ -363,7 +363,7 @@ impl FloatCompare for TransformRt {
     fn abs_diff(&self, other: &Self) -> Self {
         Self::from_rotation_translation(
             self.rotation.abs_diff(&other.rotation),
-            self.translation.abs_diff(&other.translation),
+            self.translation.abs_diff(&other.translation).into(),
         )
     }
 }

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -2,12 +2,12 @@
 mod macros;
 
 use glam::{
-    Affine2, Affine3A, DAffine2, DAffine3, DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4, Mat2,
-    Mat3, Mat3A, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4,
+    DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4, Mat2, Mat3, Mat3A, Mat4, Quat, Vec2, Vec3,
+    Vec3A, Vec4,
 };
 
 #[cfg(feature = "transform-types")]
-use glam::{Isometry3A, Transform3A};
+use glam::{Affine2, Affine3A, DAffine2, DAffine3, Isometry3A, Transform3A};
 
 pub trait Deg {
     fn to_radians(self) -> Self;
@@ -160,6 +160,7 @@ impl FloatCompare for DMat4 {
     }
 }
 
+#[cfg(feature = "transform-types")]
 impl FloatCompare for Affine2 {
     #[inline]
     fn approx_eq(&self, other: &Self, max_abs_diff: f32) -> bool {
@@ -174,6 +175,7 @@ impl FloatCompare for Affine2 {
     }
 }
 
+#[cfg(feature = "transform-types")]
 impl FloatCompare for DAffine2 {
     #[inline]
     fn approx_eq(&self, other: &Self, max_abs_diff: f32) -> bool {
@@ -188,6 +190,7 @@ impl FloatCompare for DAffine2 {
     }
 }
 
+#[cfg(feature = "transform-types")]
 impl FloatCompare for Affine3A {
     #[inline]
     fn approx_eq(&self, other: &Self, max_abs_diff: f32) -> bool {
@@ -202,6 +205,7 @@ impl FloatCompare for Affine3A {
     }
 }
 
+#[cfg(feature = "transform-types")]
 impl FloatCompare for DAffine3 {
     #[inline]
     fn approx_eq(&self, other: &Self, max_abs_diff: f32) -> bool {

--- a/tests/transform.rs
+++ b/tests/transform.rs
@@ -8,19 +8,19 @@ mod transform {
 
     #[test]
     fn test_identity() {
-        let tr = TransformRt::IDENTITY;
+        let tr = Isometry3A::IDENTITY;
         assert_eq!(tr.rotation, Quat::IDENTITY);
-        assert_eq!(tr.translation, Vec3::ZERO);
+        assert_eq!(tr.translation, Vec3A::ZERO);
 
-        let srt = TransformSrt::IDENTITY;
-        assert_eq!(srt.scale, Vec3::ONE);
+        let srt = Transform3A::IDENTITY;
+        assert_eq!(srt.scale, Vec3A::ONE);
         assert_eq!(srt.rotation, Quat::IDENTITY);
-        assert_eq!(srt.translation, Vec3::ZERO);
+        assert_eq!(srt.translation, Vec3A::ZERO);
 
         assert_eq!(srt, tr.into());
 
-        assert_eq!(TransformRt::IDENTITY, TransformRt::default());
-        assert_eq!(TransformSrt::IDENTITY, TransformSrt::default());
+        assert_eq!(Isometry3A::IDENTITY, Isometry3A::default());
+        assert_eq!(Transform3A::IDENTITY, Transform3A::default());
     }
 
     #[test]
@@ -29,59 +29,59 @@ mod transform {
         let r = Quat::from_rotation_y(90.0_f32.to_radians());
         let s = Vec3::new(-1.0, -2.0, -3.0);
 
-        let tr = TransformRt::from_rotation_translation(r, t);
+        let tr = Isometry3A::from_rotation_translation(r, t);
         assert_eq!(tr.rotation, r);
-        assert_eq!(tr.translation, t);
+        assert_eq!(tr.translation, t.into());
 
-        let srt = TransformSrt::from_scale_rotation_translation(s, r, t);
-        assert_eq!(srt.scale, s);
+        let srt = Transform3A::from_scale_rotation_translation(s, r, t);
+        assert_eq!(srt.scale, s.into());
         assert_eq!(srt.rotation, r);
-        assert_eq!(srt.translation, t);
+        assert_eq!(srt.translation, t.into());
 
         assert_eq!(tr, tr);
         assert_eq!(srt, srt);
-        assert_eq!(srt, TransformSrt::from_transform_rt(s, &tr));
+        assert_eq!(srt, Transform3A::from_scale_isometry(s, &tr));
     }
 
     #[test]
     fn test_mul() {
-        let tr = TransformRt::from_rotation_translation(
+        let tr = Isometry3A::from_rotation_translation(
             Quat::from_rotation_z(-90.0_f32.to_radians()),
             Vec3::X,
         );
-        let v0 = Vec3::Y;
-        let v1 = tr * v0;
-        assert_approx_eq!(v1, Vec3::X * 2.0);
-        assert_approx_eq!(v1, tr * v0);
+        let v0 = Vec3A::Y;
+        let v1 = tr.transform_point3a(v0);
+        assert_approx_eq!(v1, Vec3A::X * 2.0);
+        assert_approx_eq!(v1, tr.transform_point3a(v0));
         let inv_tr = tr.inverse();
-        let v2 = inv_tr * v1;
+        let v2 = inv_tr.transform_point3a(v1);
         assert_approx_eq!(v0, v2);
 
-        assert_eq!(tr * TransformRt::IDENTITY, tr);
-        assert_approx_eq!(tr * inv_tr, TransformRt::IDENTITY);
+        assert_eq!(tr * Isometry3A::IDENTITY, tr);
+        assert_approx_eq!(tr * inv_tr, Isometry3A::IDENTITY);
 
-        assert_eq!(tr * TransformSrt::IDENTITY, TransformSrt::from(tr));
-        assert_eq!(TransformSrt::IDENTITY * tr, TransformSrt::from(tr));
+        assert_eq!(tr * Transform3A::IDENTITY, Transform3A::from(tr));
+        assert_eq!(Transform3A::IDENTITY * tr, Transform3A::from(tr));
 
         let s = Vec3::splat(2.0);
         let r = Quat::from_rotation_y(180.0_f32.to_radians());
         let t = -Vec3::Y;
-        let srt = TransformSrt::from_scale_rotation_translation(s, r, t);
-        let v0 = Vec3::X;
-        let v1 = srt * v0;
-        assert_approx_eq!(v1, (r * (v0 * s)) + t);
-        assert_approx_eq!(v1, srt * v0);
+        let srt = Transform3A::from_scale_rotation_translation(s, r, t);
+        let v0 = Vec3A::X;
+        let v1 = srt.transform_point3a(v0);
+        assert_approx_eq!(v1, (r * (v0 * Vec3A::from(s))) + Vec3A::from(t));
+        assert_approx_eq!(v1, srt.transform_point3a(v0));
         let inv_srt = srt.inverse();
-        let v2 = inv_srt * v1;
+        let v2 = inv_srt.transform_point3a(v1);
         assert_approx_eq!(v0, v2);
 
-        assert_eq!(srt * TransformSrt::IDENTITY, srt);
-        assert_eq!(srt * inv_srt, TransformSrt::IDENTITY);
+        assert_eq!(srt * Transform3A::IDENTITY, srt);
+        assert_eq!(srt * inv_srt, Transform3A::IDENTITY);
 
         // negative scale mul test
         let s = Vec3::splat(-2.0);
-        let srt = TransformSrt::from_scale_rotation_translation(s, r, t);
+        let srt = Transform3A::from_scale_rotation_translation(s, r, t);
         let inv_srt = srt.inverse();
-        assert_eq!(srt * inv_srt, TransformSrt::IDENTITY);
+        assert_eq!(srt * inv_srt, Transform3A::IDENTITY);
     }
 }


### PR DESCRIPTION
For the most part this renaming is to indicate that these types are `Vec3A` based which implies they are 16 byte aligned and contain internal padding.

Renamed transform types because these names are used in other Rust crates like nalgebra and ultraviolet and they work a bit better with the `A` suffix.

All transform types are currently on the `transform-types` feature. I haven't decided yet if they should be part of the main library, a separate crate or on a feature. 

Added benches for `Mat3A`.

Removed the `to_simd` / `from_simd` code from `Mat3`, it was slower.

## Benchmarks

Below are some benchmark results from a couple of different machines:

### Intel Core i7-4710HQ

**2D Transforms**

| operation          | mat3        | mat3a      | affine2    |
|--------------------|-------------|------------|------------|
| inverse            | 11.4±0.09ns | 7.1±0.09ns | 5.4±0.06ns |
| mul self           | 10.5±0.04ns | 5.2±0.05ns | 4.0±0.05ns |
| transform point2   |  2.7±0.02ns | 2.7±0.03ns | 2.8±0.04ns |
| transform vector2  |  2.6±0.01ns | 2.6±0.03ns | 2.3±0.02ns |

**3D Transforms**

| operation          | mat4        | affine3a    | isometry3a | transform3a |
|--------------------|-------------|-------------|------------|-------------|
| inverse            | 15.9±0.11ns | 10.8±0.06ns | 5.4±0.05ns |  7.2±0.05ns |
| mul self           |  7.3±0.05ns |  7.0±0.06ns | 7.0±0.06ns |  8.0±0.21ns |
| transform point3   |  3.6±0.02ns |  4.3±0.04ns | 7.8±0.21ns |  8.5±0.08ns |
| transform point3a  |  3.0±0.02ns |  3.0±0.04ns | 4.5±0.09ns |  5.4±0.12ns |
| transform vector3  |  4.1±0.02ns |  3.9±0.04ns | 7.4±0.12ns |  8.2±0.28ns |
| transform vector3a |  2.8±0.02ns |  2.8±0.02ns | 4.3±0.04ns |  5.2±0.05ns |

### AMD Ryzen 3990x

**2D Transforms**

| operation          | mat3       | mat3a      | affine2    |
|--------------------|------------|------------|------------|
| inverse            | 5.7±0.00ns | 4.4±0.01ns | 2.6±0.01ns |
| mul self           | 6.0±0.01ns | 2.9±0.06ns | 2.3±0.00ns |
| transform point2   | 1.5±0.00ns | 2.2±0.00ns | 1.3±0.00ns |
| transform vector2  | 1.2±0.00ns | 2.2±0.00ns | 1.0±0.00ns |

**3D Transforms**

| operation          | mat4        | affine3a   | isometry3a | transform3a |
|--------------------|-------------|------------|------------|-------------|
| inverse            | 10.8±0.01ns | 7.1±0.01ns | 3.1±0.00ns |  3.8±0.05ns |
| mul self           |  4.7±0.01ns | 3.6±0.01ns | 4.5±0.01ns |  5.4±0.01ns |
| transform point3   |  2.3±0.00ns | 2.3±0.00ns | 4.3±0.01ns |  4.3±0.00ns |
| transform point3a  |  2.2±0.00ns | 2.2±0.00ns | 2.9±0.00ns |  3.1±0.04ns |
| transform vector3  |  2.2±0.00ns | 2.3±0.00ns | 4.0±0.00ns |  4.1±0.00ns |
| transform vector3a |  2.2±0.05ns | 2.2±0.00ns | 2.8±0.03ns |  2.9±0.00ns |
