### PR TITLE
added rotate

### DIFF
--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -71,14 +71,9 @@ macro_rules! impl_vec2_signed_methods {
         /// Returns `other` rotated by the angle of `self`. If `self` is normalized,
         /// then this just rotation. This is what you usually want. Otherwise,
         /// it will be like a rotation with a multiplication by `self`'s length.
-        ///
-        /// # Panics
-        ///
-        /// Will panic if `other` is not normalized when `glam_assert` is enabled.
         #[must_use]
-        #[inline]
+        #[inline(always)]
         pub fn rotate(self, other: Self) -> Self {
-            glam_assert!(other.is_normalized());
             Self::new(self.x*other.x - self.y*other.y,  self.y*other.x + self.x*other.y)
         }
     };

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -67,6 +67,20 @@ macro_rules! impl_vec2_signed_methods {
         pub fn perp_dot(self, other: $vec2) -> $t {
             self.0.perp_dot(other.0)
         }
+        
+        /// Returns `other` rotated by the angle of `self`. If `self` is normalized,
+        /// then this just rotation. This is what you usually want. Otherwise,
+        /// it will be like a rotation with a multiplication by `self`'s length.
+        ///
+        /// # Panics
+        ///
+        /// Will panic if `other` is not normalized when `glam_assert` is enabled.
+        #[must_use]
+        #[inline]
+        pub fn rotate(self, other: Self) -> Self {
+            glam_assert!(other.is_normalized());
+            Self::new(self.x*other.x - self.y*other.y,  self.y*other.x + self.x*other.y)
+        }
     };
 }
 

--- a/src/vec2.rs
+++ b/src/vec2.rs
@@ -67,14 +67,17 @@ macro_rules! impl_vec2_signed_methods {
         pub fn perp_dot(self, other: $vec2) -> $t {
             self.0.perp_dot(other.0)
         }
-        
+
         /// Returns `other` rotated by the angle of `self`. If `self` is normalized,
         /// then this just rotation. This is what you usually want. Otherwise,
         /// it will be like a rotation with a multiplication by `self`'s length.
         #[must_use]
         #[inline(always)]
         pub fn rotate(self, other: Self) -> Self {
-            Self::new(self.x*other.x - self.y*other.y,  self.y*other.x + self.x*other.y)
+            Self::new(
+                self.x * other.x - self.y * other.y,
+                self.y * other.x + self.x * other.y,
+            )
         }
     };
 }

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -673,7 +673,6 @@ macro_rules! impl_vec2_float_tests {
             );
         });
         
-        #[cfg(any(feature = "glam-assert", feature = "debug-glam-assert"))]
         glam_test!(test_rotate, {
             assert_eq!(
                 $vec2::new(0.0,1.0).rotate($vec2::new(1.0, 1.0)),

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -672,6 +672,14 @@ macro_rules! impl_vec2_float_tests {
                 $vec2::new(-0.5, 1.0)
             );
         });
+        
+        #[cfg(any(feature = "glam-assert", feature = "debug-glam-assert"))]
+        glam_test!(test_rotate, {
+            assert_eq!(
+                $vec2::new(0.0,1.0).rotate($vec2::new(1.0, 1.0)),
+                $vec2::new(-1.0, 1.0)
+            );
+        });
     };
 }
 

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -672,10 +672,10 @@ macro_rules! impl_vec2_float_tests {
                 $vec2::new(-0.5, 1.0)
             );
         });
-        
+
         glam_test!(test_rotate, {
             assert_eq!(
-                $vec2::new(0.0,1.0).rotate($vec2::new(1.0, 1.0)),
+                $vec2::new(0.0, 1.0).rotate($vec2::new(1.0, 1.0)),
                 $vec2::new(-1.0, 1.0)
             );
         });


### PR DESCRIPTION
Wondering if we should name it something else, like `turn`, since it encompasses this weird rotate-multiply operation as well if `self` isn't normalized, or in case you wanted there to also be a rotate method that normalizes self automatically. But this would be my preference.