### PR TITLE
Remove the spirv-std dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ mint = { version = "0.5", optional = true, default-features = false }
 num-traits = { version = "0.2.14", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, features = ["derive"] }
-spirv-std = { version = "0.4.0-alpha.7", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ mod vec3;
 mod vec4;
 mod vec_mask;
 
-#[cfg(feature = "spirv-std")]
+#[cfg(target_arch = "spirv")]
 mod spirv;
 
 #[cfg(feature = "transform-types")]

--- a/src/spirv.rs
+++ b/src/spirv.rs
@@ -24,26 +24,3 @@ unsupported_features! {
     "serde",
     "std",
 }
-
-use spirv_std::vector::Vector;
-
-unsafe impl Vector<bool, 2> for crate::BVec2 {}
-unsafe impl Vector<bool, 3> for crate::BVec3 {}
-unsafe impl Vector<bool, 4> for crate::BVec4 {}
-
-unsafe impl Vector<f32, 2> for crate::Vec2 {}
-unsafe impl Vector<f32, 3> for crate::Vec3 {}
-unsafe impl Vector<f32, 3> for crate::Vec3A {}
-unsafe impl Vector<f32, 4> for crate::Vec4 {}
-
-unsafe impl Vector<f64, 2> for crate::DVec2 {}
-unsafe impl Vector<f64, 3> for crate::DVec3 {}
-unsafe impl Vector<f64, 4> for crate::DVec4 {}
-
-unsafe impl Vector<u32, 2> for crate::UVec2 {}
-unsafe impl Vector<u32, 3> for crate::UVec3 {}
-unsafe impl Vector<u32, 4> for crate::UVec4 {}
-
-unsafe impl Vector<i32, 2> for crate::IVec2 {}
-unsafe impl Vector<i32, 3> for crate::IVec3 {}
-unsafe impl Vector<i32, 4> for crate::IVec4 {}


### PR DESCRIPTION
Sorry for the churn of effectively reverting https://github.com/bitshifter/glam-rs/pull/142! Our reasoning:

In the glorious sparkly far future, when spirv-std is effectively merged into std and everything is stable and unchanging, it makes sense for glam to depend on spirv-std, and for spirv-std to be completely agnostic. It _is_ called spirv-std, after all, and things should depend on it, rather than the other way around. However, today is not the glorious sparkly far future, and there are very real issues caused by the speed at which spirv-std (and rustc_codegen_spirv) is changing. We were too optimistic, and realized after a couple months of dealing with the situation that the old system was way better. For example, if a user depends on rust-gpu HEAD, but references a glam version that isn't referencing back to the same version of rust-gpu, really difficult to diagnose problems occur. Of course, cargo patches exist, and is what we've been using, but it's all just a mess and it'd be nice if it "just worked", always. Having to update glam every time we make a rust-gpu release is also tough, and it'd be super nice if we didn't have to.

So for now, we'd like to flip the dependency arrow again, and make spirv-std depend on glam. It'd still be fully generic and accepting of any vector library, basically all that's changing is moving these trait impls to spirv-std (perhaps behind a glam feature flag), and other vector libraries could still implement these traits.

On glam's side, this is kinda nice because stable semvers depending on alpha versions of crates is... I don't think it's against semver, but it's certainly pretty sketchy, and it's nice to just avoid that weirdness entirely.