### PR TITLE
clamp input for acos_approx for f64

### DIFF
--- a/src/core/traits/scalar.rs
+++ b/src/core/traits/scalar.rs
@@ -278,7 +278,7 @@ impl FloatEx for f64 {
     }
     #[inline(always)]
     fn acos_approx(self) -> Self {
-        f64::acos(self.clamp(-1.0, 1.0))
+        f64::acos(self.max(-1.0).min(1.0))
     }
 }
 

--- a/src/core/traits/scalar.rs
+++ b/src/core/traits/scalar.rs
@@ -278,8 +278,7 @@ impl FloatEx for f64 {
     }
     #[inline(always)]
     fn acos_approx(self) -> Self {
-        // TODO: clamp range
-        f64::acos(self)
+        f64::acos(self.clamp(-1.0, 1.0))
     }
 }
 
@@ -383,4 +382,8 @@ fn test_scalar_acos() {
     // input is clamped to -1.0..1.0
     assert_approx_eq!(2.0_f32.acos_approx(), 0.0);
     assert_approx_eq!((-2.0_f32).acos_approx(), core::f32::consts::PI);
+
+    // input is clamped to -1.0..1.0
+    assert_eq!(2.0_f64.acos_approx(), 0.0);
+    assert_eq!((-2.0_f64).acos_approx(), core::f64::consts::PI);
 }


### PR DESCRIPTION
I found that `DQuat::angle_between` would sometimes return `NaN` for small angles and tracked it down to this. There is likely a lot of other f64 angle-related function with similar problems.