### PR TITLE
Trying to tidy up some repr usage and tests.

### DIFF
--- a/src/affine2.rs
+++ b/src/affine2.rs
@@ -498,7 +498,7 @@ impl_affine2_traits!(
 ))]
 mod const_test_affine2 {
     const_assert_eq!(
-        core::mem::align_of::<f32>(),
+        core::mem::align_of::<super::Vec2>(),
         core::mem::align_of::<super::Affine2>()
     );
     const_assert_eq!(24, core::mem::size_of::<super::Affine2>());
@@ -510,17 +510,10 @@ mod const_test_affine2 {
     const_assert_eq!(32, core::mem::size_of::<super::Affine2>());
 }
 
-#[cfg(not(feature = "cuda"))]
 mod const_test_daffine2 {
     const_assert_eq!(
-        core::mem::align_of::<f64>(),
+        core::mem::align_of::<super::DVec2>(),
         core::mem::align_of::<super::DAffine2>()
     );
-    const_assert_eq!(48, core::mem::size_of::<super::DAffine2>());
-}
-
-#[cfg(feature = "cuda")]
-mod const_test_daffine2 {
-    const_assert_eq!(16, core::mem::align_of::<super::DAffine2>());
     const_assert_eq!(48, core::mem::size_of::<super::DAffine2>());
 }

--- a/src/affine3.rs
+++ b/src/affine3.rs
@@ -615,13 +615,16 @@ impl_affine3_traits!(
 );
 
 mod const_test_affine3a {
-    const_assert_eq!(16, core::mem::align_of::<super::Affine3A>());
+    const_assert_eq!(
+        core::mem::align_of::<super::Vec3A>(),
+        core::mem::align_of::<super::Affine3A>()
+    );
     const_assert_eq!(64, core::mem::size_of::<super::Affine3A>());
 }
 
 mod const_test_daffine3 {
     const_assert_eq!(
-        core::mem::align_of::<f64>(),
+        core::mem::align_of::<super::DVec3>(),
         core::mem::align_of::<super::DAffine3>()
     );
     const_assert_eq!(96, core::mem::size_of::<super::DAffine3>());

--- a/src/core/storage.rs
+++ b/src/core/storage.rs
@@ -52,7 +52,7 @@ pub struct Columns4<V> {
 /// The `XYZF32A16` is used for the `Vec3A` type, that is a 16 btye aligned `XYZ<f32>` type.
 #[derive(Clone, Copy, Debug, Default, PartialEq, PartialOrd)]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
-#[cfg_attr(not(target_arch = "spirv"), repr(align(16), C))]
+#[cfg_attr(not(target_arch = "spirv"), repr(C, align(16)))]
 pub struct XYZF32A16 {
     pub x: f32,
     pub y: f32,
@@ -100,7 +100,7 @@ impl From<XYZF32A16> for XY<f32> {
 }
 
 #[derive(Clone, Copy, Default, PartialEq, PartialOrd)]
-#[repr(align(16))]
+#[repr(C, align(16))]
 pub(crate) struct Align16<T>(pub T);
 
 impl<T> Align16<T> {

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -886,16 +886,10 @@ impl DMat4 {
 impl_mat4_traits!(f64, dmat4, DMat4, DVec4);
 
 mod const_test_mat4 {
-    #[cfg(all(
-        any(feature = "scalar-math", target_arch = "spriv"),
-        not(feature = "cuda")
-    ))]
     const_assert_eq!(
         core::mem::align_of::<super::Vec4>(),
         core::mem::align_of::<super::Mat4>()
     );
-    #[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
-    const_assert_eq!(16, core::mem::align_of::<super::Mat4>());
     const_assert_eq!(64, core::mem::size_of::<super::Mat4>());
 }
 

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -710,10 +710,23 @@ type InnerF32 = crate::XYZW<f32>;
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[cfg_attr(
-    not(any(feature = "scalar-math", target_arch = "spriv")),
-    repr(align(16))
+    not(any(
+        feature = "scalar-math",
+        target_arch = "spriv",
+        target_feature = "sse2",
+        target_feature = "simd128"
+    )),
+    repr(C, align(16))
 )]
-#[cfg_attr(any(feature = "scalar-math", target_arch = "spriv"), repr(transparent))]
+#[cfg_attr(
+    any(
+        feature = "scalar-math",
+        target_arch = "spriv",
+        target_feature = "sse2",
+        target_feature = "simd128"
+    ),
+    repr(transparent)
+)]
 pub struct Quat(pub(crate) InnerF32);
 
 impl Quat {

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -272,62 +272,46 @@ impl_vecn_scalar_bit_op_traits!(UVec2, u32, XYU32);
 
 impl_vecn_bit_op_traits!(UVec2, XYU32);
 
-#[cfg(not(feature = "cuda"))]
 mod const_test_vec2 {
+    #[cfg(not(feature = "cuda"))]
     const_assert_eq!(
         core::mem::align_of::<f32>(),
         core::mem::align_of::<super::Vec2>()
     );
-    const_assert_eq!(8, core::mem::size_of::<super::Vec2>());
-}
-
-#[cfg(not(feature = "cuda"))]
-mod const_test_dvec2 {
-    const_assert_eq!(
-        core::mem::align_of::<f64>(),
-        core::mem::align_of::<super::DVec2>()
-    );
-    const_assert_eq!(16, core::mem::size_of::<super::DVec2>());
-}
-
-#[cfg(not(feature = "cuda"))]
-mod const_test_ivec2 {
-    const_assert_eq!(
-        core::mem::align_of::<i32>(),
-        core::mem::align_of::<super::IVec2>()
-    );
-    const_assert_eq!(8, core::mem::size_of::<super::IVec2>());
-}
-
-#[cfg(not(feature = "cuda"))]
-mod const_test_uvec2 {
-    const_assert_eq!(
-        core::mem::align_of::<u32>(),
-        core::mem::align_of::<super::UVec2>()
-    );
-    const_assert_eq!(8, core::mem::size_of::<super::UVec2>());
-}
-
-#[cfg(feature = "cuda")]
-mod const_test_vec2 {
+    #[cfg(feature = "cuda")]
     const_assert_eq!(8, core::mem::align_of::<super::Vec2>());
     const_assert_eq!(8, core::mem::size_of::<super::Vec2>());
 }
 
-#[cfg(feature = "cuda")]
 mod const_test_dvec2 {
+    #[cfg(not(feature = "cuda"))]
+    const_assert_eq!(
+        core::mem::align_of::<f64>(),
+        core::mem::align_of::<super::DVec2>()
+    );
+    #[cfg(feature = "cuda")]
     const_assert_eq!(16, core::mem::align_of::<super::DVec2>());
     const_assert_eq!(16, core::mem::size_of::<super::DVec2>());
 }
 
-#[cfg(feature = "cuda")]
 mod const_test_ivec2 {
+    #[cfg(not(feature = "cuda"))]
+    const_assert_eq!(
+        core::mem::align_of::<i32>(),
+        core::mem::align_of::<super::IVec2>()
+    );
+    #[cfg(feature = "cuda")]
     const_assert_eq!(8, core::mem::align_of::<super::IVec2>());
     const_assert_eq!(8, core::mem::size_of::<super::IVec2>());
 }
 
-#[cfg(feature = "cuda")]
 mod const_test_uvec2 {
+    #[cfg(not(feature = "cuda"))]
+    const_assert_eq!(
+        core::mem::align_of::<u32>(),
+        core::mem::align_of::<super::UVec2>()
+    );
+    #[cfg(feature = "cuda")]
     const_assert_eq!(8, core::mem::align_of::<super::UVec2>());
     const_assert_eq!(8, core::mem::size_of::<super::UVec2>());
 }

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -246,15 +246,17 @@ type XYZWF32 = v128;
 /// This type uses 16 byte aligned SIMD vector type for storage on supported platforms.
 #[derive(Clone, Copy)]
 #[cfg_attr(
-    not(any(
-        feature = "scalar-math",
-        target_arch = "spriv",
-        target_feature = "sse2",
-        target_feature = "simd128"
-    )),
+    any(
+        not(any(
+            feature = "scalar-math",
+            target_arch = "spriv",
+            target_feature = "sse2",
+            target_feature = "simd128"
+        )),
+        feature = "cuda"
+    ),
     repr(C, align(16))
 )]
