### PR TITLE
Add documentation that lerp() extrapolates if value outside range [0,1]

### DIFF
--- a/src/vec.rs
+++ b/src/vec.rs
@@ -418,7 +418,8 @@ macro_rules! impl_vecn_float_methods {
         /// Performs a linear interpolation between `self` and `other` based on the value `s`.
         ///
         /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result
-        /// will be equal to `other`.
+        /// will be equal to `other`. When `s` is outside of range [0,1], the result is linearly
+        /// extrapolated.
         #[doc(alias = "mix")]
         #[inline]
         pub fn lerp(self, other: Self, s: $t) -> Self {


### PR DESCRIPTION
As I first thought `lerp()` clamps the result outside the range [0,1], I added a sentence to documentation which clarifies that it extrapolates.
I do not know how to make proper pull request, so this PR can be well ignored, if that notion is just added there.