### PR TITLE
Add extra documentation names for perp_dot

### DIFF
--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -61,7 +61,11 @@ macro_rules! impl_vec2_signed_methods {
         }
 
         /// The perpendicular dot product of `self` and `other`.
+        /// Also known as the wedge product, 2d cross product, and determinant.
         #[inline(always)]
+        #[doc(alias = "wedge")]
+        #[doc(alias = "cross")]
+        #[doc(alias = "determinant")]
         pub fn perp_dot(self, other: $vec2) -> $t {
             self.0.perp_dot(other.0)
         }

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -63,9 +63,12 @@ macro_rules! impl_vec2_signed_methods {
         /// The perpendicular dot product of `self` and `other`.
         /// Also known as the wedge product, 2d cross product, and determinant.
         #[inline(always)]
-        #[doc(alias = "wedge")]
-        #[doc(alias = "cross")]
-        #[doc(alias = "determinant")]
+        #[cfg_attr(
+            docsrs,
+            doc(alias = "wedge"),
+            doc(alias = "cross"),
+            doc(alias = "determinant")
+        )]
         pub fn perp_dot(self, other: $vec2) -> $t {
             self.0.perp_dot(other.0)
         }


### PR DESCRIPTION
I was recently searching `glam` for the wedge product, and I didn't find it, so I manually wrote out `Mat2::from_cols(x, y).determinant()`. Turns out, the method is called `perp_dot`! I'd like others to be able to find the method under the various names it has, so here's some aliases for rustdoc searches.

This operation has [a lot of names](https://twitter.com/FreyaHolmer/status/1397508580677390339), and each name has its use in different contexts. I think the proper, mathematical one is usually the wedge product, game devs tend towards 2d cross product, people familiar with linalg use determinant (of a 2x2 matrix), and of course perpendicular dot product.

---

Unfortunately I just realized that `#[doc(alias = "...")]` was stabilized in 1.48, and glam's MSRV is 1.45. Doubly-unfortunate is that `#[cfg(version(1.48))]` is still unstable (for `cfg_attr`). I'm still going to open this PR to start a discussion about potentially bumping the MSRV, but feel free to just shut this down if you don't want to bump the MSRV for a simple doc change.