-#[cfg_attr(feature = "cuda", repr(C, align(16)))]
 #[cfg_attr(
     all(
         any(

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -246,17 +246,27 @@ type XYZWF32 = v128;
 /// This type uses 16 byte aligned SIMD vector type for storage on supported platforms.
 #[derive(Clone, Copy)]
 #[cfg_attr(
-    not(any(feature = "scalar-math", target_arch = "spriv", feature = "cuda")),
-    repr(align(16))
+    not(any(
+        feature = "scalar-math",
+        target_arch = "spriv",
+        target_feature = "sse2",
+        target_feature = "simd128"
+    )),
+    repr(C, align(16))
 )]
+#[cfg_attr(feature = "cuda", repr(C, align(16)))]
 #[cfg_attr(
     all(
-        any(feature = "scalar-math", target_arch = "spriv"),
+        any(
+            feature = "scalar-math",
+            target_arch = "spriv",
+            target_feature = "sse2",
+            target_feature = "simd128"
+        ),
         not(feature = "cuda")
     ),
     repr(transparent)
 )]
-#[cfg_attr(feature = "cuda", repr(C, align(16)))]
 pub struct Vec4(pub(crate) XYZWF32);
 
 #[cfg(any(
@@ -395,68 +405,49 @@ mod tests {
     }
 }
 
