### PR TITLE
Documentation changes around new `Mat3A` and affine types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,33 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [ubuntu, macos, windows]
-        rust: [1.45.0, stable, beta, nightly]
-    runs-on: ${{ matrix.os }}-latest
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain: [1.45.0, stable, beta, nightly]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
-      - run: rustup update --no-self-update ${{ matrix.rust }}
-      - run: rustup default ${{ matrix.rust }}
+      - run: rustup update --no-self-update ${{ matrix.toolchain }}
+      - run: rustup default ${{ matrix.toolchain }}
       - run: ./build_and_test_features.sh
         shell: bash
 
+  build-wasm:
+    strategy:
+      matrix:
+        toolchain: [stable, nightly]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          target: wasm32-unknown-unknown
+          override: true
+
+      - name: Check wasm
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --target wasm32-unknown-unknown

--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ and feel of the API has solidified.
 
 * `f32` types
   * vectors: `Vec2`, `Vec3`, `Vec3A` and `Vec4`
-  * square matrices: `Mat2`, `Mat3` and `Mat4`
+  * square matrices: `Mat2`, `Mat3`, `Mat3A` and `Mat4`
   * a quaternion type: `Quat`
+  * affine transfomation types: `Affine2` and `Affine3A`
 * `f64` types
   * vectors: `DVec2`, `DVec3` and `DVec4`
   * square matrices: `DMat2`, `DMat3` and `DMat4`
   * a quaternion type: `DQuat`
+  * affine transfomation types: `DAffine2` and `DAffine3`
 * `i32` types
   * vectors: `IVec2`, `IVec3` and `IVec4`
 * `u32` types
@@ -29,12 +31,13 @@ and feel of the API has solidified.
 
 ### SIMD
 
-The `Vec3A`, `Vec4` and `Quat` types use SSE2 on x86/x86_64 architectures.
-`Mat2`, `Mat3` and `Mat4` also use SSE2 for some functionality. Not everything
-has a SIMD implementation yet.
-
-Note that this does result in some wasted space in the case of `Vec3A` as the
-SIMD vector type is 16 bytes large and 16 byte aligned.
+The `Vec3A`, `Vec4`, `Quat`, `Mat2`, `Mat3A`, `Mat4`, `Affine2` and `Affine3A`
+types use 128-bit wide SIMD vector types for storage on x86/x86_64
+architectures.  As a result, these types are all 16 byte aligned and depending
+on the size of the type or the type's members, they may contain internal
+padding.  This results in some wasted space in the cases of `Vec3A`, `Mat3A`,
+`Affine2` and `Affine3A`.  However the use of SIMD generally results in better
+performance than scalar math.
 
 `glam` outperforms similar Rust libraries for common operations as tested by the
 [`mathbench`][mathbench] project.

--- a/src/affine2.rs
+++ b/src/affine2.rs
@@ -327,3 +327,20 @@ impl_affine2_traits!(
     TranslateF64,
     DerefTargetF64
 );
+
+#[cfg(any(feature = "scalar-math", target_arch = "spriv"))]
+mod const_test_affine2 {
+    const_assert_eq!(4, core::mem::align_of::<super::Affine2>());
+    const_assert_eq!(24, core::mem::size_of::<super::Affine2>());
+} 
+
+#[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
+mod const_test_affine2 {
+    const_assert_eq!(16, core::mem::align_of::<super::Affine2>());
+    const_assert_eq!(32, core::mem::size_of::<super::Affine2>());
+} 
+
+mod const_test_daffine2 {
+    const_assert_eq!(8, core::mem::align_of::<super::DAffine2>());
+    const_assert_eq!(48, core::mem::size_of::<super::DAffine2>());
+}

