### PR TITLE
Bytemuck now compiles on spirv

### DIFF
--- a/src/spirv.rs
+++ b/src/spirv.rs
@@ -18,7 +18,6 @@ macro_rules! unsupported_features {
 #[cfg(target_arch = "spirv")]
 unsupported_features! {
     "approx",
-    "bytemuck",
     "debug-glam-assert",
     "glam-assert",
     "rand",


### PR DESCRIPTION
As of https://github.com/Lokathor/bytemuck/pull/69

Fixes #229