### PR TITLE
Implement element-wise Add and Sub for Vec types

### DIFF
--- a/src/core/scalar/vector.rs
+++ b/src/core/scalar/vector.rs
@@ -202,6 +202,22 @@ impl<T: NumEx> Vector<T> for XY<T> {
     }
 
     #[inline]
+    fn add_scalar(self, other: T) -> Self {
+        Self {
+            x: self.x + other,
+            y: self.y + other,
+        }
+    }
+
+    #[inline]
+    fn sub_scalar(self, other: T) -> Self {
+        Self {
+            x: self.x - other,
+            y: self.y - other,
+        }
+    }
+
+    #[inline]
     fn mul_scalar(self, other: T) -> Self {
         Self {
             x: self.x * other,
@@ -347,6 +363,22 @@ impl<T: NumEx> Vector<T> for XYZ<T> {
             x: self.x - other.x,
             y: self.y - other.y,
             z: self.z - other.z,
+        }
+    }
+
+    fn add_scalar(self, other: T) -> Self {
+        Self {
+            x: self.x + other,
+            y: self.y + other,
+            z: self.z + other,
+        }
+    }
+
+    fn sub_scalar(self, other: T) -> Self {
+        Self {
+            x: self.x - other,
+            y: self.y - other,
+            z: self.z - other,
         }
     }
 
@@ -517,6 +549,24 @@ impl<T: NumEx> Vector<T> for XYZW<T> {
             y: self.y - other.y,
             z: self.z - other.z,
             w: self.w - other.w,
+        }
+    }
+
+    fn add_scalar(self, other: T) -> Self {
+        Self {
+            x: self.x + other,
+            y: self.y + other,
+            z: self.z + other,
+            w: self.w + other,
+        }
+    }
+
+    fn sub_scalar(self, other: T) -> Self {
+        Self {
+            x: self.x - other,
+            y: self.y - other,
+            z: self.z - other,
+            w: self.w - other,
         }
     }
 
@@ -893,6 +943,16 @@ impl Vector<f32> for XYZF32A16 {
     #[inline]
     fn sub(self, other: Self) -> Self {
         XYZ::sub(self.into(), other.into()).into()
+    }
+
+    #[inline]
+    fn add_scalar(self, other: f32) -> Self {
+        XYZ::add_scalar(self.into(), other).into()
+    }
+
+    #[inline]
+    fn sub_scalar(self, other: f32) -> Self {
+        XYZ::sub_scalar(self.into(), other).into()
     }
 
     #[inline]

--- a/src/core/sse2/vector.rs
+++ b/src/core/sse2/vector.rs
@@ -244,6 +244,14 @@ impl Vector<f32> for __m128 {
         unsafe { _mm_sub_ps(self, other) }
     }
 
+    fn add_scalar(self, other: f32) -> Self {
+        unsafe { _mm_add_ps(self, _mm_set_ps1(other)) }
+    }
+
+    fn sub_scalar(self, other: f32) -> Self {
+        unsafe { _mm_sub_ps(self, _mm_set_ps1(other)) }
+    }
+
     #[inline(always)]
     fn mul_scalar(self, other: f32) -> Self {
         unsafe { _mm_mul_ps(self, _mm_set_ps1(other)) }

--- a/src/core/traits/vector.rs
+++ b/src/core/traits/vector.rs
@@ -99,6 +99,8 @@ pub trait Vector<T>: Sized + Copy + Clone {
         self.mul_scalar(other)
     }
 
+    fn add_scalar(self, other: T) -> Self;
+    fn sub_scalar(self, other: T) -> Self;
     fn mul_scalar(self, other: T) -> Self;
     fn div_scalar(self, other: T) -> Self;
 

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -345,7 +345,7 @@ macro_rules! impl_mat3_methods {
         /// This method assumes that `self` contains a valid affine transform.
         #[inline(always)]
         pub fn transform_point2(&self, other: $vec2) -> $vec2 {
-            $mat2::from_cols(self.x_axis.into(), self.y_axis.into()) * other + self.z_axis.into()
+            $mat2::from_cols(self.x_axis.into(), self.y_axis.into()) * other + $vec2::from(self.z_axis)
         }
 
         /// Rotates the given 2D vector.

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -524,22 +524,45 @@ macro_rules! impl_vecn_common_traits {
             }
         }
 
-        impl Add for $vecn {
+        impl Add<$vecn> for $vecn {
             type Output = Self;
             #[inline(always)]
-            fn add(self, other: Self) -> Self {
+            fn add(self, other: $vecn) -> Self {
                 Self(self.0.add(other.0))
             }
         }
 
-        impl AddAssign for $vecn {
+        impl AddAssign<$vecn> for $vecn {
             #[inline(always)]
-            fn add_assign(&mut self, other: Self) {
+            fn add_assign(&mut self, other: $vecn) {
                 self.0 = self.0.add(other.0)
             }
         }
 
-        impl Sub for $vecn {
+        impl Add<$t> for $vecn {
+            type Output = Self;
+            #[inline(always)]
+            fn add(self, other: $t) -> Self {
+                Self(self.0.add_scalar(other))
+            }
+        }
+
+        impl AddAssign<$t> for $vecn {
+            #[inline(always)]
+            fn add_assign(&mut self, other: $t) {
+                self.0 = self.0.add_scalar(other)
+            }
+        }
+
+        impl Add<$vecn> for $t {
+            type Output = $vecn;
+            #[inline(always)]
+            fn add(self, other: $vecn) -> $vecn {
+                $vecn($inner::splat(self).add(other.0))
+            }
+        }
+
+        impl Sub<$vecn> for $vecn {
             type Output = Self;
             #[inline(always)]
             fn sub(self, other: $vecn) -> Self {
@@ -547,10 +570,33 @@ macro_rules! impl_vecn_common_traits {
             }
         }
 
-        impl SubAssign for $vecn {
+        impl SubAssign<$vecn> for $vecn {
             #[inline(always)]
             fn sub_assign(&mut self, other: $vecn) {
                 self.0 = self.0.sub(other.0)
+            }
+        }
+
+        impl Sub<$t> for $vecn {
+            type Output = Self;
+            #[inline(always)]
+            fn sub(self, other: $t) -> Self {
+                Self(self.0.sub_scalar(other))
+            }
+        }
+
+        impl SubAssign<$t> for $vecn {
+            #[inline(always)]
+            fn sub_assign(&mut self, other: $t) {
+                self.0 = self.0.sub_scalar(other)
+            }
+        }
+
+        impl Sub<$vecn> for $t {
+            type Output = $vecn;
+            #[inline(always)]
+            fn sub(self, other: $vecn) -> $vecn {
+                $vecn($inner::splat(self).sub(other.0))
             }
         }
 


### PR DESCRIPTION
It seems that while element wise operations are already implemented for multiply and divide operations on vector types, addition and subtraction are not. I'm unsure if this was a intended decision, however, I believe this is a simple improvement that increases convenience without sacrificing readability, and thus is a worthwhile feature.

The only concern I have is that this may be considered breaking in rare cases. See the modification of mat3.rs that was required to satisfy the compiler.