--- a/src/affine2.rs
+++ b/src/affine2.rs
@@ -332,13 +332,13 @@ impl_affine2_traits!(
 mod const_test_affine2 {
     const_assert_eq!(4, core::mem::align_of::<super::Affine2>());
     const_assert_eq!(24, core::mem::size_of::<super::Affine2>());
-} 
+}
 
 #[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
 mod const_test_affine2 {
     const_assert_eq!(16, core::mem::align_of::<super::Affine2>());
     const_assert_eq!(32, core::mem::size_of::<super::Affine2>());
-} 
+}
 
 mod const_test_daffine2 {
     const_assert_eq!(8, core::mem::align_of::<super::DAffine2>());

--- a/src/affine3.rs
+++ b/src/affine3.rs
@@ -479,7 +479,7 @@ impl_affine3_traits!(
 mod const_test_affine3a {
     const_assert_eq!(16, core::mem::align_of::<super::Affine3A>());
     const_assert_eq!(64, core::mem::size_of::<super::Affine3A>());
-} 
+}
 
 mod const_test_daffine3 {
     const_assert_eq!(8, core::mem::align_of::<super::DAffine3>());

--- a/src/affine3.rs
+++ b/src/affine3.rs
@@ -8,6 +8,9 @@ use num_traits::Float;
 macro_rules! define_affine3_struct {
     ($affine3:ident, $transform:ident, $translate:ident) => {
         /// A 3D affine transform, which can represent translation, rotation, scaling and shear.
+        ///
+        /// The type is composed of a 3x3 matrix containing a linear transformation (e.g. scale,
+        /// rotation, shear, reflection) and a 3D vector translation.
         #[derive(Copy, Clone)]
         pub struct $affine3 {
             pub matrix3: $transform,
@@ -472,3 +475,13 @@ impl_affine3_traits!(
     TranslateF64,
     DerefTargetF64
 );
+
+mod const_test_affine3a {
+    const_assert_eq!(16, core::mem::align_of::<super::Affine3A>());
+    const_assert_eq!(64, core::mem::size_of::<super::Affine3A>());
+} 
+
+mod const_test_daffine3 {
+    const_assert_eq!(8, core::mem::align_of::<super::DAffine3>());
+    const_assert_eq!(96, core::mem::size_of::<super::DAffine3>());
+}

--- a/src/core/scalar/matrix.rs
+++ b/src/core/scalar/matrix.rs
@@ -154,15 +154,15 @@ impl FloatMatrix3x3<f32, XYZF32A16> for Columns3<XYZF32A16> {
     #[inline]
     fn transform_point2(&self, other: XY<f32>) -> XY<f32> {
         // TODO: This is untested, probably slower than the high level code that uses a SIMD mat2
-        Columns2::from_cols(self.x_axis.into(), self.y_axis.into())
+        Columns2::from_cols(self.x_axis.into_xy(), self.y_axis.into_xy())
             .mul_vector(other)
-            .add(self.z_axis.into())
+            .add(self.z_axis.into_xy())
     }
 
     #[inline]
     fn transform_vector2(&self, other: XY<f32>) -> XY<f32> {
         // TODO: This is untested, probably slower than the high level code that uses a SIMD mat2
-        Columns2::from_cols(self.x_axis.into(), self.y_axis.into()).mul_vector(other)
+        Columns2::from_cols(self.x_axis.into_xy(), self.y_axis.into_xy()).mul_vector(other)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,12 @@
   * vectors: [`Vec2`], [`Vec3`], [`Vec3A`] and [`Vec4`]
   * square matrices: [`Mat2`], [`Mat3`], [`Mat3A`] and [`Mat4`]
   * a quaternion type: [`Quat`]
-  * affine transfomation types: [`Affine2`] and [`Affine3A`]
+  * affine transformation types: [`Affine2`] and [`Affine3A`]
 * [`f64`](mod@f64) types
   * vectors: [`DVec2`], [`DVec3`] and [`DVec4`]
   * square matrices: [`DMat2`], [`DMat3`] and [`DMat4`]
   * a quaternion type: [`DQuat`]
-  * affine transfomation types: [`DAffine2`] and [`DAffine3`]
+  * affine transformation types: [`DAffine2`] and [`DAffine3`]
 * [`i32`](mod@i32) types
   * vectors: [`IVec2`], [`IVec3`] and [`IVec4`]
 * [`u32`](mod@u32) types
@@ -25,26 +25,25 @@
 ## SIMD
 
 `glam` is built with SIMD in mind. Many `f32` types use 128-bit SIMD vector types for storage
-and/or impelementation. The use of SIMD generally enables better performance than using primitive
+and/or implementation. The use of SIMD generally enables better performance than using primitive
 numeric types such as `f32`.
 
 Some `glam` types use SIMD for storage meaning they are 16 byte aligned, these types include
-[`Mat2`], `[Mat3A`], [`Mat4`], [`Quat`], [`Vec3A`], [`Vec4`], [`Affine2`] and [`Affine3A`].
+`Mat2`, `Mat3A`, `Mat4`, `Quat`, `Vec3A`, `Vec4`, `Affine2` an `Affine3A`. Types
+with an `A` suffix are a SIMD alternative to a scalar type, e.g. `Vec3` uses `f32` storage and
+`Vec3A` uses SIMD storage.
 
-When SIMD is not available on the target architecture the types with an `A` suffix will maintain 16
-byte alignment and internal padding so that object sizes and layouts will not change between
-architectures.
-
-All the main `glam` types are `#[repr(C)]`, so they are possible to expose as struct members to C
-interfaces if desired. However be mindful of internal padding of `A` suffix types.
+When SIMD is not available on the target architecture the types will maintain 16 byte alignment and
+internal padding so that object sizes and layouts will not change between architectures.
 
 Currently only SSE2 on x86/x86_64 is supported as this is what stable Rust supports. There are
-scalar math fallback implementations exist when SSE2 is not available.
+scalar math fallback implementations exist when SSE2 is not available. It is intended to add support
+for other SIMD architectures once they appear in stable Rust.
 
 ## `Vec3A` and `Mat3A`
 
-[`Vec3A`] is a SIMD optimized version of the [`Vec3`] type, which due to 16 byte alignment results
-in [`Vec3A`] containing 4 bytes of padding making it 16 bytes in size in total. `Mat3A` is composed
+`Vec3A` is a SIMD optimized version of the `Vec3` type, which due to 16 byte alignment results
+in `Vec3A` containing 4 bytes of padding making it 16 bytes in size in total. `Mat3A` is composed
 of 3 `Vec3A` columns.
 
 | Type       | `f32` bytes | Align bytes | Size bytes | Padding |
@@ -81,16 +80,37 @@ let v3a = Vec3A::from(v3);
 assert_eq!(Vec3A::new(1.0, 2.0, 3.0), v3a);
 ```
 
-## Affine2 and Affine3A
+## `Affine2` and `Affine3A`
 
-Affine2 and Affine3A are composed of a linear transform matrix and a vector translation. The
-specialised affine types perform better than the equivalent transform in a 3x3 or 4x4 matrix,
-especially in the 2D case.
+`Affine2` and `Affine3A` are composed of a linear transform matrix and a vector translation. The
+represent 2D and 3D affine transformations which are commonly used in games.
+
+The table below shows the performance advantage of `Affine2` over `Mat3A` and `Mat3A` over `Mat3`.
+
+| operation          | `Mat3`      | `Mat3A`    | `Affine2`  |
+|--------------------|-------------|------------|------------|
+| inverse            | 11.4±0.09ns | 7.1±0.09ns | 5.4±0.06ns |
+| mul self           | 10.5±0.04ns | 5.2±0.05ns | 4.0±0.05ns |
+| transform point2   |  2.7±0.02ns | 2.7±0.03ns | 2.8±0.04ns |
+| transform vector2  |  2.6±0.01ns | 2.6±0.03ns | 2.3±0.02ns |
+
+Performance is much closer between `Mat4` and `Affine3A` with the affine type being faster to invert.
+
+| operation          | `Mat4`      | `Affine3A`  |
+|--------------------|-------------|-------------|
+| inverse            | 15.9±0.11ns | 10.8±0.06ns |
+| mul self           |  7.3±0.05ns |  7.0±0.06ns |
+| transform point3   |  3.6±0.02ns |  4.3±0.04ns |
+| transform point3a  |  3.0±0.02ns |  3.0±0.04ns |
+| transform vector3  |  4.1±0.02ns |  3.9±0.04ns |
+| transform vector3a |  2.8±0.02ns |  2.8±0.02ns |
+
+Benchmarks were taken on an Intel Core i7-4710HQ.
 
 ## Linear algebra conventions
 
-`glam` interprets vectors as column matrices (also known as *column vectors*)
-meaning when transforming a vector with a matrix the matrix goes on the left.
+`glam` interprets vectors as column matrices (also known as column vectors) meaning when
+transforming a vector with a matrix the matrix goes on the left.
 
 ```
 use glam::{Mat3, Vec3};
@@ -107,7 +127,7 @@ convert from degrees.
 
 ## Direct element access
 
-Because some types may internally be implemeted using SIMD types, direct access to vector elements
+Because some types may internally be implemented using SIMD types, direct access to vector elements
 is supported by implementing the [`Deref`] and [`DerefMut`] traits.
 
 ```
@@ -123,16 +143,16 @@ assert_eq!(4.0, v.z);
 
 ## Vector swizzles
 
-`glam` vector types have functions allowing elements of vectors to be reordered,
-this includes creating a vector of a different size from the vectors elements.
+`glam` vector types have functions allowing elements of vectors to be reordered, this includes
+creating a vector of a different size from the vectors elements.
 
-The swizzle functions are implemented using traits to add them to each vector
-type. This is primarily because there are a lot of swizzle functions which can
-obfuscate the other vector functions in documentation and so on. The traits are
-[`Vec2Swizzles`], [`Vec3Swizzles`] and [`Vec4Swizzles`].
+The swizzle functions are implemented using traits to add them to each vector type. This is
+primarily because there are a lot of swizzle functions which can obfuscate the other vector
+functions in documentation and so on. The traits are [`Vec2Swizzles`], [`Vec3Swizzles`] and
+[`Vec4Swizzles`].
 
-Note that the [`Vec3Swizzles`] implementation for [`Vec3A`] will return a [`Vec3A`]
-for 3 element swizzles, all other implementations will return [`Vec3`].
+Note that the [`Vec3Swizzles`] implementation for [`Vec3A`] will return a [`Vec3A`] for 3 element
+swizzles, all other implementations will return [`Vec3`].
 
 ```
 use glam::{swizzles::*, Vec2, Vec3, Vec3A, Vec4};
@@ -186,12 +206,11 @@ and benchmarks.
 * `rand` - used to generate random values. Used in benchmarks.
 * `serde` - used for serialization and deserialization of types.
 * `mint` - used for interoperating with other linear algebra libraries.
-* `scalar-math` - disables SIMD support and uses native alignment for all
-  types.
-* `debug-glam-assert` - adds assertions in debug builds which check the validity
-  of parameters passed to `glam` to help catch runtime errors.
-* `glam-assert` - adds assertions to all builds which check the validity of
-  parameters passed to `glam` to help catch runtime errors.
+* `scalar-math` - disables SIMD support and uses native alignment for all types.
+* `debug-glam-assert` - adds assertions in debug builds which check the validity of parameters
+  passed to `glam` to help catch runtime errors.
+* `glam-assert` - adds assertions to all builds which check the validity of parameters passed to
+  `glam` to help catch runtime errors.
 
 ## Minimum Supported Version or Rust (MSVR)
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,15 +5,31 @@
 
 ## Features
 
-`glam` is built with SIMD in mind. Currently only SSE2 on x86/x86_64 is
-supported as this is what stable Rust supports.
+* [`f32`](mod@f32) types
+  * vectors: [`Vec2`], [`Vec3`], [`Vec3A`] and [`Vec4`]
+  * square matrices: [`Mat2`], [`Mat3`], [`Mat3A`] and [`Mat4`]
+  * a quaternion type: [`Quat`]
+  * affine transfomation types: [`Affine2`] and [`Affine3A`]
+* [`f64`](mod@f64) types
+  * vectors: [`DVec2`], [`DVec3`] and [`DVec4`]
+  * square matrices: [`DMat2`], [`DMat3`] and [`DMat4`]
+  * a quaternion type: [`DQuat`]
+  * affine transfomation types: [`DAffine2`] and [`DAffine3`]
+* [`i32`](mod@i32) types
+  * vectors: [`IVec2`], [`IVec3`] and [`IVec4`]
+* [`u32`](mod@u32) types
+  * vectors: [`UVec2`], [`UVec3`] and [`UVec4`]
+* [`bool`](mod@bool) types
+  * vectors: [`BVec2`], [`BVec3`] and [`BVec4`]
 
-* Vector, quaternion and matrix types support for [`f32`](mod@f32) and [`f64`](mod@f64)
-* Vector types supported for [`i32`](mod@i32), [`u32`](mod@u32) and [`bool`](mod@bool)
-* SSE2 storage and optimization for many [`f32`](mod@f32) types, including [`Mat2`], [`Mat4`],
-  [`Quat`], [`Vec3A`] and [`Vec4`]
-* Scalar math fallback implementations exist when SSE2 is not available
-* Most functionality includes unit tests and benchmarks
+## SIMD
+
+`glam` is built with SIMD in mind. Many `f32` types use 128-bit SIMD vector types for storage
+and/or impelementation. The use of SIMD generally enables better performance than using regular
+`f32` math.
+
+Currently only SSE2 on x86/x86_64 is supported as this is what stable Rust supports. There are
+scalar math fallback implementations exist when SSE2 is not available.
 
 ## Linear algebra conventions
 
@@ -30,8 +46,8 @@ assert_eq!(v, x);
 
 Matrices are stored in memory in column-major order.
 
-All angles are in radians. Rust provides the `to_radians()` method which can be
-used to convert from degrees.
+All angles are in radians. Rust provides the `f32::to_radians()` and `f64::to_radians()` methods to
+convert from degrees.
 
 ## Direct element access
 
@@ -52,7 +68,8 @@ assert_eq!(4.0, v.z);
 ## Size and alignment of types
 
 Some `glam` types use SIMD for storage meaning they are 16 byte aligned, these
-types include [`Mat2`], [`Mat4`], [`Quat`], [`Vec3A`] and [`Vec4`].
+types include [`Mat2`], `[Mat3A`], [`Mat4`], [`Quat`], [`Vec3A`], [`Vec4`], [`Affine2`] and
+[`Affine3A`].
 
 When SSE2 is not available on the target architecture this type will still be 16
 byte aligned so that object sizes and layouts will not change between

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -15,7 +15,7 @@ macro_rules! glam_assert {
 
 macro_rules! const_assert {
     ($x:expr $(,)?) => {
-        #[allow(unknown_lints, eq_op)]
+        #[allow(unknown_lints, clippy::eq_op)]
         const _: [(); 0 - !{
             const ASSERT: bool = $x;
             ASSERT

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -13,6 +13,19 @@ macro_rules! glam_assert {
     ($($arg:tt)*) => {};
 }
 
+macro_rules! const_assert {
+    ($x:expr $(,)?) => {
+        #[allow(unknown_lints, eq_op)]
+        const _: [(); 0 - !{ const ASSERT: bool = $x; ASSERT } as usize] = [];
+    };
+}
+
+macro_rules! const_assert_eq {
+    ($x:expr, $y:expr $(,)?) => {
+        const_assert!($x == $y);
+    };
+}
+
 #[macro_export]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 macro_rules! const_m128 {
@@ -20,6 +33,7 @@ macro_rules! const_m128 {
         unsafe { $crate::cast::Vec4Cast { fx4: $fx4 }.m128 }
     };
 }
+
 
 /// Creates a `Vec2` that can be used to initialize a constant value.
 ///
@@ -166,6 +180,7 @@ macro_rules! const_mat3a {
         )
     };
 }
+
 /// Creates a `Mat4` from four column vectors that can be used to initialize a constant value.
 ///
 /// ```

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,7 +16,10 @@ macro_rules! glam_assert {
 macro_rules! const_assert {
     ($x:expr $(,)?) => {
         #[allow(unknown_lints, eq_op)]
-        const _: [(); 0 - !{ const ASSERT: bool = $x; ASSERT } as usize] = [];
+        const _: [(); 0 - !{
+            const ASSERT: bool = $x;
+            ASSERT
+        } as usize] = [];
     };
 }
 
@@ -33,7 +36,6 @@ macro_rules! const_m128 {
         unsafe { $crate::cast::Vec4Cast { fx4: $fx4 }.m128 }
     };
 }
-
 
 /// Creates a `Vec2` that can be used to initialize a constant value.
 ///

--- a/src/mat2.rs
+++ b/src/mat2.rs
@@ -366,7 +366,10 @@ type InnerF32 = crate::core::storage::Columns2<XY<f32>>;
 
 /// A 2x2 column major matrix.
 #[derive(Clone, Copy)]
-#[cfg_attr(not(any(feature = "scalar-math", target_arch = "spriv")), repr(align(16)))]
+#[cfg_attr(
+    not(any(feature = "scalar-math", target_arch = "spriv")),
+    repr(align(16))
+)]
 #[cfg_attr(any(feature = "scalar-math", target_arch = "spriv"), repr(transparent))]
 pub struct Mat2(pub(crate) InnerF32);
 
@@ -401,13 +404,13 @@ impl_mat2_traits!(f64, dmat2, DMat2, DMat3, DVec2);
 mod const_test_mat2 {
     const_assert_eq!(4, core::mem::align_of::<super::Mat2>());
     const_assert_eq!(16, core::mem::size_of::<super::Mat2>());
-} 
+}
 
 #[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
 mod const_test_mat2 {
     const_assert_eq!(16, core::mem::align_of::<super::Mat2>());
     const_assert_eq!(16, core::mem::size_of::<super::Mat2>());
-} 
+}
 
 mod const_test_dmat2 {
     const_assert_eq!(8, core::mem::align_of::<super::DMat2>());

--- a/src/mat2.rs
+++ b/src/mat2.rs
@@ -366,7 +366,8 @@ type InnerF32 = crate::core::storage::Columns2<XY<f32>>;
 
 /// A 2x2 column major matrix.
 #[derive(Clone, Copy)]
-#[repr(transparent)]
+#[cfg_attr(not(any(feature = "scalar-math", target_arch = "spriv")), repr(align(16)))]
+#[cfg_attr(any(feature = "scalar-math", target_arch = "spriv"), repr(transparent))]
 pub struct Mat2(pub(crate) InnerF32);
 
 impl Mat2 {
@@ -395,3 +396,20 @@ impl DMat2 {
     }
 }
 impl_mat2_traits!(f64, dmat2, DMat2, DMat3, DVec2);
+
+#[cfg(any(feature = "scalar-math", target_arch = "spriv"))]
+mod const_test_mat2 {
+    const_assert_eq!(4, core::mem::align_of::<super::Mat2>());
+    const_assert_eq!(16, core::mem::size_of::<super::Mat2>());
+} 
+
+#[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
+mod const_test_mat2 {
+    const_assert_eq!(16, core::mem::align_of::<super::Mat2>());
+    const_assert_eq!(16, core::mem::size_of::<super::Mat2>());
+} 
+
+mod const_test_dmat2 {
+    const_assert_eq!(8, core::mem::align_of::<super::DMat2>());
+    const_assert_eq!(32, core::mem::size_of::<super::DMat2>());
+}

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -598,12 +598,12 @@ impl_mat3_traits_unsafe!(f64, DMat3);
 mod const_test_mat3 {
     const_assert_eq!(4, core::mem::align_of::<super::Mat3>());
     const_assert_eq!(36, core::mem::size_of::<super::Mat3>());
-} 
+}
 
 mod const_test_mat3a {
     const_assert_eq!(16, core::mem::align_of::<super::Mat3A>());
     const_assert_eq!(48, core::mem::size_of::<super::Mat3A>());
-} 
+}
 
 mod const_test_dmat3 {
     const_assert_eq!(8, core::mem::align_of::<super::DMat3>());

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -594,3 +594,18 @@ impl DMat3 {
 }
 impl_mat3_traits!(f64, dmat3, DMat3, DMat4, DVec3, DVec3);
 impl_mat3_traits_unsafe!(f64, DMat3);
+
+mod const_test_mat3 {
+    const_assert_eq!(4, core::mem::align_of::<super::Mat3>());
+    const_assert_eq!(36, core::mem::size_of::<super::Mat3>());
+} 
+
+mod const_test_mat3a {
+    const_assert_eq!(16, core::mem::align_of::<super::Mat3A>());
+    const_assert_eq!(48, core::mem::size_of::<super::Mat3A>());
+} 
+
+mod const_test_dmat3 {
+    const_assert_eq!(8, core::mem::align_of::<super::DMat3>());
+    const_assert_eq!(72, core::mem::size_of::<super::DMat3>());
+}

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -27,40 +27,40 @@ use core::ops::{Add, Deref, DerefMut, Mul, Sub};
 #[cfg(feature = "std")]
 use std::iter::{Product, Sum};
 
-macro_rules! define_mat4_struct {
-    ($mat4:ident, $inner:ident) => {
-        /// A 4x4 column major matrix.
-        ///
-        /// This 4x4 matrix type features convenience methods for creating and using affine
-        /// transforms and perspective projections.
-        ///
-        /// Affine transformations including 3D translation, rotation and scale can be created
-        /// using methods such as [`Self::from_translation()`], [`Self::from_quat()`],
-        /// [`Self::from_scale()`] and [`Self::from_scale_rotation_translation()`].
-        ///
-        /// Othographic projections can be created using the methods [`Self::orthographic_lh()`] for
-        /// left-handed coordinate systems and [`Self::orthographic_rh()`] for right-handed
-        /// systems. The resulting matrix is also an affine transformation.
-        ///
-        /// The [`Self::transform_point3()`] and [`Self::transform_vector3()`] convenience methods
-        /// are provided for performing affine transformations on 3D vectors and points. These
-        /// multiply 3D inputs as 4D vectors with an implicit `w` value of `1` for points and `0`
-        /// for vectors respectively. These methods assume that `Self` contains a valid affine
-        /// transform.
-        ///
-        /// Perspective projections can be created using methods such as
-        /// [`Self::perspective_lh()`], [`Self::perspective_infinite_lh()`] and
-        /// [`Self::perspective_infinite_reverse_lh()`] for left-handed co-ordinate systems and
-        /// [`Self::perspective_rh()`], [`Self::perspective_infinite_rh()`] and
-        /// [`Self::perspective_infinite_reverse_rh()`] for right-handed co-ordinate systems.
-        ///
-        /// The resulting perspective project can be use to transform 3D vectors as points with
-        /// perspective correction using the [`Self::project_point3()`] convenience method.
-        #[derive(Clone, Copy)]
-        #[repr(transparent)]
-        pub struct $mat4(pub(crate) $inner);
-    };
-}
+//macro_rules! define_mat4_struct {
+//    ($mat4:ident, $inner:ident) => {
+//        /// A 4x4 column major matrix.
+//        ///
+//        /// This 4x4 matrix type features convenience methods for creating and using affine
+//        /// transforms and perspective projections.
+//        ///
+//        /// Affine transformations including 3D translation, rotation and scale can be created
+//        /// using methods such as [`Self::from_translation()`], [`Self::from_quat()`],
+//        /// [`Self::from_scale()`] and [`Self::from_scale_rotation_translation()`].
+//        ///
+//        /// Othographic projections can be created using the methods [`Self::orthographic_lh()`] for
+//        /// left-handed coordinate systems and [`Self::orthographic_rh()`] for right-handed
+//        /// systems. The resulting matrix is also an affine transformation.
+//        ///
+//        /// The [`Self::transform_point3()`] and [`Self::transform_vector3()`] convenience methods
+//        /// are provided for performing affine transformations on 3D vectors and points. These
+//        /// multiply 3D inputs as 4D vectors with an implicit `w` value of `1` for points and `0`
+//        /// for vectors respectively. These methods assume that `Self` contains a valid affine
+//        /// transform.
+//        ///
+//        /// Perspective projections can be created using methods such as
+//        /// [`Self::perspective_lh()`], [`Self::perspective_infinite_lh()`] and
+//        /// [`Self::perspective_infinite_reverse_lh()`] for left-handed co-ordinate systems and
+//        /// [`Self::perspective_rh()`], [`Self::perspective_infinite_rh()`] and
+//        /// [`Self::perspective_infinite_reverse_rh()`] for right-handed co-ordinate systems.
+//        ///
+//        /// The resulting perspective project can be use to transform 3D vectors as points with
+//        /// perspective correction using the [`Self::project_point3()`] convenience method.
+//        #[derive(Clone, Copy)]
+//        #[repr(transparent)]
+//        pub struct $mat4(pub(crate) $inner);
+//    };
+//}
 
 macro_rules! impl_mat4_methods {
     ($t:ident, $vec4:ident, $vec3:ident, $quat:ident, $inner:ident) => {
@@ -715,7 +715,38 @@ type InnerF32 = Columns4<__m128>;
 #[cfg(any(not(target_feature = "sse2"), feature = "scalar-math"))]
 type InnerF32 = Columns4<XYZW<f32>>;
 
-define_mat4_struct!(Mat4, InnerF32);
+/// A 4x4 column major matrix.
+///
+/// This 4x4 matrix type features convenience methods for creating and using affine
+/// transforms and perspective projections.
+///
+/// Affine transformations including 3D translation, rotation and scale can be created
+/// using methods such as [`Self::from_translation()`], [`Self::from_quat()`],
+/// [`Self::from_scale()`] and [`Self::from_scale_rotation_translation()`].
+///
+/// Othographic projections can be created using the methods [`Self::orthographic_lh()`] for
+/// left-handed coordinate systems and [`Self::orthographic_rh()`] for right-handed
+/// systems. The resulting matrix is also an affine transformation.
+///
+/// The [`Self::transform_point3()`] and [`Self::transform_vector3()`] convenience methods
+/// are provided for performing affine transformations on 3D vectors and points. These
+/// multiply 3D inputs as 4D vectors with an implicit `w` value of `1` for points and `0`
+/// for vectors respectively. These methods assume that `Self` contains a valid affine
+/// transform.
+///
+/// Perspective projections can be created using methods such as
+/// [`Self::perspective_lh()`], [`Self::perspective_infinite_lh()`] and
+/// [`Self::perspective_infinite_reverse_lh()`] for left-handed co-ordinate systems and
+/// [`Self::perspective_rh()`], [`Self::perspective_infinite_rh()`] and
+/// [`Self::perspective_infinite_reverse_rh()`] for right-handed co-ordinate systems.
+///
+/// The resulting perspective project can be use to transform 3D vectors as points with
+/// perspective correction using the [`Self::project_point3()`] convenience method.
+#[derive(Clone, Copy)]
+#[cfg_attr(not(any(feature = "scalar-math", target_arch = "spriv")), repr(align(16)))]
+#[cfg_attr(any(feature = "scalar-math", target_arch = "spriv"), repr(transparent))]
+pub struct Mat4(pub(crate) InnerF32);
+// define_mat4_struct!(Mat4, InnerF32);
 
 impl Mat4 {
     impl_mat4_methods!(f32, Vec4, Vec3, Quat, InnerF32);
@@ -752,7 +783,37 @@ impl_mat4_traits!(f32, mat4, Mat4, Vec4);
 
 type InnerF64 = Columns4<XYZW<f64>>;
 
-define_mat4_struct!(DMat4, InnerF64);
+/// A 4x4 column major matrix.
+///
+/// This 4x4 matrix type features convenience methods for creating and using affine
+/// transforms and perspective projections.
+///
+/// Affine transformations including 3D translation, rotation and scale can be created
+/// using methods such as [`Self::from_translation()`], [`Self::from_quat()`],
+/// [`Self::from_scale()`] and [`Self::from_scale_rotation_translation()`].
+///
+/// Othographic projections can be created using the methods [`Self::orthographic_lh()`] for
+/// left-handed coordinate systems and [`Self::orthographic_rh()`] for right-handed
+/// systems. The resulting matrix is also an affine transformation.
+///
+/// The [`Self::transform_point3()`] and [`Self::transform_vector3()`] convenience methods
+/// are provided for performing affine transformations on 3D vectors and points. These
+/// multiply 3D inputs as 4D vectors with an implicit `w` value of `1` for points and `0`
+/// for vectors respectively. These methods assume that `Self` contains a valid affine
+/// transform.
+///
+/// Perspective projections can be created using methods such as
+/// [`Self::perspective_lh()`], [`Self::perspective_infinite_lh()`] and
+/// [`Self::perspective_infinite_reverse_lh()`] for left-handed co-ordinate systems and
+/// [`Self::perspective_rh()`], [`Self::perspective_infinite_rh()`] and
+/// [`Self::perspective_infinite_reverse_rh()`] for right-handed co-ordinate systems.
+///
+/// The resulting perspective project can be use to transform 3D vectors as points with
+/// perspective correction using the [`Self::project_point3()`] convenience method.
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct DMat4(pub(crate) InnerF64);
+// define_mat4_struct!(DMat4, InnerF64);
 
 impl DMat4 {
     impl_mat4_methods!(f64, DVec4, DVec3, DQuat, InnerF64);
@@ -768,3 +829,20 @@ impl DMat4 {
     }
 }
 impl_mat4_traits!(f64, dmat4, DMat4, DVec4);
+
+#[cfg(any(feature = "scalar-math", target_arch = "spriv"))]
+mod const_test_mat4 {
+    const_assert_eq!(4, core::mem::align_of::<super::Mat4>());
+    const_assert_eq!(64, core::mem::size_of::<super::Mat4>());
+} 
+
+#[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
+mod const_test_mat4 {
+    const_assert_eq!(16, core::mem::align_of::<super::Mat4>());
+    const_assert_eq!(64, core::mem::size_of::<super::Mat4>());
+} 
+
+mod const_test_dmat4 {
+    const_assert_eq!(8, core::mem::align_of::<super::DMat4>());
+    const_assert_eq!(128, core::mem::size_of::<super::DMat4>());
+}

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -743,7 +743,10 @@ type InnerF32 = Columns4<XYZW<f32>>;
 /// The resulting perspective project can be use to transform 3D vectors as points with
 /// perspective correction using the [`Self::project_point3()`] convenience method.
 #[derive(Clone, Copy)]
-#[cfg_attr(not(any(feature = "scalar-math", target_arch = "spriv")), repr(align(16)))]
+#[cfg_attr(
+    not(any(feature = "scalar-math", target_arch = "spriv")),
+    repr(align(16))
+)]
 #[cfg_attr(any(feature = "scalar-math", target_arch = "spriv"), repr(transparent))]
 pub struct Mat4(pub(crate) InnerF32);
 // define_mat4_struct!(Mat4, InnerF32);
@@ -834,13 +837,13 @@ impl_mat4_traits!(f64, dmat4, DMat4, DVec4);
 mod const_test_mat4 {
     const_assert_eq!(4, core::mem::align_of::<super::Mat4>());
     const_assert_eq!(64, core::mem::size_of::<super::Mat4>());
-} 
+}
 
 #[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
 mod const_test_mat4 {
     const_assert_eq!(16, core::mem::align_of::<super::Mat4>());
     const_assert_eq!(64, core::mem::size_of::<super::Mat4>());
-} 
+}
 
 mod const_test_dmat4 {
     const_assert_eq!(8, core::mem::align_of::<super::DMat4>());

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -595,7 +595,8 @@ type InnerF32 = crate::XYZW<f32>;
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[repr(transparent)]
+#[cfg_attr(not(any(feature = "scalar-math", target_arch = "spriv")), repr(align(16)))]
+#[cfg_attr(any(feature = "scalar-math", target_arch = "spriv"), repr(transparent))]
 pub struct Quat(pub(crate) InnerF32);
 
 impl Quat {
@@ -663,3 +664,21 @@ impl DQuat {
     }
 }
 impl_quat_traits!(f64, dquat, DQuat, DVec3, DVec4, InnerF64);
+
+#[cfg(any(feature = "scalar-math", target_arch = "spriv"))]
+mod const_test_quat {
+    const_assert_eq!(4, core::mem::align_of::<super::Quat>());
+    const_assert_eq!(16, core::mem::size_of::<super::Quat>());
+} 
+
+#[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
+mod const_test_quat {
+    const_assert_eq!(16, core::mem::align_of::<super::Quat>());
+    const_assert_eq!(16, core::mem::size_of::<super::Quat>());
+} 
+
+mod const_test_dquat {
+    const_assert_eq!(8, core::mem::align_of::<super::DQuat>());
+    const_assert_eq!(32, core::mem::size_of::<super::DQuat>());
+}
+

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -595,7 +595,10 @@ type InnerF32 = crate::XYZW<f32>;
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(not(any(feature = "scalar-math", target_arch = "spriv")), repr(align(16)))]
+#[cfg_attr(
+    not(any(feature = "scalar-math", target_arch = "spriv")),
+    repr(align(16))
+)]
 #[cfg_attr(any(feature = "scalar-math", target_arch = "spriv"), repr(transparent))]
 pub struct Quat(pub(crate) InnerF32);
 
