### PR TITLE
Fix bad Matrix4x4 determinant in sse&wasm implementations

### DIFF
--- a/src/core/sse2/matrix.rs
+++ b/src/core/sse2/matrix.rs
@@ -279,7 +279,14 @@ impl Matrix4x4<f32, __m128> for Columns4<__m128> {
     #[inline]
     fn determinant(&self) -> f32 {
         unsafe {
-            // Based on https://github.com/g-truc/glm `glm_mat4_determinant`
+            // SubFactor00 = m[2][2] * m[3][3] - m[3][2] * m[2][3];
+            // SubFactor01 = m[2][1] * m[3][3] - m[3][1] * m[2][3];
+            // SubFactor02 = m[2][1] * m[3][2] - m[3][1] * m[2][2];
+            // SubFactor03 = m[2][0] * m[3][3] - m[3][0] * m[2][3];
+            // SubFactor04 = m[2][0] * m[3][2] - m[3][0] * m[2][2];
+            // SubFactor05 = m[2][0] * m[3][1] - m[3][0] * m[2][1];
+
+            // Based on https://github.com/g-truc/glm `glm_mat4_determinant_lowp`
             let swp2a = _mm_shuffle_ps(self.z_axis, self.z_axis, 0b00_01_01_10);
             let swp3a = _mm_shuffle_ps(self.w_axis, self.w_axis, 0b11_10_11_11);
             let swp2b = _mm_shuffle_ps(self.z_axis, self.z_axis, 0b11_10_11_11);

--- a/src/core/sse2/matrix.rs
+++ b/src/core/sse2/matrix.rs
@@ -283,7 +283,7 @@ impl Matrix4x4<f32, __m128> for Columns4<__m128> {
             let swp2a = _mm_shuffle_ps(self.z_axis, self.z_axis, 0b00_01_01_10);
             let swp3a = _mm_shuffle_ps(self.w_axis, self.w_axis, 0b11_10_11_11);
             let swp2b = _mm_shuffle_ps(self.z_axis, self.z_axis, 0b11_10_11_11);
-            let swp3b = _mm_shuffle_ps(self.w_axis, self.w_axis, 0b00_10_01_10);
+            let swp3b = _mm_shuffle_ps(self.w_axis, self.w_axis, 0b00_01_01_10);
             let swp2c = _mm_shuffle_ps(self.z_axis, self.z_axis, 0b00_00_01_10);
             let swp3c = _mm_shuffle_ps(self.w_axis, self.w_axis, 0b01_10_00_00);
 

--- a/src/core/wasm32/matrix.rs
+++ b/src/core/wasm32/matrix.rs
@@ -269,7 +269,7 @@ impl Matrix4x4<f32, v128> for Columns4<v128> {
         let swp2a = i32x4_shuffle::<2, 1, 1, 0>(self.z_axis, self.z_axis);
         let swp3a = i32x4_shuffle::<3, 3, 2, 3>(self.w_axis, self.w_axis);
         let swp2b = i32x4_shuffle::<3, 3, 2, 3>(self.z_axis, self.z_axis);
-        let swp3b = i32x4_shuffle::<2, 1, 2, 0>(self.w_axis, self.w_axis);
+        let swp3b = i32x4_shuffle::<2, 1, 1, 0>(self.w_axis, self.w_axis);
         let swp2c = i32x4_shuffle::<2, 1, 0, 0>(self.z_axis, self.z_axis);
         let swp3c = i32x4_shuffle::<0, 0, 2, 1>(self.w_axis, self.w_axis);
 

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -300,6 +300,16 @@ macro_rules! impl_mat4_tests {
                 2.0 * 2.0 * 2.0,
                 $mat4::from_scale($newvec3(2.0, 2.0, 2.0)).determinant()
             );
+            assert_eq!(
+                1.0,
+                $newmat4(
+                    $newvec4(0.0, 0.0, 0.0, 1.0),
+                    $newvec4(1.0, 0.0, 0.0, 0.0),
+                    $newvec4(0.0, 0.0, 1.0, 0.0),
+                    $newvec4(0.0, 1.0, 0.0, 0.0),
+                )
+                .determinant()
+            );
         });
 
         glam_test!(test_mat4_inverse, {


### PR DESCRIPTION
This fixes #279.

There is a bug in the determinant calculation using SSE.

The code from glm was not translated correctly.