### PR TITLE
Replace spriv typo with spirv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,13 +227,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 * Deprecated `TransformSRT` and `TransformRT` which are under the
   `transform-types` feature. These will be moved to a separate experimental
   crate.
-* Updated `spriv-std` dependency version to `0.4.0-alpha7`.
+* Updated `spirv-std` dependency version to `0.4.0-alpha7`.
 
 ## [0.14.0] - 2021-04-09
 
 ### Breaking changes
 
-* Minimum Supported Version of Rust bumped to 1.45.0 for the `spriv-std`
+* Minimum Supported Version of Rust bumped to 1.45.0 for the `spirv-std`
   dependency.
 
 ### Added
@@ -245,7 +245,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Changed
 
 * Updated dependency versions of `bytemuck` to `1.5`, `rand` to `0.8`,
-  `rand_xoshiro` to `0.6` and `spriv-std` to `0.4.0-alpha4`.
+  `rand_xoshiro` to `0.6` and `spirv-std` to `0.4.0-alpha4`.
 
 ## [0.13.1] - 2021-03-24
 
@@ -253,7 +253,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 * Added vector `clamp()` functions.
 * Added matrix column and row accessor methods, `col()` and `row()`.
-* Added SPIR-V module and dependency on `spriv-std` for the SPIR-V target.
+* Added SPIR-V module and dependency on `spirv-std` for the SPIR-V target.
 * Added matrix truncation from 4x4 to 3x3 and 3x3 to 2x2 via `From` impls.
 
 ### Changed
@@ -332,7 +332,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Changed
 
-* Made `Vec3` `repr(simd)` for `spriv` targets.
+* Made `Vec3` `repr(simd)` for `spirv` targets.
 
 ### Added
 

