### PR TITLE
Add missing impls to affine types, (add, sub, mul scalar, display, to and from array, slice.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## [Unreleased]
+
+### Added
+
+* Added `from_cols` methods to affine types.
+* Added methods for reading and writing affine types from and to arrays and
+  slices, including `from_cols_array`, `to_cols_array`, `from_cols_array_2d`,
+  `to_cols_array_2d`, `from_cols_slice` and `write_cols_to_slice`.
+* Added `core::fmt::Display` trait implementations for affine types.
+* Added `core::ops::Add`, `core::ops::Mul` scalar and `core::ops::Sub` trait
+  implementations for affine types.
+
+### Changed
+
+* Renamed vector `from_slice_unaligned` and `write_to_slice_unaligned` methods
+  to `from_slice` and `write_to_slice`.
+
 ## [0.15.1] - 2021-05-14
 
 ### Changed
@@ -40,7 +57,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Added 2D affine transform types `Affine2` and `DAffine2`. These are more
   efficient than using `Mat3` and `DMat3` respectively when working with 2D
   affine transforms.
-* Aded `Quat::from_affine3` to create a quaternion from an affine transform
+* Added `Quat::from_affine3` to create a quaternion from an affine transform
   rotation.
 * Added explicit `to_array` method to vector types to better match the matrix
   methods.
@@ -80,7 +97,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 * Added vector `clamp()` functions.
 * Added matrix column and row accessor methods, `col()` and `row()`.
-* Added SPIR-V module and depenency on `spriv-std` for the SPIR-V target.
+* Added SPIR-V module and dependency on `spriv-std` for the SPIR-V target.
 * Added matrix truncation from 4x4 to 3x3 and 3x3 to 2x2 via `From` impls.
 
 ### Changed
@@ -121,7 +138,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Added quaternion `inverse()` which assumes the quaternion is already
   normalized and returns the conjugate.
 * Added `from_translation()` and `from_angle()` methods to 3x3 matrix types.
-* Added `project_point3()` method to 4x4 matrics types. This method is for
+* Added `project_point3()` method to 4x4 matrix types. This method is for
   transforming 3D vectors by perspective projection transforms.
 * Added `Eq` and `Hash` impls for integer vector types.
 

--- a/src/affine2.rs
+++ b/src/affine2.rs
@@ -36,6 +36,72 @@ macro_rules! impl_affine2_methods {
                 translation: $translate::ZERO,
             };
 
+            /// Creates an affine transform from a `[S; 6]` array stored in column major order.
+            /// If your data is stored in row major you will need to `transpose` the returned
+            /// matrix.
+            #[inline(always)]
+            pub fn from_cols_array(m: &[$t; 6]) -> Self {
+                Self {
+                    matrix2: $transform::from_cols_slice(&m[0..4]),
+                    translation: $translate::from_slice(&m[4..6]),
+                }
+            }
+
+            /// Creates a `[S; 6]` array storing data in column major order.
+            /// If you require data in row major order `transpose` the matrix first.
+            #[inline(always)]
+            pub fn to_cols_array(&self) -> [$t; 6] {
+                let x = &self.matrix2.x_axis;
+                let y = &self.matrix2.y_axis;
+                let z = &self.translation;
+                [x.x, x.y, y.x, y.y, z.x, z.y]
+            }
+
+            /// Creates an affine transform from a `[[S; 2]; 3]` 2D array stored in column major order.
+            /// If your data is in row major order you will need to `transpose` the returned
+            /// matrix.
+            #[inline(always)]
+            pub fn from_cols_array_2d(m: &[[$t; 2]; 3]) -> Self {
+                Self {
+                    matrix2: $transform::from_cols(m[0].into(), m[1].into()),
+                    translation: m[2].into(),
+                }
+            }
+
+            /// Creates a `[[S; 2]; 3]` 2D array storing data in column major order.
+            /// If you require data in row major order `transpose` the matrix first.
+            #[inline(always)]
+            pub fn to_cols_array_2d(&self) -> [[$t; 2]; 3] {
+                let x = &self.matrix2.x_axis;
+                let y = &self.matrix2.y_axis;
+                let z = &self.translation;
+                [[x.x, x.y], [y.x, y.y], [z.x, z.y]]
+            }
+
+            /// Creates an affine transform from the first 6 values in `slice`.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `slice` is less than 6 elements long.
+            #[inline(always)]
+            pub fn from_cols_slice(slice: &[$t]) -> Self {
+                Self {
+                    matrix2: $transform::from_cols_slice(&slice[0..4]),
+                    translation: $translate::from_slice(&slice[4..6]),
+                }
+            }
+
+            /// Writes the columns of `self` to the first 12 elements in `slice`.
+            ///
+            /// # Panics
+            ///
+            /// Panics if `slice` is less than 12 elements long.
+            #[inline(always)]
+            pub fn write_cols_to_slice(self, slice: &mut [$t]) {
+                self.matrix2.write_cols_to_slice(&mut slice[0..4]);
+                self.translation.write_to_slice(&mut slice[4..6]);
+            }
+
             /// Creates an affine transform that changes scale.
             /// Note that if any scale is zero the transform will be non-invertible.
             #[inline(always)]
@@ -231,6 +297,13 @@ macro_rules! impl_affine2_traits {
                     .field("matrix2", &self.matrix2)
                     .field("translation", &self.translation)
                     .finish()
+            }
+        }
+
+        #[cfg(not(target_arch = "spirv"))]
+        impl core::fmt::Display for $affine2 {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                write!(f, "[{}, {}, {}]", self.x_axis, self.y_axis, self.z_axis)
             }
         }
 