@@ -669,16 +672,15 @@ impl_quat_traits!(f64, dquat, DQuat, DVec3, DVec4, InnerF64);
 mod const_test_quat {
     const_assert_eq!(4, core::mem::align_of::<super::Quat>());
     const_assert_eq!(16, core::mem::size_of::<super::Quat>());
-} 
+}
 
 #[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
 mod const_test_quat {
     const_assert_eq!(16, core::mem::align_of::<super::Quat>());
     const_assert_eq!(16, core::mem::size_of::<super::Quat>());
-} 
+}
 
 mod const_test_dquat {
     const_assert_eq!(8, core::mem::align_of::<super::DQuat>());
     const_assert_eq!(32, core::mem::size_of::<super::DQuat>());
 }
-

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -219,7 +219,7 @@ impl_vecn_eq_hash_traits!(u32, 2, UVec2);
 mod const_test_vec2 {
     const_assert_eq!(4, core::mem::align_of::<super::Vec2>());
     const_assert_eq!(8, core::mem::size_of::<super::Vec2>());
-} 
+}
 
 mod const_test_dvec2 {
     const_assert_eq!(8, core::mem::align_of::<super::DVec2>());
@@ -229,9 +229,9 @@ mod const_test_dvec2 {
 mod const_test_ivec2 {
     const_assert_eq!(4, core::mem::align_of::<super::IVec2>());
     const_assert_eq!(8, core::mem::size_of::<super::IVec2>());
-} 
+}
 
 mod const_test_uvec2 {
     const_assert_eq!(4, core::mem::align_of::<super::UVec2>());
     const_assert_eq!(8, core::mem::size_of::<super::UVec2>());
-} 
+}

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -215,3 +215,23 @@ impl UVec2 {
 }
 impl_vec2_unsigned_traits!(u32, uvec2, UVec2, UVec3, BVec2, XYU32);
 impl_vecn_eq_hash_traits!(u32, 2, UVec2);
