### PR TITLE
Implement mint conversions for Mat3A.

### DIFF
--- a/src/features/impl_mint.rs
+++ b/src/features/impl_mint.rs
@@ -440,6 +440,40 @@ mod test {
             assert_eq!(g, Vec3A::new(1.0, 2.0, 3.0));
             assert_eq!(m, g.into());
         }
+
+        #[test]
+        fn test_mat3a_col_major() {
+            use crate::Mat3A;
+            let m = mint::ColumnMatrix3 {
+                x: [0.0, 1.0, 2.0].into(),
+                y: [3.0, 4.0, 5.0].into(),
+                z: [6.0, 7.0, 8.0].into(),
+            };
+            let expected = Mat3A::from_cols(
+                [0.0, 1.0, 2.0].into(),
+                [3.0, 4.0, 5.0].into(),
+                [6.0, 7.0, 8.0].into(),
+            );
+            assert_eq!(expected, m.into());
+            assert_eq!(m, expected.into());
+        }
+
+        #[test]
+        fn test_mat3a_row_major() {
+            use crate::Mat3A;
+            let m = mint::RowMatrix3 {
+                x: [0.0, 1.0, 2.0].into(),
+                y: [3.0, 4.0, 5.0].into(),
+                z: [6.0, 7.0, 8.0].into(),
+            };
+            let expected = Mat3A::from_cols(
+                [0.0, 3.0, 6.0].into(),
+                [1.0, 4.0, 7.0].into(),
+                [2.0, 5.0, 8.0].into(),
+            );
+            assert_eq!(expected, m.into());
+            assert_eq!(m, expected.into());
+        }
     }
 
     mod f64 {


### PR DESCRIPTION
I am using Mat3A heavily in my project and I am dearly missing these.