### PR TITLE
Derive PartialEq and Eq when possible

### DIFF
--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -135,7 +135,16 @@ pub const fn {{ self_t | lower }}(
 {%- else %}
 /// A {{ dim }}-dimensional vector.
 {%- endif %}
-#[derive(Clone, Copy)]
+#[derive(
+    Clone,
+    Copy,
+    {% if is_scalar %}
+    PartialEq,
+    {% if not is_float%}
+    Eq,
+    {% endif %}
+    {% endif %}
+)]
 {%- if self_t == "Vec3A" and is_scalar %}
 #[cfg_attr(not(target_arch = "spirv"), repr(align(16)))]
 {%- elif self_t == "Vec4" and is_scalar %}
@@ -1367,12 +1376,14 @@ impl Default for {{ self_t }} {
     }
 }
 
+{% if not is_scalar %}
 impl PartialEq for {{ self_t }} {
     #[inline]
     fn eq(&self, rhs: &Self) -> bool {
         self.cmpeq(*rhs).all()
     }
 }
+{% endif %}
 
 impl Div<{{ self_t }}> for {{ self_t }} {
     type Output = Self;
@@ -1847,8 +1858,6 @@ impl Neg for {{ self_t }} {
 {% endif %}
 
 {% if not is_float %}
-impl Eq for {{ self_t }} {}
-
 #[cfg(not(target_arch = "spirv"))]
 impl core::hash::Hash for {{ self_t }} {
     fn hash<H: core::hash::Hasher>(&self, state: &mut H) {

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -23,7 +23,7 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 /// better performance than the `Vec3` type.
 ///
 /// It is possible to convert between `Vec3` and `Vec3A` types using `From` trait implementations.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
@@ -720,13 +720,6 @@ impl Default for Vec3A {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for Vec3A {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -18,7 +18,7 @@ pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {
 }
 
 /// A 4-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(
     any(
         not(any(feature = "scalar-math", target_arch = "spirv")),
@@ -694,13 +694,6 @@ impl Default for Vec4 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for Vec4 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -18,7 +18,7 @@ pub const fn vec2(x: f32, y: f32) -> Vec2 {
 }
 
 /// A 2-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
@@ -648,13 +648,6 @@ impl Default for Vec2 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for Vec2 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -18,7 +18,7 @@ pub const fn vec3(x: f32, y: f32, z: f32) -> Vec3 {
 }
 
 /// A 3-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct Vec3 {
@@ -714,13 +714,6 @@ impl Default for Vec3 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for Vec3 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -18,7 +18,7 @@ pub const fn dvec2(x: f64, y: f64) -> DVec2 {
 }
 
 /// A 2-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
@@ -648,13 +648,6 @@ impl Default for DVec2 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for DVec2 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -18,7 +18,7 @@ pub const fn dvec3(x: f64, y: f64, z: f64) -> DVec3 {
 }
 
 /// A 3-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct DVec3 {
@@ -720,13 +720,6 @@ impl Default for DVec3 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for DVec3 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -18,7 +18,7 @@ pub const fn dvec4(x: f64, y: f64, z: f64, w: f64) -> DVec4 {
 }
 
 /// A 4-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
@@ -686,13 +686,6 @@ impl Default for DVec4 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for DVec4 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -14,7 +14,7 @@ pub const fn ivec2(x: i32, y: i32) -> IVec2 {
 }
 
 /// A 2-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
@@ -305,13 +305,6 @@ impl Default for IVec2 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for IVec2 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 
@@ -606,8 +599,6 @@ impl Neg for IVec2 {
         }
     }
 }
-
-impl Eq for IVec2 {}
 
 #[cfg(not(target_arch = "spirv"))]
 impl core::hash::Hash for IVec2 {

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -14,7 +14,7 @@ pub const fn ivec3(x: i32, y: i32, z: i32) -> IVec3 {
 }
 
 /// A 3-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct IVec3 {
@@ -322,13 +322,6 @@ impl Default for IVec3 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for IVec3 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 
@@ -649,8 +642,6 @@ impl Neg for IVec3 {
         }
     }
 }
-
-impl Eq for IVec3 {}
 
 #[cfg(not(target_arch = "spirv"))]
 impl core::hash::Hash for IVec3 {

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -14,7 +14,7 @@ pub const fn ivec4(x: i32, y: i32, z: i32, w: i32) -> IVec4 {
 }
 
 /// A 4-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
@@ -341,13 +341,6 @@ impl Default for IVec4 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for IVec4 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 
@@ -694,8 +687,6 @@ impl Neg for IVec4 {
         }
     }
 }
-
-impl Eq for IVec4 {}
 
 #[cfg(not(target_arch = "spirv"))]
 impl core::hash::Hash for IVec4 {

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -14,7 +14,7 @@ pub const fn uvec2(x: u32, y: u32) -> UVec2 {
 }
 
 /// A 2-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
@@ -243,13 +243,6 @@ impl Default for UVec2 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for UVec2 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 
@@ -533,8 +526,6 @@ impl<'a> Product<&'a Self> for UVec2 {
         iter.fold(Self::ONE, |a, &b| Self::mul(a, b))
     }
 }
-
-impl Eq for UVec2 {}
 
 #[cfg(not(target_arch = "spirv"))]
 impl core::hash::Hash for UVec2 {

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -14,7 +14,7 @@ pub const fn uvec3(x: u32, y: u32, z: u32) -> UVec3 {
 }
 
 /// A 3-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct UVec3 {
@@ -286,13 +286,6 @@ impl Default for UVec3 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for UVec3 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 
@@ -601,8 +594,6 @@ impl<'a> Product<&'a Self> for UVec3 {
         iter.fold(Self::ONE, |a, &b| Self::mul(a, b))
     }
 }
-
-impl Eq for UVec3 {}
 
 #[cfg(not(target_arch = "spirv"))]
 impl core::hash::Hash for UVec3 {

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -14,7 +14,7 @@ pub const fn uvec4(x: u32, y: u32, z: u32, w: u32) -> UVec4 {
 }
 
 /// A 4-dimensional vector.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
@@ -300,13 +300,6 @@ impl Default for UVec4 {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
-    }
-}
-
-impl PartialEq for UVec4 {
-    #[inline]
-    fn eq(&self, rhs: &Self) -> bool {
-        self.cmpeq(*rhs).all()
     }
 }
 
@@ -640,8 +633,6 @@ impl<'a> Product<&'a Self> for UVec4 {
         iter.fold(Self::ONE, |a, &b| Self::mul(a, b))
     }
 }
-
-impl Eq for UVec4 {}
 
 #[cfg(not(target_arch = "spirv"))]
 impl core::hash::Hash for UVec4 {


### PR DESCRIPTION
This PR derives the `PartialEq` and `Eq` trait when possible, instead of always implementing them. This is so that the integer vector types can be used as a constant generic - Rust requires const generic params to derive `Eq` and `PartialEq` in the unstable `adt_const_params` feature.