--- a/src/affine2.rs
+++ b/src/affine2.rs
@@ -494,7 +494,7 @@ impl_affine2_traits!(
 
 #[cfg(all(
     not(feature = "cuda"),
-    any(feature = "scalar-math", target_arch = "spriv")
+    any(feature = "scalar-math", target_arch = "spirv")
 ))]
 mod const_test_affine2 {
     const_assert_eq!(
@@ -504,7 +504,7 @@ mod const_test_affine2 {
     const_assert_eq!(24, core::mem::size_of::<super::Affine2>());
 }
 
-#[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
+#[cfg(not(any(feature = "scalar-math", target_arch = "spirv")))]
 mod const_test_affine2 {
     const_assert_eq!(16, core::mem::align_of::<super::Affine2>());
     const_assert_eq!(32, core::mem::size_of::<super::Affine2>());

--- a/src/mat2.rs
+++ b/src/mat2.rs
@@ -262,7 +262,7 @@ macro_rules! impl_mat2_traits {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsRef<[$t; 4]> for $mat2 {
             #[inline(always)]
             fn as_ref(&self) -> &[$t; 4] {
@@ -270,7 +270,7 @@ macro_rules! impl_mat2_traits {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsMut<[$t; 4]> for $mat2 {
             #[inline(always)]
             fn as_mut(&mut self) -> &mut [$t; 4] {
@@ -329,7 +329,7 @@ type InnerF32 = crate::core::storage::Columns2<XY<f32>>;
 #[cfg_attr(
     not(any(
         feature = "scalar-math",
-        target_arch = "spriv",
+        target_arch = "spirv",
         target_feature = "sse2",
         target_feature = "simd128"
     )),
@@ -340,7 +340,7 @@ type InnerF32 = crate::core::storage::Columns2<XY<f32>>;
     all(
         any(
             feature = "scalar-math",
-            target_arch = "spriv",
+            target_arch = "spirv",
             target_feature = "sse2",
             target_feature = "simd128"
         ),
@@ -379,12 +379,12 @@ impl DMat2 {
 impl_mat2_traits!(f64, dmat2, DMat2, DVec2);
 
 mod const_test_mat2 {
-    #[cfg(any(feature = "scalar-math", target_arch = "spriv"))]
+    #[cfg(any(feature = "scalar-math", target_arch = "spirv"))]
     const_assert_eq!(
         core::mem::align_of::<super::Vec2>(),
         core::mem::align_of::<super::Mat2>()
     );
-    #[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
+    #[cfg(not(any(feature = "scalar-math", target_arch = "spirv")))]
     const_assert_eq!(16, core::mem::align_of::<super::Mat2>());
     const_assert_eq!(16, core::mem::size_of::<super::Mat2>());
 }

--- a/src/mat3.rs
+++ b/src/mat3.rs
@@ -451,7 +451,7 @@ macro_rules! impl_mat3_traits {
 
 macro_rules! impl_mat3_traits_unsafe {
     ($t:ty, $mat3:ident) => {
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsRef<[$t; 9]> for $mat3 {
             #[inline(always)]
             fn as_ref(&self) -> &[$t; 9] {
@@ -459,7 +459,7 @@ macro_rules! impl_mat3_traits_unsafe {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsMut<[$t; 9]> for $mat3 {
             #[inline(always)]
             fn as_mut(&mut self) -> &mut [$t; 9] {

--- a/src/mat4.rs
+++ b/src/mat4.rs
@@ -688,7 +688,7 @@ macro_rules! impl_mat4_traits {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsRef<[$t; 16]> for $mat4 {
             #[inline]
             fn as_ref(&self) -> &[$t; 16] {
@@ -696,7 +696,7 @@ macro_rules! impl_mat4_traits {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsMut<[$t; 16]> for $mat4 {
             #[inline]
             fn as_mut(&mut self) -> &mut [$t; 16] {
@@ -773,14 +773,14 @@ type InnerF32 = Columns4<XYZW<f32>>;
 #[derive(Clone, Copy)]
 #[cfg_attr(
     any(
-        not(any(feature = "scalar-math", target_arch = "spriv")),
+        not(any(feature = "scalar-math", target_arch = "spirv")),
         feature = "cuda"
     ),
     repr(C, align(16))
 )]
 #[cfg_attr(
     all(
-        any(feature = "scalar-math", target_arch = "spriv"),
+        any(feature = "scalar-math", target_arch = "spirv"),
         not(feature = "cuda"),
     ),
     repr(transparent)

--- a/src/quat.rs
+++ b/src/quat.rs
@@ -615,7 +615,7 @@ macro_rules! impl_quat_traits {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsRef<[$t; 4]> for $quat {
             #[inline(always)]
             fn as_ref(&self) -> &[$t; 4] {
@@ -623,7 +623,7 @@ macro_rules! impl_quat_traits {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsMut<[$t; 4]> for $quat {
             #[inline(always)]
             fn as_mut(&mut self) -> &mut [$t; 4] {
@@ -712,7 +712,7 @@ type InnerF32 = crate::XYZW<f32>;
 #[cfg_attr(
     not(any(
         feature = "scalar-math",
-        target_arch = "spriv",
+        target_arch = "spirv",
         target_feature = "sse2",
         target_feature = "simd128"
     )),
@@ -721,7 +721,7 @@ type InnerF32 = crate::XYZW<f32>;
 #[cfg_attr(
     any(
         feature = "scalar-math",
-        target_arch = "spriv",
+        target_arch = "spirv",
         target_feature = "sse2",
         target_feature = "simd128"
     ),
@@ -795,7 +795,7 @@ impl DQuat {
 }
 impl_quat_traits!(f64, dquat, DQuat, DVec3, DVec4, InnerF64);
 
-#[cfg(any(feature = "scalar-math", target_arch = "spriv"))]
+#[cfg(any(feature = "scalar-math", target_arch = "spirv"))]
 mod const_test_quat {
     const_assert_eq!(
         core::mem::align_of::<f32>(),
@@ -804,7 +804,7 @@ mod const_test_quat {
     const_assert_eq!(16, core::mem::size_of::<super::Quat>());
 }
 
-#[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
+#[cfg(not(any(feature = "scalar-math", target_arch = "spirv")))]
 mod const_test_quat {
     const_assert_eq!(16, core::mem::align_of::<super::Quat>());
     const_assert_eq!(16, core::mem::size_of::<super::Quat>());

--- a/src/vec.rs
+++ b/src/vec.rs
@@ -701,7 +701,7 @@ macro_rules! impl_vecn_common_traits {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsRef<[$t; $size]> for $vecn {
             #[inline(always)]
             fn as_ref(&self) -> &[$t; $size] {
@@ -709,7 +709,7 @@ macro_rules! impl_vecn_common_traits {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsMut<[$t; $size]> for $vecn {
             #[inline(always)]
             fn as_mut(&mut self) -> &mut [$t; $size] {
@@ -757,7 +757,7 @@ macro_rules! impl_vecn_eq_hash_traits {
     ($t:ty, $size:literal, $vecn:ident) => {
         impl Eq for $vecn {}
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl core::hash::Hash for $vecn {
             fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
                 let inner: &[$t; $size] = self.as_ref();

--- a/src/vec4.rs
+++ b/src/vec4.rs
@@ -249,7 +249,7 @@ type XYZWF32 = v128;
     any(
         not(any(
             feature = "scalar-math",
-            target_arch = "spriv",
+            target_arch = "spirv",
             target_feature = "sse2",
             target_feature = "simd128"
         )),
@@ -261,7 +261,7 @@ type XYZWF32 = v128;
     all(
         any(
             feature = "scalar-math",
-            target_arch = "spriv",
+            target_arch = "spirv",
             target_feature = "sse2",
             target_feature = "simd128"
         ),
@@ -409,14 +409,14 @@ mod tests {
 
 mod const_test_vec4 {
     #[cfg(all(
-        any(feature = "scalar-math", target_arch = "spriv"),
+        any(feature = "scalar-math", target_arch = "spirv"),
         not(feature = "cuda")
     ))]
     const_assert_eq!(
         core::mem::align_of::<f32>(),
         core::mem::align_of::<super::Vec4>()
     );
-    #[cfg(not(any(feature = "scalar-math", target_arch = "spriv")))]
+    #[cfg(not(any(feature = "scalar-math", target_arch = "spirv")))]
     const_assert_eq!(16, core::mem::align_of::<super::Vec4>());
     const_assert_eq!(16, core::mem::size_of::<super::Vec4>());
 }

--- a/src/vec_mask.rs
+++ b/src/vec_mask.rs
@@ -162,7 +162,7 @@ macro_rules! impl_vec2mask {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsRef<[$t; 2]> for $vec2mask {
             #[inline]
             fn as_ref(&self) -> &[$t; 2] {
@@ -223,7 +223,7 @@ macro_rules! impl_vec3mask {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsRef<[$t; 3]> for $vec3mask {
             #[inline]
             fn as_ref(&self) -> &[$t; 3] {
@@ -285,7 +285,7 @@ macro_rules! impl_vec4mask {
             }
         }
 
-        #[cfg(not(target_arch = "spriv"))]
+        #[cfg(not(target_arch = "spirv"))]
         impl AsRef<[$t; 4]> for $vec4mask {
             #[inline]
             fn as_ref(&self) -> &[$t; 4] {


### PR DESCRIPTION
I've made this typo _so_ many many countless times myself, haha.

Noticed this when upgrading to glam 0.20 - `Vec4` wasn't marked as `repr(transparent)` due to the typo, which unfortunately mucked up a cast in Mat4's Deref impl from `*const Columns4<XYZW<f32>>` to `*const Columns4<Vec4>` in rust-gpu (due to the extra layer of struct wrapper in the latter)... it'd be real nice if SPIR-V was more friendly and allowed casts like that, but alas. I've confirmed this change fixes rust-gpu's consumption of glam.