-#[cfg(all(
-    any(feature = "scalar-math", target_arch = "spriv"),
-    not(feature = "cuda")
-))]
 mod const_test_vec4 {
+    #[cfg(all(
+        any(feature = "scalar-math", target_arch = "spriv"),
+        not(feature = "cuda")
+    ))]
     const_assert_eq!(
         core::mem::align_of::<f32>(),
         core::mem::align_of::<super::Vec4>()
     );
-    const_assert_eq!(16, core::mem::size_of::<super::Vec4>());
-}
-
-#[cfg(any(
-    not(any(feature = "scalar-math", target_arch = "spriv")),
-    feature = "cuda"
-))]
-mod const_test_vec4 {
+    #[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
     const_assert_eq!(16, core::mem::align_of::<super::Vec4>());
     const_assert_eq!(16, core::mem::size_of::<super::Vec4>());
 }
 
-#[cfg(not(feature = "cuda"))]
 mod const_test_dvec4 {
+    #[cfg(not(feature = "cuda"))]
     const_assert_eq!(
         core::mem::align_of::<f64>(),
         core::mem::align_of::<super::DVec4>()
     );
-    const_assert_eq!(32, core::mem::size_of::<super::DVec4>());
-}
-
-#[cfg(not(feature = "cuda"))]
-mod const_test_ivec4 {
-    const_assert_eq!(
-        core::mem::align_of::<i32>(),
-        core::mem::align_of::<super::IVec4>()
-    );
-    const_assert_eq!(16, core::mem::size_of::<super::IVec4>());
-}
-
-#[cfg(not(feature = "cuda"))]
-mod const_test_uvec4 {
-    const_assert_eq!(
-        core::mem::align_of::<u32>(),
-        core::mem::align_of::<super::UVec4>()
-    );
-    const_assert_eq!(16, core::mem::size_of::<super::UVec4>());
-}
-
-#[cfg(feature = "cuda")]
-mod const_test_dvec4 {
+    #[cfg(feature = "cuda")]
     const_assert_eq!(16, core::mem::align_of::<super::DVec4>());
     const_assert_eq!(32, core::mem::size_of::<super::DVec4>());
 }
 
-#[cfg(feature = "cuda")]
 mod const_test_ivec4 {
+    #[cfg(not(feature = "cuda"))]
+    const_assert_eq!(
+        core::mem::align_of::<i32>(),
+        core::mem::align_of::<super::IVec4>()
+    );
+    #[cfg(feature = "cuda")]
     const_assert_eq!(16, core::mem::align_of::<super::IVec4>());
     const_assert_eq!(16, core::mem::size_of::<super::IVec4>());
 }
 
-#[cfg(feature = "cuda")]
 mod const_test_uvec4 {
+    #[cfg(not(feature = "cuda"))]
+    const_assert_eq!(
+        core::mem::align_of::<u32>(),
+        core::mem::align_of::<super::UVec4>()
+    );
+    #[cfg(feature = "cuda")]
     const_assert_eq!(16, core::mem::align_of::<super::UVec4>());
     const_assert_eq!(16, core::mem::size_of::<super::UVec4>());
 }

