### PR TITLE
Add `Quat::to_array` function

### DIFF
--- a/src/quat.rs
+++ b/src/quat.rs
@@ -282,6 +282,12 @@ macro_rules! impl_quat_methods {
             euler.convert_quat(self)
         }
 
+        /// `[x, y, z, w]`
+        #[inline(always)]
+        pub fn to_array(&self) -> [$t; 4] {
+            [self.x, self.y, self.z, self.w]
+        }
+
         /// Returns the vector part of the quaternion.
         #[inline(always)]
         pub fn xyz(self) -> $vec3 {

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -461,6 +461,10 @@ macro_rules! impl_quat_tests {
             should_glam_assert!({ $quat::from_rotation_arc_2d($vec2::ZERO, $vec2::X) });
             should_glam_assert!({ $quat::from_rotation_arc_2d($vec2::X, $vec2::ZERO) });
         });
+
+        glam_test!(test_to_array, {
+            assert!($new(1.0, 2.0, 3.0, 4.0).to_array() == [1.0, 2.0, 3.0, 4.0]);
+        });
     };
 }
 


### PR DESCRIPTION
Add `Quat::to_array` function to simplify conversion from `Quat` type to plain array.
`Quat` already has `from_array` function and vector types have `from_array` function so as a user of this library I would expect to have such function implemented for `Quat` struct as well.