+
+mod const_test_vec2 {
+    const_assert_eq!(4, core::mem::align_of::<super::Vec2>());
+    const_assert_eq!(8, core::mem::size_of::<super::Vec2>());
+} 
+
+mod const_test_dvec2 {
+    const_assert_eq!(8, core::mem::align_of::<super::DVec2>());
+    const_assert_eq!(16, core::mem::size_of::<super::DVec2>());
+}
+
+mod const_test_ivec2 {
+    const_assert_eq!(4, core::mem::align_of::<super::IVec2>());
+    const_assert_eq!(8, core::mem::size_of::<super::IVec2>());
+} 
+
+mod const_test_uvec2 {
+    const_assert_eq!(4, core::mem::align_of::<super::UVec2>());
+    const_assert_eq!(8, core::mem::size_of::<super::UVec2>());
+} 

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -356,12 +356,12 @@ fn test_vec3_private() {
 mod const_test_vec3 {
     const_assert_eq!(4, core::mem::align_of::<super::Vec3>());
     const_assert_eq!(12, core::mem::size_of::<super::Vec3>());
-} 
+}
 
 mod const_test_vec3a {
     const_assert_eq!(16, core::mem::align_of::<super::Vec3A>());
     const_assert_eq!(16, core::mem::size_of::<super::Vec3A>());
-} 
+}
 
 mod const_test_dvec3 {
     const_assert_eq!(8, core::mem::align_of::<super::DVec3>());
@@ -371,9 +371,9 @@ mod const_test_dvec3 {
 mod const_test_ivec3 {
     const_assert_eq!(4, core::mem::align_of::<super::IVec3>());
     const_assert_eq!(12, core::mem::size_of::<super::IVec3>());
-} 
+}
 
 mod const_test_uvec3 {
     const_assert_eq!(4, core::mem::align_of::<super::UVec3>());
     const_assert_eq!(12, core::mem::size_of::<super::UVec3>());
-} 
+}