--- a/src/affine2.rs
+++ b/src/affine2.rs
@@ -6,35 +6,44 @@ use core::ops::{Add, Deref, DerefMut, Mul, Sub};
 use num_traits::Float;
 
 macro_rules! define_affine2_struct {
-    ($affine2:ident, $transform:ident, $translate:ident) => {
+    ($affine2:ident, $matrix:ident, $column:ident) => {
         /// A 2D affine transform, which can represent translation, rotation, scaling and shear.
         #[derive(Copy, Clone)]
         pub struct $affine2 {
-            pub matrix2: $transform,
-            pub translation: $translate,
+            pub matrix2: $matrix,
+            pub translation: $column,
         }
     };
 }
 
 macro_rules! impl_affine2_methods {
-    ($t:ty, $mat2:ident, $mat3:ident, $vec2:ident, $affine2:ident, $transform:ident, $translate:ident) => {
+    ($t:ty, $mat2:ident, $mat3:ident, $vec2:ident, $affine2:ident, $matrix:ident, $column:ident) => {
         impl $affine2 {
             /// The degenerate zero transform.
             ///
             /// This transforms any finite vector and point to zero.
             /// The zero transform is non-invertible.
             pub const ZERO: Self = Self {
-                matrix2: $transform::ZERO,
-                translation: $translate::ZERO,
+                matrix2: $matrix::ZERO,
+                translation: $column::ZERO,
             };
 
             /// The identity transform.
             ///
             /// Multiplying a vector with this returns the same vector.
             pub const IDENTITY: Self = Self {
-                matrix2: $transform::IDENTITY,
-                translation: $translate::ZERO,
+                matrix2: $matrix::IDENTITY,
+                translation: $column::ZERO,
             };
+
+            /// Creates an affine transform from three column vectors.
+            #[inline(always)]
+            pub fn from_cols(x_axis: $column, y_axis: $column, z_axis: $column) -> Self {
+                Self {
+                    matrix2: $matrix::from_cols(x_axis, y_axis),
+                    translation: z_axis,
+                }
+            }
 
             /// Creates an affine transform from a `[S; 6]` array stored in column major order.
             /// If your data is stored in row major you will need to `transpose` the returned
@@ -42,8 +51,8 @@ macro_rules! impl_affine2_methods {
             #[inline(always)]
             pub fn from_cols_array(m: &[$t; 6]) -> Self {
                 Self {
-                    matrix2: $transform::from_cols_slice(&m[0..4]),
-                    translation: $translate::from_slice(&m[4..6]),
+                    matrix2: $matrix::from_cols_slice(&m[0..4]),
+                    translation: $column::from_slice(&m[4..6]),
                 }
             }
 
@@ -63,7 +72,7 @@ macro_rules! impl_affine2_methods {
             #[inline(always)]
             pub fn from_cols_array_2d(m: &[[$t; 2]; 3]) -> Self {
                 Self {
-                    matrix2: $transform::from_cols(m[0].into(), m[1].into()),
+                    matrix2: $matrix::from_cols(m[0].into(), m[1].into()),
                     translation: m[2].into(),
                 }
             }
@@ -72,10 +81,11 @@ macro_rules! impl_affine2_methods {
             /// If you require data in row major order `transpose` the matrix first.
             #[inline(always)]
             pub fn to_cols_array_2d(&self) -> [[$t; 2]; 3] {
-                let x = &self.matrix2.x_axis;
-                let y = &self.matrix2.y_axis;
-                let z = &self.translation;
-                [[x.x, x.y], [y.x, y.y], [z.x, z.y]]
+                [
+                    self.matrix2.x_axis.into(),
+                    self.matrix2.y_axis.into(),
+                    self.translation.into(),
+                ]
             }
 
             /// Creates an affine transform from the first 6 values in `slice`.
@@ -86,8 +96,8 @@ macro_rules! impl_affine2_methods {
             #[inline(always)]
             pub fn from_cols_slice(slice: &[$t]) -> Self {
                 Self {
-                    matrix2: $transform::from_cols_slice(&slice[0..4]),
-                    translation: $translate::from_slice(&slice[4..6]),
+                    matrix2: $matrix::from_cols_slice(&slice[0..4]),
+                    translation: $column::from_slice(&slice[4..6]),
                 }
             }
 
@@ -107,8 +117,8 @@ macro_rules! impl_affine2_methods {
             #[inline(always)]
             pub fn from_scale(scale: $vec2) -> Self {
                 Self {
-                    matrix2: $transform::from_diagonal(scale),
-                    translation: $translate::ZERO,
+                    matrix2: $matrix::from_diagonal(scale),
+                    translation: $column::ZERO,
                 }
             }
 
@@ -116,8 +126,8 @@ macro_rules! impl_affine2_methods {
             #[inline(always)]
             pub fn from_angle(angle: $t) -> Self {
                 Self {
-                    matrix2: $transform::from_angle(angle),
-                    translation: $translate::ZERO,
+                    matrix2: $matrix::from_angle(angle),
+                    translation: $column::ZERO,
                 }
             }
 
@@ -125,7 +135,7 @@ macro_rules! impl_affine2_methods {
             #[inline(always)]
             pub fn from_translation(translation: $vec2) -> Self {
                 Self {
-                    matrix2: $transform::IDENTITY,
+                    matrix2: $matrix::IDENTITY,
                     translation,
                 }
             }
@@ -136,7 +146,7 @@ macro_rules! impl_affine2_methods {
             pub fn from_mat2(matrix2: $mat2) -> Self {
                 Self {
                     matrix2,
-                    translation: $translate::ZERO,
+                    translation: $column::ZERO,
                 }
             }
 
@@ -163,9 +173,9 @@ macro_rules! impl_affine2_methods {
                 angle: $t,
                 translation: $vec2,
             ) -> Self {
-                let rotation = $transform::from_angle(angle);
+                let rotation = $matrix::from_angle(angle);
                 Self {
-                    matrix2: $transform::from_cols(
+                    matrix2: $matrix::from_cols(
                         rotation.x_axis * scale.x,
                         rotation.y_axis * scale.y,
                     ),
@@ -180,7 +190,7 @@ macro_rules! impl_affine2_methods {
             #[inline(always)]
             pub fn from_angle_translation(angle: $t, translation: $vec2) -> Self {
                 Self {
-                    matrix2: $transform::from_angle(angle),
+                    matrix2: $matrix::from_angle(angle),
                     translation,
                 }
             }
@@ -189,7 +199,7 @@ macro_rules! impl_affine2_methods {
             #[inline]
             pub fn from_mat3(m: $mat3) -> Self {
                 Self {
-                    matrix2: $transform::from_cols(m.x_axis.into(), m.y_axis.into()),
+                    matrix2: $matrix::from_cols(m.x_axis.into(), m.y_axis.into()),
                     translation: m.z_axis.into(),
                 }
             }
@@ -260,7 +270,7 @@ macro_rules! impl_affine2_methods {
 }
 
 macro_rules! impl_affine2_traits {
-    ($t:ty, $mat2:ident, $mat3:ident, $vec2:ident, $affine2:ident, $transform:ident, $translate:ident, $deref:ident) => {
+    ($t:ty, $mat2:ident, $mat3:ident, $vec2:ident, $affine2:ident, $matrix:ident, $column:ident, $deref:ident) => {
         impl Default for $affine2 {
             #[inline(always)]
             fn default() -> Self {

--- a/src/affine3.rs
+++ b/src/affine3.rs
@@ -1,6 +1,6 @@
 use crate::core::storage::Columns4;
 use crate::{DMat3, DMat4, DQuat, DVec3, Mat3, Mat3A, Mat4, Quat, Vec3, Vec3A};
-use core::ops::{Deref, DerefMut};
+use core::ops::{Add, Deref, DerefMut, Mul, Sub};
 
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
@@ -364,7 +364,7 @@ macro_rules! impl_affine3_traits {
             }
         }
 
-        impl core::ops::Mul for $affine3 {
+        impl Mul for $affine3 {
             type Output = $affine3;
 
             #[inline(always)]
@@ -376,7 +376,51 @@ macro_rules! impl_affine3_traits {
             }
         }
 
-        impl core::ops::Mul<$mat4> for $affine3 {
+        impl Mul<$affine3> for $t {
+            type Output = $affine3;
+            #[inline(always)]
+            fn mul(self, other: $affine3) -> Self::Output {
+                $affine3 {
+                    matrix3: self * other.matrix3,
+                    translation: self * other.translation,
+                }
+            }
+        }
+
+        impl Mul<$t> for $affine3 {
+            type Output = Self;
+            #[inline(always)]
+            fn mul(self, other: $t) -> Self::Output {
+                Self {
+                    matrix3: self.matrix3 * other,
+                    translation: self.translation * other,
+                }
+            }
+        }
+
+        impl Add<$affine3> for $affine3 {
+            type Output = Self;
+            #[inline(always)]
+            fn add(self, other: Self) -> Self::Output {
+                Self {
+                    matrix3: self.matrix3 + other.matrix3,
+                    translation: self.translation + other.translation,
+                }
+            }
+        }
+
+        impl Sub<$affine3> for $affine3 {
+            type Output = Self;
+            #[inline(always)]
+            fn sub(self, other: Self) -> Self::Output {
+                Self {
+                    matrix3: self.matrix3 - other.matrix3,
+                    translation: self.translation - other.translation,
+                }
+            }
+        }
+
+        impl Mul<$mat4> for $affine3 {
             type Output = $mat4;
 
             #[inline(always)]
@@ -385,7 +429,7 @@ macro_rules! impl_affine3_traits {
             }
         }
 
-        impl core::ops::Mul<$affine3> for $mat4 {
+        impl Mul<$affine3> for $mat4 {
             type Output = $mat4;
 
             #[inline(always)]

--- a/src/affine3.rs
+++ b/src/affine3.rs
@@ -6,38 +6,52 @@ use core::ops::{Add, Deref, DerefMut, Mul, Sub};
 use num_traits::Float;
 
 macro_rules! define_affine3_struct {
-    ($affine3:ident, $transform:ident, $translate:ident) => {
+    ($affine3:ident, $matrix:ident, $column:ident) => {
         /// A 3D affine transform, which can represent translation, rotation, scaling and shear.
         ///
         /// The type is composed of a 3x3 matrix containing a linear transformation (e.g. scale,
         /// rotation, shear, reflection) and a 3D vector translation.
         #[derive(Copy, Clone)]
         pub struct $affine3 {
-            pub matrix3: $transform,
-            pub translation: $translate,
+            pub matrix3: $matrix,
+            pub translation: $column,
         }
     };
 }
 
 macro_rules! impl_affine3_methods {
-    ($t:ty, $mat3:ident, $mat4:ident, $quat:ident, $vec3:ident, $affine3:ident, $transform:ident, $translate:ident) => {
+    ($t:ty, $mat3:ident, $mat4:ident, $quat:ident, $vec3:ident, $affine3:ident, $matrix:ident, $column:ident) => {
         impl $affine3 {
             /// The degenerate zero transform.
             ///
             /// This transforms any finite vector and point to zero.
             /// The zero transform is non-invertible.
             pub const ZERO: Self = Self {
-                matrix3: $transform::ZERO,
-                translation: $translate::ZERO,
+                matrix3: $matrix::ZERO,
+                translation: $column::ZERO,
             };
 
             /// The identity transform.
             ///
             /// Multiplying a vector with this returns the same vector.
             pub const IDENTITY: Self = Self {
-                matrix3: $transform::IDENTITY,
-                translation: $translate::ZERO,
+                matrix3: $matrix::IDENTITY,
+                translation: $column::ZERO,
             };
+
+            /// Creates an affine transform from four column vectors.
+            #[inline(always)]
+            pub fn from_cols(
+                x_axis: $column,
+                y_axis: $column,
+                z_axis: $column,
+                w_axis: $column,
+            ) -> Self {
+                Self {
+                    matrix3: $matrix::from_cols(x_axis, y_axis, z_axis),
+                    translation: w_axis,
+                }
+            }
 
             /// Creates an affine transform from a `[S; 12]` array stored in column major order.
             /// If your data is stored in row major you will need to `transpose` the returned
@@ -45,8 +59,8 @@ macro_rules! impl_affine3_methods {
             #[inline(always)]
             pub fn from_cols_array(m: &[$t; 12]) -> Self {
                 Self {
-                    matrix3: $transform::from_cols_slice(&m[0..9]),
-                    translation: $translate::from_slice(&m[9..12]),
+                    matrix3: $matrix::from_cols_slice(&m[0..9]),
+                    translation: $column::from_slice(&m[9..12]),
                 }
             }
 
@@ -67,7 +81,7 @@ macro_rules! impl_affine3_methods {
             #[inline(always)]
             pub fn from_cols_array_2d(m: &[[$t; 3]; 4]) -> Self {
                 Self {
-                    matrix3: $transform::from_cols(m[0].into(), m[1].into(), m[2].into()),
+                    matrix3: $matrix::from_cols(m[0].into(), m[1].into(), m[2].into()),
                     translation: m[3].into(),
                 }
             }
@@ -76,15 +90,11 @@ macro_rules! impl_affine3_methods {
             /// If you require data in row major order `transpose` the matrix first.
             #[inline(always)]
             pub fn to_cols_array_2d(&self) -> [[$t; 3]; 4] {
-                let x = &self.matrix3.x_axis;
-                let y = &self.matrix3.y_axis;
-                let z = &self.matrix3.z_axis;
-                let w = &self.translation;
                 [
-                    [x.x, x.y, x.z],
-                    [y.x, y.y, y.z],
-                    [z.x, z.y, z.z],
-                    [w.x, w.y, w.z],
+                    self.matrix3.x_axis.into(),
+                    self.matrix3.y_axis.into(),
+                    self.matrix3.z_axis.into(),
+                    self.translation.into(),
                 ]
             }
 
@@ -96,8 +106,8 @@ macro_rules! impl_affine3_methods {
             #[inline(always)]
             pub fn from_cols_slice(slice: &[$t]) -> Self {
                 Self {
-                    matrix3: $transform::from_cols_slice(&slice[0..9]),
-                    translation: $translate::from_slice(&slice[9..12]),
+                    matrix3: $matrix::from_cols_slice(&slice[0..9]),
+                    translation: $column::from_slice(&slice[9..12]),
                 }
             }
 
@@ -117,8 +127,8 @@ macro_rules! impl_affine3_methods {
             #[inline(always)]
             pub fn from_scale(scale: $vec3) -> Self {
                 Self {
-                    matrix3: $transform::from_diagonal(scale),
-                    translation: $translate::ZERO,
+                    matrix3: $matrix::from_diagonal(scale),
+                    translation: $column::ZERO,
                 }
             }
 
@@ -126,8 +136,8 @@ macro_rules! impl_affine3_methods {
             #[inline(always)]
             pub fn from_quat(rotation: $quat) -> Self {
                 Self {
-                    matrix3: $transform::from_quat(rotation),
-                    translation: $translate::ZERO,
+                    matrix3: $matrix::from_quat(rotation),
+                    translation: $column::ZERO,
                 }
             }
 
@@ -136,8 +146,8 @@ macro_rules! impl_affine3_methods {
             #[inline(always)]
             pub fn from_axis_angle(axis: $vec3, angle: $t) -> Self {
                 Self {
-                    matrix3: $transform::from_axis_angle(axis, angle),
-                    translation: $translate::ZERO,
+                    matrix3: $matrix::from_axis_angle(axis, angle),
+                    translation: $column::ZERO,
                 }
             }
 
@@ -146,8 +156,8 @@ macro_rules! impl_affine3_methods {
             #[inline(always)]
             pub fn from_rotation_x(angle: $t) -> Self {
                 Self {
-                    matrix3: $transform::from_rotation_x(angle),
-                    translation: $translate::ZERO,
+                    matrix3: $matrix::from_rotation_x(angle),
+                    translation: $column::ZERO,
                 }
             }
 
@@ -156,8 +166,8 @@ macro_rules! impl_affine3_methods {
             #[inline]
             pub fn from_rotation_y(angle: $t) -> Self {
                 Self {
-                    matrix3: $transform::from_rotation_y(angle),
-                    translation: $translate::ZERO,
+                    matrix3: $matrix::from_rotation_y(angle),
+                    translation: $column::ZERO,
                 }
             }
 
@@ -166,8 +176,8 @@ macro_rules! impl_affine3_methods {
             #[inline]
             pub fn from_rotation_z(angle: $t) -> Self {
                 Self {
-                    matrix3: $transform::from_rotation_z(angle),
-                    translation: $translate::ZERO,
+                    matrix3: $matrix::from_rotation_z(angle),
+                    translation: $column::ZERO,
                 }
             }
 
@@ -175,7 +185,7 @@ macro_rules! impl_affine3_methods {
             #[inline(always)]
             pub fn from_translation(translation: $vec3) -> Self {
                 Self {
-                    matrix3: $transform::IDENTITY,
+                    matrix3: $matrix::IDENTITY,
                     translation: translation.into(),
                 }
             }
@@ -186,7 +196,7 @@ macro_rules! impl_affine3_methods {
             pub fn from_mat3(mat3: $mat3) -> Self {
                 Self {
                     matrix3: mat3.into(),
-                    translation: $translate::ZERO,
+                    translation: $column::ZERO,
                 }
             }
 
@@ -213,9 +223,9 @@ macro_rules! impl_affine3_methods {
                 rotation: $quat,
                 translation: $vec3,
             ) -> Self {
-                let rotation = $transform::from_quat(rotation);
+                let rotation = $matrix::from_quat(rotation);
                 Self {
-                    matrix3: $transform::from_cols(
+                    matrix3: $matrix::from_cols(
                         rotation.x_axis * scale.x,
                         rotation.y_axis * scale.y,
                         rotation.z_axis * scale.z,
@@ -230,7 +240,7 @@ macro_rules! impl_affine3_methods {
             #[inline(always)]
             pub fn from_rotation_translation(rotation: $quat, translation: $vec3) -> Self {
                 Self {
-                    matrix3: $transform::from_quat(rotation.into()),
+                    matrix3: $matrix::from_quat(rotation.into()),
                     translation: translation.into(),
                 }
             }
@@ -240,11 +250,7 @@ macro_rules! impl_affine3_methods {
             #[inline]
             pub fn from_mat4(m: $mat4) -> Self {
                 Self {
-                    matrix3: $transform::from_cols(
-                        m.x_axis.into(),
-                        m.y_axis.into(),
-                        m.z_axis.into(),
-                    ),
+                    matrix3: $matrix::from_cols(m.x_axis.into(), m.y_axis.into(), m.z_axis.into()),
                     translation: m.w_axis.into(),
                 }
             }
@@ -284,12 +290,12 @@ macro_rules! impl_affine3_methods {
                 let s = up.cross(f).normalize();
                 let u = f.cross(s);
                 Self {
-                    matrix3: $transform::from_cols(
+                    matrix3: $matrix::from_cols(
                         $vec3::new(s.x, u.x, f.x).into(),
                         $vec3::new(s.y, u.y, f.y).into(),
                         $vec3::new(s.z, u.z, f.z).into(),
                     ),
-                    translation: $translate::new(-s.dot(eye), -u.dot(eye), -f.dot(eye)),
+                    translation: $column::new(-s.dot(eye), -u.dot(eye), -f.dot(eye)),
                 }
             }
 
@@ -385,7 +391,7 @@ macro_rules! impl_affine3_methods {
 }
 
 macro_rules! impl_affine3_traits {
-    ($t:ty, $mat3:ident, $mat4:ident, $vec3:ident, $vec4:ident, $affine3:ident, $transform:ident, $translate:ident, $deref:ident) => {
+    ($t:ty, $mat3:ident, $mat4:ident, $vec3:ident, $vec4:ident, $affine3:ident, $matrix:ident, $column:ident, $deref:ident) => {
         impl Default for $affine3 {
             #[inline(always)]
             fn default() -> Self {

--- a/src/core/traits/matrix.rs
+++ b/src/core/traits/matrix.rs
@@ -51,6 +51,21 @@ pub trait Matrix2x2<T: NumEx, V2: Vector2<T>>: Matrix<T> {
         [self.x_axis().into_array(), self.y_axis().into_array()]
     }
 
+    #[inline(always)]
+    fn from_cols_slice(m: &[T]) -> Self {
+        Self::new(m[0], m[1], m[2], m[3])
+    }
+
+    #[inline(always)]
+    fn write_cols_to_slice(&self, slice: &mut [T]) {
+        let x_axis = self.x_axis();
+        let y_axis = self.y_axis();
+        slice[0] = x_axis.x();
+        slice[1] = x_axis.y();
+        slice[2] = y_axis.x();
+        slice[3] = y_axis.y();
+    }
+
     #[rustfmt::skip]
     #[inline(always)]
     fn from_diagonal(diagonal: XY<T>) -> Self {
@@ -204,6 +219,31 @@ pub trait Matrix3x3<T: NumEx, V3: Vector3<T>>: Matrix<T> {
             self.y_axis().into_array(),
             self.z_axis().into_array(),
         ]
+    }
+
+    #[inline(always)]
+    fn from_cols_slice(m: &[T]) -> Self {
+        Self::from_cols(
+            V3::new(m[0], m[1], m[2]),
+            V3::new(m[3], m[4], m[5]),
+            V3::new(m[6], m[7], m[8]),
+        )
+    }
+
+    #[inline(always)]
+    fn write_cols_to_slice(&self, slice: &mut [T]) {
+        let x_axis = self.x_axis();
+        let y_axis = self.y_axis();
+        let z_axis = self.z_axis();
+        slice[0] = x_axis.x();
+        slice[1] = x_axis.y();
+        slice[2] = x_axis.z();
+        slice[3] = y_axis.x();
+        slice[4] = y_axis.y();
+        slice[5] = y_axis.z();
+        slice[6] = z_axis.x();
+        slice[7] = z_axis.y();
+        slice[8] = z_axis.z();
     }
 
     #[rustfmt::skip]
@@ -478,6 +518,43 @@ pub trait Matrix4x4<T: NumEx, V4: Vector4<T>>: Matrix<T> {
             self.z_axis().into_array(),
             self.w_axis().into_array(),
         ]
+    }
+
+    #[rustfmt::skip]
+    #[inline(always)]
+    fn from_cols_slice(m: &[T]) -> Self {
+        Self::from_cols(
+            V4::new( m[0],  m[1],  m[2],  m[3]),
+            V4::new( m[4],  m[5],  m[6],  m[7]),
+            V4::new( m[8],  m[9], m[10], m[11]),
+            V4::new(m[12], m[13], m[14], m[15]))
+    }
+
+    #[inline(always)]
+    fn write_cols_to_slice(&self, slice: &mut [T]) {
+        let x_axis = self.x_axis();
+        let y_axis = self.y_axis();
+        let z_axis = self.z_axis();
+        let w_axis = self.w_axis();
+        slice[0] = x_axis.x();
+        slice[1] = x_axis.y();
+        slice[2] = x_axis.z();
+        slice[3] = x_axis.w();
+
+        slice[4] = y_axis.x();
+        slice[5] = y_axis.y();
+        slice[6] = y_axis.z();
+        slice[7] = y_axis.w();
+
+        slice[8] = z_axis.x();
+        slice[9] = z_axis.y();
+        slice[10] = z_axis.z();
+        slice[11] = z_axis.w();
+
+        slice[12] = w_axis.x();
+        slice[13] = w_axis.y();
+        slice[14] = w_axis.z();
+        slice[15] = w_axis.w();
     }
 
     #[inline(always)]

--- a/src/mat2.rs
+++ b/src/mat2.rs
@@ -87,6 +87,26 @@ macro_rules! impl_mat2_methods {
             Self($inner::from_angle(angle))
         }
 
+        /// Creates a 2x2 matrix from the first 4 values in `slice`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `slice` is less than 4 elements long.
+        #[inline(always)]
+        pub fn from_cols_slice(slice: &[$t]) -> Self {
+            Self(Matrix2x2::from_cols_slice(slice))
+        }
+
+        /// Writes the columns of `self` to the first 4 elements in `slice`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `slice` is less than 4 elements long.
+        #[inline(always)]
+        pub fn write_cols_to_slice(self, slice: &mut [$t]) {
+            Matrix2x2::write_cols_to_slice(&self.0, slice)
+        }
+
         /// Returns the matrix column for the given `index`.
         ///
         /// # Panics

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -197,6 +197,26 @@ macro_rules! impl_mat3_methods {
             Self(Matrix3x3::from_scale(scale.0))
         }
 
+        /// Creates a 3x3 matrix from the first 9 values in `slice`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `slice` is less than 9 elements long.
+        #[inline(always)]
+        pub fn from_cols_slice(slice: &[$t]) -> Self {
+            Self(Matrix3x3::from_cols_slice(slice))
+        }
+
+        /// Writes the columns of `self` to the first 9 elements in `slice`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `slice` is less than 9 elements long.
+        #[inline(always)]
+        pub fn write_cols_to_slice(self, slice: &mut [$t]) {
+            Matrix3x3::write_cols_to_slice(&self.0, slice)
+        }
+
         /// Returns the matrix column for the given `index`.
         ///
         /// # Panics

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -604,7 +604,7 @@ macro_rules! impl_mat4_traits {
         impl Add<$mat4> for $mat4 {
             type Output = Self;
             #[inline(always)]
-            fn add(self, other: Self) -> Self {
+            fn add(self, other: Self) -> Self::Output {
                 self.add_mat4(&other)
             }
         }
@@ -612,7 +612,7 @@ macro_rules! impl_mat4_traits {
         impl Sub<$mat4> for $mat4 {
             type Output = Self;
             #[inline(always)]
-            fn sub(self, other: Self) -> Self {
+            fn sub(self, other: Self) -> Self::Output {
                 self.sub_mat4(&other)
             }
         }
@@ -620,7 +620,7 @@ macro_rules! impl_mat4_traits {
         impl Mul<$mat4> for $mat4 {
             type Output = Self;
             #[inline(always)]
-            fn mul(self, other: Self) -> Self {
+            fn mul(self, other: Self) -> Self::Output {
                 self.mul_mat4(&other)
             }
         }
@@ -628,7 +628,7 @@ macro_rules! impl_mat4_traits {
         impl Mul<$vec4> for $mat4 {
             type Output = $vec4;
             #[inline(always)]
-            fn mul(self, other: $vec4) -> $vec4 {
+            fn mul(self, other: $vec4) -> Self::Output {
                 self.mul_vec4(other)
             }
         }
@@ -636,7 +636,7 @@ macro_rules! impl_mat4_traits {
         impl Mul<$mat4> for $t {
             type Output = $mat4;
             #[inline(always)]
-            fn mul(self, other: $mat4) -> $mat4 {
+            fn mul(self, other: $mat4) -> Self::Output {
                 other.mul_scalar(self)
             }
         }
@@ -644,7 +644,7 @@ macro_rules! impl_mat4_traits {
         impl Mul<$t> for $mat4 {
             type Output = Self;
             #[inline(always)]
-            fn mul(self, other: $t) -> Self {
+            fn mul(self, other: $t) -> Self::Output {
                 self.mul_scalar(other)
             }
         }

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -238,6 +238,26 @@ macro_rules! impl_mat4_methods {
             Self($inner::from_scale(scale.0))
         }
 
+        /// Creates a 4x4 matrix from the first 16 values in `slice`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `slice` is less than 16 elements long.
+        #[inline(always)]
+        pub fn from_cols_slice(slice: &[$t]) -> Self {
+            Self(Matrix4x4::from_cols_slice(slice))
+        }
+
+        /// Writes the columns of `self` to the first 16 elements in `slice`.
+        ///
+        /// # Panics
+        ///
+        /// Panics if `slice` is less than 16 elements long.
+        #[inline(always)]
+        pub fn write_cols_to_slice(self, slice: &mut [$t]) {
+            Matrix4x4::write_cols_to_slice(&self.0, slice)
+        }
+
         /// Returns the matrix column for the given `index`.
         ///
         /// # Panics

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -59,6 +59,12 @@ macro_rules! impl_quat_methods {
             Self(v.0)
         }
 
+        #[deprecated(since = "0.15.2", note = "Please use `from_slice()` instead")]
+        #[inline(always)]
+        pub fn from_slice_unaligned(slice: &[$t]) -> Self {
+            Self::from_slice(slice)
+        }
+
         /// Creates a rotation quaternion from an unaligned slice.
         ///
         /// # Preconditions
@@ -69,11 +75,17 @@ macro_rules! impl_quat_methods {
         ///
         /// Panics if `slice` length is less than 4.
         #[inline(always)]
-        pub fn from_slice_unaligned(slice: &[$t]) -> Self {
+        pub fn from_slice(slice: &[$t]) -> Self {
             #[allow(clippy::let_and_return)]
             let q = Vector4::from_slice_unaligned(slice);
             glam_assert!(FloatVector4::is_normalized(q));
             Self(q)
+        }
+
+        #[deprecated(since = "0.15.2", note = "Please use `write_to_slice()` instead")]
+        #[inline(always)]
+        pub fn write_to_slice_unaligned(self, slice: &mut [$t]) {
+            self.write_to_slice(slice)
         }
 
         /// Writes the quaternion to an unaligned slice.
@@ -82,7 +94,7 @@ macro_rules! impl_quat_methods {
         ///
         /// Panics if `slice` length is less than 4.
         #[inline(always)]
-        pub fn write_to_slice_unaligned(self, slice: &mut [$t]) {
+        pub fn write_to_slice(self, slice: &mut [$t]) {
             Vector4::write_to_slice_unaligned(self.0, slice)
         }
 

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -127,14 +127,26 @@ macro_rules! impl_vecn_common_methods {
             $mask(self.0.cmplt(other.0))
         }
 
+        #[deprecated(since = "0.15.2", note = "Please use `from_slice()` instead")]
+        #[inline(always)]
+        pub fn from_slice_unaligned(slice: &[$t]) -> Self {
+            Self::from_slice(slice)
+        }
+
         /// Creates a vector from the first N values in `slice`.
         ///
         /// # Panics
         ///
         /// Panics if `slice` is less than N elements long.
         #[inline(always)]
-        pub fn from_slice_unaligned(slice: &[$t]) -> Self {
+        pub fn from_slice(slice: &[$t]) -> Self {
             Self($vectrait::from_slice_unaligned(slice))
+        }
+
+        #[deprecated(since = "0.15.2", note = "Please use `write_to_slice()` instead")]
+        #[inline(always)]
+        pub fn write_to_slice_unaligned(self, slice: &mut [$t]) {
+            self.write_to_slice(slice)
         }
 
         /// Writes the elements of `self` to the first N elements in `slice`.
@@ -143,7 +155,7 @@ macro_rules! impl_vecn_common_methods {
         ///
         /// Panics if `slice` is less than N elements long.
         #[inline(always)]
-        pub fn write_to_slice_unaligned(self, slice: &mut [$t]) {
+        pub fn write_to_slice(self, slice: &mut [$t]) {
             $vectrait::write_to_slice_unaligned(self.0, slice)
         }
 

--- a/tests/affine2.rs
+++ b/tests/affine2.rs
@@ -3,6 +3,8 @@ mod support;
 
 macro_rules! impl_affine2_tests {
     ($t:ident, $affine2:ident, $vec2:ident) => {
+        const MATRIX: [[$t; 2]; 3] = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]];
+
         use core::$t::NAN;
         use core::$t::NEG_INFINITY;
 
@@ -90,6 +92,34 @@ macro_rules! impl_affine2_tests {
             let m_inv = m.inverse();
             assert_approx_eq!($affine2::IDENTITY, m * m_inv, 1.0e-5);
             assert_approx_eq!($affine2::IDENTITY, m_inv * m, 1.0e-5);
+        }
+
+        #[test]
+        fn test_affine2_ops() {
+            let m0 = $affine2::from_cols_array_2d(&MATRIX);
+            let m0x2 = $affine2::from_cols_array_2d(&[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]);
+            assert_eq!(m0x2, m0 * 2.0);
+            assert_eq!(m0x2, 2.0 * m0);
+            assert_eq!(m0x2, m0 + m0);
+            assert_eq!($affine2::ZERO, m0 - m0);
+            assert_approx_eq!(m0, m0 * $affine2::IDENTITY);
+            assert_approx_eq!(m0, $affine2::IDENTITY * m0);
+        }
+
+        #[test]
+        fn test_affine2_fmt() {
+            let a = $affine2::from_cols_array_2d(&MATRIX);
+            assert_eq!(format!("{}", a), "[[1, 2], [3, 4], [5, 6]]");
+        }
+
+        #[test]
+        fn test_affine2_to_from_slice() {
+            const MATRIX1D: [$t; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+            let m = $affine2::from_cols_slice(&MATRIX1D);
+            assert_eq!($affine2::from_cols_array(&MATRIX1D), m);
+            let mut out: [$t; 6] = Default::default();
+            m.write_cols_to_slice(&mut out);
+            assert_eq!(MATRIX1D, out);
         }
 
         #[cfg(feature = "std")]

--- a/tests/affine2.rs
+++ b/tests/affine2.rs
@@ -3,7 +3,7 @@ mod support;
 
 macro_rules! impl_affine2_tests {
     ($t:ident, $affine2:ident, $vec2:ident) => {
-        const MATRIX: [[$t; 2]; 3] = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]];
+        const MATRIX2D: [[$t; 2]; 3] = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]];
 
         use core::$t::NAN;
         use core::$t::NEG_INFINITY;
@@ -96,7 +96,7 @@ macro_rules! impl_affine2_tests {
 
         #[test]
         fn test_affine2_ops() {
-            let m0 = $affine2::from_cols_array_2d(&MATRIX);
+            let m0 = $affine2::from_cols_array_2d(&MATRIX2D);
             let m0x2 = $affine2::from_cols_array_2d(&[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]);
             assert_eq!(m0x2, m0 * 2.0);
             assert_eq!(m0x2, 2.0 * m0);
@@ -108,7 +108,7 @@ macro_rules! impl_affine2_tests {
 
         #[test]
         fn test_affine2_fmt() {
-            let a = $affine2::from_cols_array_2d(&MATRIX);
+            let a = $affine2::from_cols_array_2d(&MATRIX2D);
             assert_eq!(format!("{}", a), "[[1, 2], [3, 4], [5, 6]]");
         }
 
@@ -117,9 +117,15 @@ macro_rules! impl_affine2_tests {
             const MATRIX1D: [$t; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
             let m = $affine2::from_cols_slice(&MATRIX1D);
             assert_eq!($affine2::from_cols_array(&MATRIX1D), m);
+            assert_eq!(MATRIX1D, m.to_cols_array());
+            assert_eq!(MATRIX2D, m.to_cols_array_2d());
             let mut out: [$t; 6] = Default::default();
             m.write_cols_to_slice(&mut out);
             assert_eq!(MATRIX1D, out);
+            assert_eq!(
+                m,
+                $affine2::from_cols(MATRIX2D[0].into(), MATRIX2D[1].into(), MATRIX2D[2].into())
+            );
         }
 
         #[cfg(feature = "std")]

--- a/tests/affine3.rs
+++ b/tests/affine3.rs
@@ -3,6 +3,13 @@ mod support;
 
 macro_rules! impl_affine3_tests {
     ($t:ident, $affine3:ident, $quat:ident, $vec3:ident) => {
+        const MATRIX: [[$t; 3]; 4] = [
+            [1.0, 2.0, 3.0],
+            [4.0, 5.0, 6.0],
+            [7.0, 8.0, 9.0],
+            [10.0, 11.0, 12.0],
+        ];
+
         use core::$t::NAN;
         use core::$t::NEG_INFINITY;
 
@@ -193,6 +200,44 @@ macro_rules! impl_affine3_tests {
             let point = $vec3::new(1.0, 0.0, 0.0);
             assert_approx_eq!(lh.transform_point3(point), $vec3::new(0.0, 1.0, 5.0));
             assert_approx_eq!(rh.transform_point3(point), $vec3::new(0.0, 1.0, -5.0));
+        }
+
+        #[test]
+        fn test_affine3_ops() {
+            let m0 = $affine3::from_cols_array_2d(&MATRIX);
+            let m0x2 = $affine3::from_cols_array_2d(&[
+                [2.0, 4.0, 6.0],
+                [8.0, 10.0, 12.0],
+                [14.0, 16.0, 18.0],
+                [20.0, 22.0, 24.0],
+            ]);
+            assert_eq!(m0x2, m0 * 2.0);
+            assert_eq!(m0x2, 2.0 * m0);
+            assert_eq!(m0x2, m0 + m0);
+            assert_eq!($affine3::ZERO, m0 - m0);
+            assert_approx_eq!(m0, m0 * $affine3::IDENTITY);
+            assert_approx_eq!(m0, $affine3::IDENTITY * m0);
+        }
+
+        #[test]
+        fn test_affine3_fmt() {
+            let a = $affine3::from_cols_array_2d(&MATRIX);
+            assert_eq!(
+                format!("{}", a),
+                "[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]"
+            );
+        }
+
+        #[test]
+        fn test_affine3_to_from_slice() {
+            const MATRIX1D: [$t; 12] = [
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+            ];
+            let m = $affine3::from_cols_slice(&MATRIX1D);
+            assert_eq!($affine3::from_cols_array(&MATRIX1D), m);
+            let mut out: [$t; 12] = Default::default();
+            m.write_cols_to_slice(&mut out);
+            assert_eq!(MATRIX1D, out);
         }
 
         #[cfg(feature = "std")]

--- a/tests/affine3.rs
+++ b/tests/affine3.rs
@@ -3,7 +3,7 @@ mod support;
 
 macro_rules! impl_affine3_tests {
     ($t:ident, $affine3:ident, $quat:ident, $vec3:ident) => {
-        const MATRIX: [[$t; 3]; 4] = [
+        const MATRIX2D: [[$t; 3]; 4] = [
             [1.0, 2.0, 3.0],
             [4.0, 5.0, 6.0],
             [7.0, 8.0, 9.0],
@@ -204,7 +204,7 @@ macro_rules! impl_affine3_tests {
 
         #[test]
         fn test_affine3_ops() {
-            let m0 = $affine3::from_cols_array_2d(&MATRIX);
+            let m0 = $affine3::from_cols_array_2d(&MATRIX2D);
             let m0x2 = $affine3::from_cols_array_2d(&[
                 [2.0, 4.0, 6.0],
                 [8.0, 10.0, 12.0],
@@ -221,7 +221,7 @@ macro_rules! impl_affine3_tests {
 
         #[test]
         fn test_affine3_fmt() {
-            let a = $affine3::from_cols_array_2d(&MATRIX);
+            let a = $affine3::from_cols_array_2d(&MATRIX2D);
             assert_eq!(
                 format!("{}", a),
                 "[[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]"
@@ -235,9 +235,20 @@ macro_rules! impl_affine3_tests {
             ];
             let m = $affine3::from_cols_slice(&MATRIX1D);
             assert_eq!($affine3::from_cols_array(&MATRIX1D), m);
+            assert_eq!(MATRIX1D, m.to_cols_array());
+            assert_eq!(MATRIX2D, m.to_cols_array_2d());
             let mut out: [$t; 12] = Default::default();
             m.write_cols_to_slice(&mut out);
             assert_eq!(MATRIX1D, out);
+            assert_eq!(
+                m,
+                $affine3::from_cols(
+                    MATRIX2D[0].into(),
+                    MATRIX2D[1].into(),
+                    MATRIX2D[2].into(),
+                    MATRIX2D[3].into()
+                )
+            );
         }
 
         #[cfg(feature = "std")]

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -176,6 +176,16 @@ macro_rules! impl_mat2_tests {
             assert_eq!(format!("{}", a), "[[1, 2], [3, 4]]");
         }
 
+        #[test]
+        fn test_mat2_to_from_slice() {
+            const MATRIX1D: [$t; 4] = [1.0, 2.0, 3.0, 4.0];
+            let m = $mat2::from_cols_slice(&MATRIX1D);
+            assert_eq!($mat2::from_cols_array(&MATRIX1D), m);
+            let mut out: [$t; 4] = Default::default();
+            m.write_cols_to_slice(&mut out);
+            assert_eq!(MATRIX1D, out);
+        }
+
         #[cfg(feature = "std")]
         #[test]
         fn test_sum() {

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -277,6 +277,16 @@ macro_rules! impl_mat3_tests {
             assert_eq!(format!("{}", a), "[[1, 2, 3], [4, 5, 6], [7, 8, 9]]");
         }
 
+        #[test]
+        fn test_mat3_to_from_slice() {
+            const MATRIX1D: [$t; 9] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+            let m = $mat3::from_cols_slice(&MATRIX1D);
+            assert_eq!($mat3::from_cols_array(&MATRIX1D), m);
+            let mut out: [$t; 9] = Default::default();
+            m.write_cols_to_slice(&mut out);
+            assert_eq!(MATRIX1D, out);
+        }
+
         #[cfg(feature = "std")]
         #[test]
         fn test_sum() {

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -554,6 +554,19 @@ macro_rules! impl_mat4_tests {
             );
         }
 
+        #[test]
+        fn test_mat4_to_from_slice() {
+            const MATRIX1D: [$t; 16] = [
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+                16.0,
+            ];
+            let m = $mat4::from_cols_slice(&MATRIX1D);
+            assert_eq!($mat4::from_cols_array(&MATRIX1D), m);
+            let mut out: [$t; 16] = Default::default();
+            m.write_cols_to_slice(&mut out);
+            assert_eq!(MATRIX1D, out);
+        }
+
         #[cfg(feature = "std")]
         #[test]
         fn test_sum() {

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -307,11 +307,11 @@ macro_rules! impl_quat_tests {
         fn test_slice() {
             let a: [$t; 4] =
                 $quat::from_euler(EulerRot::YXZ, deg(30.0), deg(60.0), deg(90.0)).into();
-            let b = $quat::from_slice_unaligned(&a);
+            let b = $quat::from_slice(&a);
             let c: [$t; 4] = b.into();
             assert_eq!(a, c);
             let mut d = [0.0, 0.0, 0.0, 0.0];
-            b.write_to_slice_unaligned(&mut d[..]);
+            b.write_to_slice(&mut d[..]);
             assert_eq!(a, d);
         }
 

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -372,8 +372,8 @@ macro_rules! impl_vec2_tests {
         fn test_to_from_slice() {
             let v = $vec2::new(1 as $t, 2 as $t);
             let mut a = [0 as $t, 0 as $t];
-            v.write_to_slice_unaligned(&mut a);
-            assert_eq!(v, $vec2::from_slice_unaligned(&a));
+            v.write_to_slice(&mut a);
+            assert_eq!(v, $vec2::from_slice(&a));
         }
 
         #[cfg(feature = "std")]

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -416,8 +416,8 @@ macro_rules! impl_vec3_tests {
         fn test_to_from_slice() {
             let v = $vec3::new(1 as $t, 2 as $t, 3 as $t);
             let mut a = [0 as $t, 0 as $t, 0 as $t];
-            v.write_to_slice_unaligned(&mut a);
-            assert_eq!(v, $vec3::from_slice_unaligned(&a));
+            v.write_to_slice(&mut a);
+            assert_eq!(v, $vec3::from_slice(&a));
         }
 
         #[cfg(feature = "std")]

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -253,11 +253,11 @@ macro_rules! impl_vec4_tests {
         #[test]
         fn test_slice() {
             let a = [1 as $t, 2 as $t, 3 as $t, 4 as $t];
-            let b = $vec4::from_slice_unaligned(&a);
+            let b = $vec4::from_slice(&a);
             let c: [$t; 4] = b.into();
             assert_eq!(a, c);
             let mut d = [0 as $t, 0 as $t, 0 as $t, 0 as $t];
-            b.write_to_slice_unaligned(&mut d[..]);
+            b.write_to_slice(&mut d[..]);
             assert_eq!(a, d);
         }
 
@@ -484,8 +484,8 @@ macro_rules! impl_vec4_tests {
         fn test_to_from_slice() {
             let v = $vec4::new(1 as $t, 2 as $t, 3 as $t, 4 as $t);
             let mut a = [0 as $t, 0 as $t, 0 as $t, 0 as $t];
-            v.write_to_slice_unaligned(&mut a);
-            assert_eq!(v, $vec4::from_slice_unaligned(&a));
+            v.write_to_slice(&mut a);
+            assert_eq!(v, $vec4::from_slice(&a));
         }
 
         #[cfg(feature = "std")]


### PR DESCRIPTION
Fixes #182.

Also add methods for from and write to slices for matrix and affine types.