### PR TITLE
Ensure a positive dot product in `Quat::slerp`

### DIFF
--- a/src/quat.rs
+++ b/src/quat.rs
@@ -437,13 +437,6 @@ macro_rules! impl_quat_methods {
         /// When `s` is `0.0`, the result will be equal to `self`.  When `s`
         /// is `1.0`, the result will be equal to `end`.
         ///
-        /// Note that a rotation can be represented by two quaternions: `q` and
-        /// `-q`. The slerp path between `q` and `end` will be different from the
-        /// path between `-q` and `end`. One path will take the long way around and
-        /// one will take the short way. In order to correct for this, the `dot`
-        /// product between `self` and `end` should be positive. If the `dot`
-        /// product is negative, slerp between `-self` and `end`.
-        ///
         /// # Panics
         ///
         /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -280,11 +280,9 @@ macro_rules! impl_quat_tests {
             while s <= 1.0 {
                 let q0 = $quat::from_rotation_y(deg(0.0));
                 let q1 = $quat::from_rotation_y(deg(90.0));
-                assert_approx_eq!(
-                    $quat::from_rotation_y(deg(s * 90.0)),
-                    q0.slerp(q1, s),
-                    1.0e-3
-                );
+                let result = q0.slerp(q1, s);
+                assert_approx_eq!($quat::from_rotation_y(deg(s * 90.0)), result, 1.0e-3);
+                assert!(result.is_normalized());
                 s += step;
             }
         });
@@ -294,6 +292,7 @@ macro_rules! impl_quat_tests {
             let q2 = $quat::from_rotation_x(core::$t::consts::TAU);
             let s = q1.slerp(q2, 1.);
             assert!(s.is_finite());
+            assert!(s.is_normalized());
         });
 
         glam_test!(test_slerp_negative_tau, {
@@ -301,6 +300,7 @@ macro_rules! impl_quat_tests {
             let q2 = $quat::from_rotation_x(-core::$t::consts::TAU);
             let s = q1.slerp(q2, 1.);
             assert!(s.is_finite());
+            assert!(s.is_normalized());
         });
 
         glam_test!(test_slerp_pi, {
@@ -308,6 +308,7 @@ macro_rules! impl_quat_tests {
             let q2 = $quat::from_rotation_x(core::$t::consts::PI);
             let s = q1.slerp(q2, 1.);
             assert!(s.is_finite());
+            assert!(s.is_normalized());
         });
 
         glam_test!(test_slerp_negative_pi, {
@@ -315,6 +316,7 @@ macro_rules! impl_quat_tests {
             let q2 = $quat::from_rotation_x(-core::$t::consts::PI);
             let s = q1.slerp(q2, 1.);
             assert!(s.is_finite());
+            assert!(s.is_normalized());
         });
 
         glam_test!(test_fmt, {

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -289,6 +289,34 @@ macro_rules! impl_quat_tests {
             }
         });
 
+        glam_test!(test_slerp_tau, {
+            let q1 = $quat::IDENTITY;
+            let q2 = $quat::from_rotation_x(core::$t::consts::TAU);
+            let s = q1.slerp(q2, 1.);
+            assert!(s.is_finite());
+        });
+
+        glam_test!(test_slerp_negative_tau, {
+            let q1 = $quat::IDENTITY;
+            let q2 = $quat::from_rotation_x(-core::$t::consts::TAU);
+            let s = q1.slerp(q2, 1.);
+            assert!(s.is_finite());
+        });
+
+        glam_test!(test_slerp_pi, {
+            let q1 = $quat::IDENTITY;
+            let q2 = $quat::from_rotation_x(core::$t::consts::PI);
+            let s = q1.slerp(q2, 1.);
+            assert!(s.is_finite());
+        });
+
+        glam_test!(test_slerp_negative_pi, {
+            let q1 = $quat::IDENTITY;
+            let q2 = $quat::from_rotation_x(-core::$t::consts::PI);
+            let s = q1.slerp(q2, 1.);
+            assert!(s.is_finite());
+        });
+
         glam_test!(test_fmt, {
             let a = $quat::IDENTITY;
             assert_eq!(


### PR DESCRIPTION
Fixes https://github.com/bitshifter/glam-rs/issues/276.

This also has the benefit of no longer requiring the user to check
 the dot product and negating one of the quaternions if the dot
product is negative.