--- a/src/vec3.rs
+++ b/src/vec3.rs
@@ -352,3 +352,28 @@ fn test_vec3_private() {
         vec3a(-0.5, 1.0, -5.0)
     );
 }
+
+mod const_test_vec3 {
+    const_assert_eq!(4, core::mem::align_of::<super::Vec3>());
+    const_assert_eq!(12, core::mem::size_of::<super::Vec3>());
+} 
+
+mod const_test_vec3a {
+    const_assert_eq!(16, core::mem::align_of::<super::Vec3A>());
+    const_assert_eq!(16, core::mem::size_of::<super::Vec3A>());
+} 
+
+mod const_test_dvec3 {
+    const_assert_eq!(8, core::mem::align_of::<super::DVec3>());
+    const_assert_eq!(24, core::mem::size_of::<super::DVec3>());
+}
+
+mod const_test_ivec3 {
+    const_assert_eq!(4, core::mem::align_of::<super::IVec3>());
+    const_assert_eq!(12, core::mem::size_of::<super::IVec3>());
+} 
+
+mod const_test_uvec3 {
+    const_assert_eq!(4, core::mem::align_of::<super::UVec3>());
+    const_assert_eq!(12, core::mem::size_of::<super::UVec3>());
+} 

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -219,7 +219,8 @@ type XYZWF32 = __m128;
 ///
 /// This type uses 16 byte aligned SIMD vector type for storage on supported platforms.
 #[derive(Clone, Copy)]