--- a/tests/affine3.rs
+++ b/tests/affine3.rs
@@ -293,7 +293,7 @@ mod affine3a {
     glam_test!(test_align, {
         use std::mem;
         assert_eq!(64, mem::size_of::<Affine3A>());
-        assert_eq!(16, mem::align_of::<Affine3A>());
+        assert_eq!(mem::align_of::<Vec3A>(), mem::align_of::<Affine3A>());
     });
 
     glam_test!(test_affine3_mul_vec3a, {

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -246,21 +246,6 @@ mod mat2 {
     impl_mat2_tests!(f32, const_mat2, mat2, Mat2, Mat3, vec2, Vec2);
 }
 
-#[cfg(not(feature = "cuda"))]
-mod dmat2 {
-    use super::support::deg;
-    use glam::{const_dmat2, dmat2, dvec2, swizzles::*, DMat2, DMat3, DVec2};
-
-    glam_test!(test_align, {
-        use std::mem;
-        assert_eq!(32, mem::size_of::<DMat2>());
-        assert_eq!(mem::align_of::<f64>(), mem::align_of::<DMat2>());
-    });
-
-    impl_mat2_tests!(f64, const_dmat2, dmat2, DMat2, DMat3, dvec2, DVec2);
-}
-
-#[cfg(feature = "cuda")]
 mod dmat2 {
     use super::support::deg;
     use glam::{const_dmat2, dmat2, dvec2, swizzles::*, DMat2, DMat3, DVec2};

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -225,7 +225,7 @@ mod mat2 {
         use std::mem;
         assert_eq!(16, mem::size_of::<Mat2>());
         if cfg!(feature = "scalar-math") {
-            assert_eq!(4, mem::align_of::<Mat2>());
+            assert_eq!(mem::align_of::<Vec2>(), mem::align_of::<Mat2>());
         } else {
             assert_eq!(16, mem::align_of::<Mat2>());
         }

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -360,7 +360,7 @@ mod mat3 {
     glam_test!(test_align, {
         use std::mem;
         assert_eq!(36, mem::size_of::<Mat3>());
-        assert_eq!(4, mem::align_of::<Mat3>());
+        assert_eq!(mem::align_of::<Vec3>(), mem::align_of::<Mat3>());
     });
 
     glam_test!(test_mul_vec3a, {
@@ -393,7 +393,7 @@ mod mat3a {
     glam_test!(test_align, {
         use std::mem;
         assert_eq!(48, mem::size_of::<Mat3A>());
-        assert_eq!(16, mem::align_of::<Mat3A>());
+        assert_eq!(mem::align_of::<Vec3A>(), mem::align_of::<Mat3A>());
     });
 
     glam_test!(test_mul_vec3a, {
@@ -431,7 +431,7 @@ mod dmat3 {
     glam_test!(test_align, {
         use std::mem;
         assert_eq!(72, mem::size_of::<DMat3>());
-        assert_eq!(mem::align_of::<f64>(), mem::align_of::<DMat3>());
+        assert_eq!(mem::align_of::<DVec3>(), mem::align_of::<DMat3>());
     });
 
     impl_mat3_tests!(

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -713,8 +713,12 @@ mod dmat4 {
 
     glam_test!(test_align, {
         use std::mem;
+        if cfg!(not(feature = "cuda")) {
+            assert_eq!(mem::align_of::<f64>(), mem::align_of::<DMat4>());
+        } else {
+            assert_eq!(16, mem::align_of::<DMat4>());
+        }
         assert_eq!(128, mem::size_of::<DMat4>());
-        assert_eq!(mem::align_of::<f64>(), mem::align_of::<DMat4>());
     });
 
     impl_mat4_tests!(

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -662,12 +662,8 @@ mod mat4 {
 
     glam_test!(test_align, {
         use std::mem;
+        assert_eq!(mem::align_of::<Vec4>(), mem::align_of::<Mat4>());
         assert_eq!(64, mem::size_of::<Mat4>());
-        if cfg!(all(feature = "scalar-math", not(feature = "cuda"))) {
-            assert_eq!(4, mem::align_of::<Mat4>());
-        } else {
-            assert_eq!(16, mem::align_of::<Mat4>());
-        }
     });
 
     glam_test!(test_as, {
@@ -713,11 +709,7 @@ mod dmat4 {
 
     glam_test!(test_align, {
         use std::mem;
-        if cfg!(not(feature = "cuda")) {
-            assert_eq!(mem::align_of::<f64>(), mem::align_of::<DMat4>());
-        } else {
-            assert_eq!(16, mem::align_of::<DMat4>());
-        }
+        assert_eq!(mem::align_of::<DVec4>(), mem::align_of::<DMat4>());
         assert_eq!(128, mem::size_of::<DMat4>());
     });
 


### PR DESCRIPTION
Attempting to simplify some of repr attributes and tests.

* Try to make all types that wrap SIMD `transparent` - seems like the most likely benefit of using transparent. I haven't actually checked to see if it makes any different codegen wise though.
* Make sure matrix and affine types are aligned to the vector types they contain