### PR TITLE
Add `codegen` crate to `[workspace]` to allow running with `cargo r -p codegen`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       # run clippy to verify we have no warnings
       - run: cargo fetch
       - name: cargo clippy
-        run: cargo clippy --all-features -- -D warnings
+        run: cargo clippy --workspace --all-features -- -D warnings
 
   test:
     name: Test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ If you feel any documentation could be added or improved please
 
 ## Code contributions
 
-Most of `glam`'s source code is generated. See the [codegen/README.md] on how
+Most of `glam`'s source code is generated. See the [codegen README] on how
 to modify the code templates and generate new source code.
 
 You can run some of `glam`'s test suite locally by running the
@@ -56,3 +56,4 @@ Also run `cargo fmt` and `cargo clippy` on any new code.
 [ask a question]: https://github.com/bitshifter/glam-rs/discussions/new?category=q-a
 [suggest a new feature]: https://github.com/bitshifter/glam-rs/discussions/new?category=ideas
 [ARCHITECTURE]: ARCHITECTURE.md
+[codegen README]: codegen/README.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,9 @@ harness = false
 [[bench]]
 name = "vec4"
 harness = false
+
+[workspace]
+members = [
+    "codegen",
+    "test_no_std",
+]

--- a/build_and_test_features.sh
+++ b/build_and_test_features.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # Set of features to build & test.
 FEATURE_SETS=(
@@ -19,15 +19,11 @@ rustc --version
 
 for features in "${FEATURE_SETS[@]}"
 do
-   :
-   echo cargo build --tests --no-default-features --features=\"$features\"
-   cargo build --tests --no-default-features --features="$features"
-   echo cargo test --no-default-features --features=\"$features\"
-   cargo test --no-default-features --features="$features"
+  :
+  cargo build --tests --no-default-features --features="$features"
+  cargo test --no-default-features --features="$features"
 done
 
-echo RUSTFLAGS='-C target-feature=+fma' cargo check
 RUSTFLAGS='-C target-feature=+fma' cargo check
 
-echo cargo check test_no_std
-pushd test_no_std && cargo check
+cargo check -p glam-no_std


### PR DESCRIPTION
This also makes the CI (i.e. `cargo fmt` and `cargo clippy`) pick up the crate.