-#[repr(transparent)]
+#[cfg_attr(not(any(feature = "scalar-math", target_arch = "spriv")), repr(align(16)))]
+#[cfg_attr(any(feature = "scalar-math", target_arch = "spriv"), repr(transparent))]
 pub struct Vec4(pub(crate) XYZWF32);
 
 #[cfg(any(not(target_feature = "sse2"), feature = "scalar-math"))]
@@ -306,3 +307,30 @@ mod tests {
         );
     }
 }
+
+#[cfg(any(feature = "scalar-math", target_arch = "spriv"))]
+mod const_test_vec4 {
+    const_assert_eq!(4, core::mem::align_of::<super::Vec4>());
+    const_assert_eq!(16, core::mem::size_of::<super::Vec4>());
+} 
+
+#[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
+mod const_test_vec4 {
+    const_assert_eq!(16, core::mem::align_of::<super::Vec4>());
+    const_assert_eq!(16, core::mem::size_of::<super::Vec4>());
+} 
+
+mod const_test_dvec4 {
+    const_assert_eq!(8, core::mem::align_of::<super::DVec4>());
+    const_assert_eq!(32, core::mem::size_of::<super::DVec4>());
+}
+
+mod const_test_ivec4 {
+    const_assert_eq!(4, core::mem::align_of::<super::IVec4>());
+    const_assert_eq!(16, core::mem::size_of::<super::IVec4>());
+} 
+
+mod const_test_uvec4 {
+    const_assert_eq!(4, core::mem::align_of::<super::UVec4>());
+    const_assert_eq!(16, core::mem::size_of::<super::UVec4>());
+} 

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -219,7 +219,10 @@ type XYZWF32 = __m128;
 ///
 /// This type uses 16 byte aligned SIMD vector type for storage on supported platforms.
 #[derive(Clone, Copy)]
