### PR TITLE
codegen: Fix missing parameter `c` and types in `mul_add` for `fma`

### DIFF
--- a/codegen/templates/vec.rs
+++ b/codegen/templates/vec.rs
@@ -1130,7 +1130,7 @@ impl {{ self_t }} {
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         {% if is_sse2 %}
             #[cfg(target_feature = "fma")]
-            unsafe { _mm_fmadd_ps(self, b, c) }
+            unsafe { Self(_mm_fmadd_ps(self.0, a.0, b.0)) }
             #[cfg(not(target_feature = "fma"))]
         {% endif %}
         Self::new(

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -623,7 +623,7 @@ impl Vec3A {
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         #[cfg(target_feature = "fma")]
         unsafe {
-            _mm_fmadd_ps(self, b, c)
+            Self(_mm_fmadd_ps(self.0, a.0, b.0))
         }
         #[cfg(not(target_feature = "fma"))]
         Self::new(

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -603,7 +603,7 @@ impl Vec4 {
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         #[cfg(target_feature = "fma")]
         unsafe {
-            _mm_fmadd_ps(self, b, c)
+            Self(_mm_fmadd_ps(self.0, a.0, b.0))
         }
         #[cfg(not(target_feature = "fma"))]
         Self::new(


### PR DESCRIPTION
Running into a bunch of:

    error[E0425]: cannot find value `c` in this scope
       --> .cargo/registry/src/github.com-1ecc6299db9ec823/glam-0.21.0/src/f32/sse2/vec3a.rs:626:35
        |
    626 |             _mm_fmadd_ps(self, b, c)
        |                                   ^ help: a local variable with a similar name exists: `a`

And:

    error[E0308]: mismatched types
       --> .cargo/registry/src/github.com-1ecc6299db9ec823/glam-0.21.0/src/f32/sse2/vec3a.rs:626:26
        |
    626 |             _mm_fmadd_ps(self, b, c)
        |                          ^^^^ expected struct `std::arch::x86_64::__m128`, found struct `f32::sse2::vec3a::Vec3A`

On the new 0.21 release when building for a CPU with FMA, introduced by the new codegen in #294.  These are trivially fixable by updating the template.