-#[cfg_attr(not(any(feature = "scalar-math", target_arch = "spriv")), repr(align(16)))]
+#[cfg_attr(
+    not(any(feature = "scalar-math", target_arch = "spriv")),
+    repr(align(16))
+)]
 #[cfg_attr(any(feature = "scalar-math", target_arch = "spriv"), repr(transparent))]
 pub struct Vec4(pub(crate) XYZWF32);
 
@@ -312,13 +315,13 @@ mod tests {
 mod const_test_vec4 {
     const_assert_eq!(4, core::mem::align_of::<super::Vec4>());
     const_assert_eq!(16, core::mem::size_of::<super::Vec4>());
-} 
+}
 
 #[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
 mod const_test_vec4 {
     const_assert_eq!(16, core::mem::align_of::<super::Vec4>());
     const_assert_eq!(16, core::mem::size_of::<super::Vec4>());
-} 
+}
 
 mod const_test_dvec4 {
     const_assert_eq!(8, core::mem::align_of::<super::DVec4>());
@@ -328,9 +331,9 @@ mod const_test_dvec4 {
 mod const_test_ivec4 {
     const_assert_eq!(4, core::mem::align_of::<super::IVec4>());
     const_assert_eq!(16, core::mem::size_of::<super::IVec4>());
-} 
+}
 
 mod const_test_uvec4 {
     const_assert_eq!(4, core::mem::align_of::<super::UVec4>());
     const_assert_eq!(16, core::mem::size_of::<super::UVec4>());
-} 
+}

--- a/src/vec_mask.rs
+++ b/src/vec_mask.rs
@@ -406,11 +406,10 @@ mod const_test_bvec3a {
 mod const_test_bvec4 {
     const_assert_eq!(1, core::mem::align_of::<super::BVec4>());
     const_assert_eq!(4, core::mem::size_of::<super::BVec4>());
-} 
+}
 
 #[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))]
 mod const_test_bvec4a {
     const_assert_eq!(16, core::mem::align_of::<super::BVec4A>());
     const_assert_eq!(16, core::mem::size_of::<super::BVec4A>());
 }
-

--- a/src/vec_mask.rs
+++ b/src/vec_mask.rs
@@ -386,3 +386,31 @@ type XYZWBool = crate::XYZW<bool>;
 #[repr(transparent)]
 pub struct BVec4(pub(crate) XYZWBool);
 impl_vec4mask!(BVec4, bool, XYZWBool);
+
+mod const_test_bvec2 {
+    const_assert_eq!(1, core::mem::align_of::<super::BVec2>());
+    const_assert_eq!(2, core::mem::size_of::<super::BVec2>());
+}
+
+mod const_test_bvec3 {
+    const_assert_eq!(1, core::mem::align_of::<super::BVec3>());
+    const_assert_eq!(3, core::mem::size_of::<super::BVec3>());
+}
+
+#[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))]
+mod const_test_bvec3a {
+    const_assert_eq!(16, core::mem::align_of::<super::BVec3A>());
+    const_assert_eq!(16, core::mem::size_of::<super::BVec3A>());
+}
+
+mod const_test_bvec4 {
+    const_assert_eq!(1, core::mem::align_of::<super::BVec4>());
+    const_assert_eq!(4, core::mem::size_of::<super::BVec4>());
+} 
+
+#[cfg(all(target_feature = "sse2", not(feature = "scalar-math")))]
+mod const_test_bvec4a {
+    const_assert_eq!(16, core::mem::align_of::<super::BVec4A>());
+    const_assert_eq!(16, core::mem::size_of::<super::BVec4A>());
+}
+


### PR DESCRIPTION
* Added wasm32-unknown-unknown build target
* Improvements around size and alignment consistency when SIMD is not available (e.g. not x86)
* Added const asserts to catch alignment and size problems at compile time so it's not necessary to execute test code for these checks