### PR TITLE
Simd quickfix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,19 +40,19 @@ jobs:
       - run: ./build_and_test_features.sh
         shell: bash
 
-#  test-core-simd:
-#    name: Test portable simd
-#    strategy:
-#      matrix:
-#        os: [ubuntu-latest, macos-latest, windows-latest]
-#        toolchain: [nightly]
-#    runs-on: ${{ matrix.os }}
-#    steps:
-#      - uses: actions/checkout@v2
-#      - run: rustup update --no-self-update ${{ matrix.toolchain }}
-#      - run: rustup default ${{ matrix.toolchain }}
-#      - run: cargo test --features core-simd
-#        shell: bash
+  test-core-simd:
+    name: Test portable simd
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        toolchain: [nightly]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup update --no-self-update ${{ matrix.toolchain }}
+      - run: rustup default ${{ matrix.toolchain }}
+      - run: cargo test --features core-simd
+        shell: bash
 
   test-wasm:
     name: Test wasm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 ### Added
 
 * Added experimental `core-simd` feature which enables SIMD support via the
-  unstable `core::simd` module. Already broken due to changes on nightly.
+  unstable `core::simd` module.
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,8 +41,7 @@ cuda = []
 # the end binary build instead.
 fast-math = []
 
-# experimental nightly portable-simd support. This is currently broken due to
-# f32 min and max being removed on nightly
+# experimental nightly portable-simd support
 core-simd = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -54,9 +54,13 @@ SIMD is supported on `x86`, `x86_64` and `wasm32` targets.
   `RUSTCFLAGS`.
 * To enable `simd128` on `wasm32` targets add `-C target-feature=+simd128` to
   `RUSTFLAGS`.
+* Experimental [portable simd] support can be enabled with the `core-simd`
+  feature. This requires the nightly compiler as it is still unstable in Rust.
 
 Note that SIMD on `wasm32` passes tests but has not been benchmarked,
 performance may or may not be better than scalar math.
+
+[portable simd]: https://doc.rust-lang.org/core/simd/index.html
 
 ### `no_std` support
 
@@ -123,6 +127,8 @@ glam = { version = "0.21", default-features = false }
   optimizations that may not be identical to other platforms. **Intermediate
   libraries should not use this feature and defer the decision to the final
   binary build**.
+* `core-simd` - enables SIMD support via the [portable simd] module. This is an
+  unstable feature which requires a nightly Rust toolchain and `std` support.
 
 [cuda alignment]: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#built-in-vector-types
 

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -284,7 +284,7 @@ impl {{ self_t }} {
                 {% endfor %}
             }
         {% elif is_coresimd %}
-            Self(f32x4::splat(v))
+            Self(Simd::from_array([v; 4]))
         {% else %}
             unsafe { UnionCast { a: [v; 4] }.v }
         {% endif %}
@@ -488,7 +488,7 @@ impl {{ self_t }} {
         {% elif is_wasm32 %}
             Self(f32x4_pmin(self.0, rhs.0))
         {% elif is_coresimd %}
-            Self(self.0.min(rhs.0))
+            Self(self.0.simd_min(rhs.0))
         {% endif %}
     }
 
@@ -508,7 +508,7 @@ impl {{ self_t }} {
         {% elif is_wasm32 %}
             Self(f32x4_pmax(self.0, rhs.0))
         {% elif is_coresimd %}
-            Self(self.0.max(rhs.0))
+            Self(self.0.simd_max(rhs.0))
         {% endif %}
     }
 
@@ -569,8 +569,8 @@ impl {{ self_t }} {
         {% elif is_coresimd %}
             {% if dim == 3 %}
                 let v = self.0;
-                let v = v.min(simd_swizzle!(v, [2, 2, 1, 1]));
-                let v = v.min(simd_swizzle!(v, [1, 0, 0, 0]));
+                let v = v.simd_min(simd_swizzle!(v, [2, 2, 1, 1]));
+                let v = v.simd_min(simd_swizzle!(v, [1, 0, 0, 0]));
                 v[0]
             {% elif dim == 4 %}
                 self.0.reduce_min()
@@ -622,8 +622,8 @@ impl {{ self_t }} {
         {% elif is_coresimd %}
             {% if dim == 3 %}
                 let v = self.0;
-                let v = v.max(simd_swizzle!(v, [2, 2, 0, 0]));
-                let v = v.max(simd_swizzle!(v, [1, 0, 0, 0]));
+                let v = v.simd_max(simd_swizzle!(v, [2, 2, 0, 0]));
+                let v = v.simd_max(simd_swizzle!(v, [1, 0, 0, 0]));
                 v[0]
             {% elif dim == 4 %}
                 self.0.reduce_max()
@@ -649,7 +649,7 @@ impl {{ self_t }} {
         {% elif is_wasm32 %}
             {{ mask_t }}(f32x4_eq(self.0, rhs.0))
         {% elif is_coresimd %}
-            {{ mask_t }}(f32x4::lanes_eq(self.0, rhs.0))
+            {{ mask_t }}(f32x4::simd_eq(self.0, rhs.0))
         {% endif %}
     }
 
@@ -671,7 +671,7 @@ impl {{ self_t }} {
         {% elif is_wasm32 %}
             {{ mask_t }}(f32x4_ne(self.0, rhs.0))
         {% elif is_coresimd %}
-            {{ mask_t }}(f32x4::lanes_ne(self.0, rhs.0))
+            {{ mask_t }}(f32x4::simd_ne(self.0, rhs.0))
         {% endif %}
     }
 
@@ -693,7 +693,7 @@ impl {{ self_t }} {
         {% elif is_wasm32 %}
             {{ mask_t }}(f32x4_ge(self.0, rhs.0))
         {% elif is_coresimd %}
-            {{ mask_t }}(f32x4::lanes_ge(self.0, rhs.0))
+            {{ mask_t }}(f32x4::simd_ge(self.0, rhs.0))
         {% endif %}
     }
 
@@ -715,7 +715,7 @@ impl {{ self_t }} {
         {% elif is_wasm32 %}
             {{ mask_t }}(f32x4_gt(self.0, rhs.0))
         {% elif is_coresimd %}
-            {{ mask_t }}(f32x4::lanes_gt(self.0, rhs.0))
+            {{ mask_t }}(f32x4::simd_gt(self.0, rhs.0))
         {% endif %}
     }
 
@@ -737,7 +737,7 @@ impl {{ self_t }} {
         {% elif is_wasm32 %}
             {{ mask_t }}(f32x4_le(self.0, rhs.0))
         {% elif is_coresimd %}
-            {{ mask_t }}(f32x4::lanes_le(self.0, rhs.0))
+            {{ mask_t }}(f32x4::simd_le(self.0, rhs.0))
         {% endif %}
     }
 
@@ -759,7 +759,7 @@ impl {{ self_t }} {
         {% elif is_wasm32 %}
             {{ mask_t }}(f32x4_lt(self.0, rhs.0))
         {% elif is_coresimd %}
-            {{ mask_t }}(f32x4::lanes_lt(self.0, rhs.0))
+            {{ mask_t }}(f32x4::simd_lt(self.0, rhs.0))
         {% endif %}
     }
 

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -32,16 +32,16 @@ pub struct Vec3A(pub(crate) f32x4);
 
 impl Vec3A {
     /// All zeroes.
-    pub const ZERO: Self = Self::splat(0.0);
+    pub const ZERO: Self = Self(Simd::from_array([0.0; 4]));
 
     /// All ones.
-    pub const ONE: Self = Self::splat(1.0);
+    pub const ONE: Self = Self(Simd::from_array([1.0; 4]));
 
     /// All negative ones.
-    pub const NEG_ONE: Self = Self::splat(-1.0);
+    pub const NEG_ONE: Self = Self(Simd::from_array([-1.0; 4]));
 
     /// All NAN.
-    pub const NAN: Self = Self::splat(f32::NAN);
+    pub const NAN: Self = Self(Simd::from_array([f32::NAN; 4]));
 
     /// A unit-length vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
@@ -73,7 +73,7 @@ impl Vec3A {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: f32) -> Self {
-        Self(f32x4::splat(v))
+        Self(Simd::from_array([v; 4]))
     }
 
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
@@ -164,7 +164,7 @@ impl Vec3A {
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
     pub fn min(self, rhs: Self) -> Self {
-        Self(self.0.min(rhs.0))
+        Self(self.0.simd_min(rhs.0))
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -172,7 +172,7 @@ impl Vec3A {
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
     pub fn max(self, rhs: Self) -> Self {
-        Self(self.0.max(rhs.0))
+        Self(self.0.simd_max(rhs.0))
     }
 
     /// Component-wise clamping of values, similar to [`f32::clamp`].
@@ -194,8 +194,8 @@ impl Vec3A {
     #[inline]
     pub fn min_element(self) -> f32 {
         let v = self.0;
-        let v = v.min(simd_swizzle!(v, [2, 2, 1, 1]));
-        let v = v.min(simd_swizzle!(v, [1, 0, 0, 0]));
+        let v = v.simd_min(simd_swizzle!(v, [2, 2, 1, 1]));
+        let v = v.simd_min(simd_swizzle!(v, [1, 0, 0, 0]));
         v[0]
     }
 
@@ -205,8 +205,8 @@ impl Vec3A {
     #[inline]
     pub fn max_element(self) -> f32 {
         let v = self.0;
-        let v = v.max(simd_swizzle!(v, [2, 2, 0, 0]));
-        let v = v.max(simd_swizzle!(v, [1, 0, 0, 0]));
+        let v = v.simd_max(simd_swizzle!(v, [2, 2, 0, 0]));
+        let v = v.simd_max(simd_swizzle!(v, [1, 0, 0, 0]));
         v[0]
     }
 
@@ -217,7 +217,7 @@ impl Vec3A {
     /// elements.
     #[inline]
     pub fn cmpeq(self, rhs: Self) -> BVec3A {
-        BVec3A(f32x4::lanes_eq(self.0, rhs.0))
+        BVec3A(f32x4::simd_eq(self.0, rhs.0))
     }
 
     /// Returns a vector mask containing the result of a `!=` comparison for each element of
@@ -227,7 +227,7 @@ impl Vec3A {
     /// elements.
     #[inline]
     pub fn cmpne(self, rhs: Self) -> BVec3A {
-        BVec3A(f32x4::lanes_ne(self.0, rhs.0))
+        BVec3A(f32x4::simd_ne(self.0, rhs.0))
     }
 
     /// Returns a vector mask containing the result of a `>=` comparison for each element of
@@ -237,7 +237,7 @@ impl Vec3A {
     /// elements.
     #[inline]
     pub fn cmpge(self, rhs: Self) -> BVec3A {
-        BVec3A(f32x4::lanes_ge(self.0, rhs.0))
+        BVec3A(f32x4::simd_ge(self.0, rhs.0))
     }
 
     /// Returns a vector mask containing the result of a `>` comparison for each element of
@@ -247,7 +247,7 @@ impl Vec3A {
     /// elements.
     #[inline]
     pub fn cmpgt(self, rhs: Self) -> BVec3A {
-        BVec3A(f32x4::lanes_gt(self.0, rhs.0))
+        BVec3A(f32x4::simd_gt(self.0, rhs.0))
     }
 
     /// Returns a vector mask containing the result of a `<=` comparison for each element of
@@ -257,7 +257,7 @@ impl Vec3A {
     /// elements.
     #[inline]
     pub fn cmple(self, rhs: Self) -> BVec3A {
-        BVec3A(f32x4::lanes_le(self.0, rhs.0))
+        BVec3A(f32x4::simd_le(self.0, rhs.0))
     }
 
     /// Returns a vector mask containing the result of a `<` comparison for each element of
@@ -267,7 +267,7 @@ impl Vec3A {
     /// elements.
     #[inline]
     pub fn cmplt(self, rhs: Self) -> BVec3A {
-        BVec3A(f32x4::lanes_lt(self.0, rhs.0))
+        BVec3A(f32x4::simd_lt(self.0, rhs.0))
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -32,16 +32,16 @@ pub struct Vec3A(pub(crate) f32x4);
 
 impl Vec3A {
     /// All zeroes.
-    pub const ZERO: Self = Self(Simd::from_array([0.0; 4]));
+    pub const ZERO: Self = Self::splat(0.0);
 
     /// All ones.
-    pub const ONE: Self = Self(Simd::from_array([1.0; 4]));
+    pub const ONE: Self = Self::splat(1.0);
 
     /// All negative ones.
-    pub const NEG_ONE: Self = Self(Simd::from_array([-1.0; 4]));
+    pub const NEG_ONE: Self = Self::splat(-1.0);
 
     /// All NAN.
-    pub const NAN: Self = Self(Simd::from_array([f32::NAN; 4]));
+    pub const NAN: Self = Self::splat(f32::NAN);
 
     /// A unit-length vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -29,16 +29,16 @@ pub struct Vec4(pub(crate) f32x4);
 
 impl Vec4 {
     /// All zeroes.
-    pub const ZERO: Self = Self(Simd::from_array([0.0; 4]));
+    pub const ZERO: Self = Self::splat(0.0);
 
     /// All ones.
-    pub const ONE: Self = Self(Simd::from_array([1.0; 4]));
+    pub const ONE: Self = Self::splat(1.0);
 
     /// All negative ones.
-    pub const NEG_ONE: Self = Self(Simd::from_array([-1.0; 4]));
+    pub const NEG_ONE: Self = Self::splat(-1.0);
 
     /// All NAN.
-    pub const NAN: Self = Self(Simd::from_array([f32::NAN; 4]));
+    pub const NAN: Self = Self::splat(f32::NAN);
 
     /// A unit-length vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -29,16 +29,16 @@ pub struct Vec4(pub(crate) f32x4);
 
 impl Vec4 {
     /// All zeroes.
-    pub const ZERO: Self = Self::splat(0.0);
+    pub const ZERO: Self = Self(Simd::from_array([0.0; 4]));
 
     /// All ones.
-    pub const ONE: Self = Self::splat(1.0);
+    pub const ONE: Self = Self(Simd::from_array([1.0; 4]));
 
     /// All negative ones.
-    pub const NEG_ONE: Self = Self::splat(-1.0);
+    pub const NEG_ONE: Self = Self(Simd::from_array([-1.0; 4]));
 
     /// All NAN.
-    pub const NAN: Self = Self::splat(f32::NAN);
+    pub const NAN: Self = Self(Simd::from_array([f32::NAN; 4]));
 
     /// A unit-length vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
@@ -76,7 +76,7 @@ impl Vec4 {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: f32) -> Self {
-        Self(f32x4::splat(v))
+        Self(Simd::from_array([v; 4]))
     }
 
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
@@ -146,7 +146,7 @@ impl Vec4 {
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
     pub fn min(self, rhs: Self) -> Self {
-        Self(self.0.min(rhs.0))
+        Self(self.0.simd_min(rhs.0))
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -154,7 +154,7 @@ impl Vec4 {
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
     pub fn max(self, rhs: Self) -> Self {
-        Self(self.0.max(rhs.0))
+        Self(self.0.simd_max(rhs.0))
     }
 
     /// Component-wise clamping of values, similar to [`f32::clamp`].
@@ -193,7 +193,7 @@ impl Vec4 {
     /// elements.
     #[inline]
     pub fn cmpeq(self, rhs: Self) -> BVec4A {
-        BVec4A(f32x4::lanes_eq(self.0, rhs.0))
+        BVec4A(f32x4::simd_eq(self.0, rhs.0))
     }
 
     /// Returns a vector mask containing the result of a `!=` comparison for each element of
@@ -203,7 +203,7 @@ impl Vec4 {
     /// elements.
     #[inline]
     pub fn cmpne(self, rhs: Self) -> BVec4A {
-        BVec4A(f32x4::lanes_ne(self.0, rhs.0))
+        BVec4A(f32x4::simd_ne(self.0, rhs.0))
     }
 
     /// Returns a vector mask containing the result of a `>=` comparison for each element of
@@ -213,7 +213,7 @@ impl Vec4 {
     /// elements.
     #[inline]
     pub fn cmpge(self, rhs: Self) -> BVec4A {
-        BVec4A(f32x4::lanes_ge(self.0, rhs.0))
+        BVec4A(f32x4::simd_ge(self.0, rhs.0))
     }
 
     /// Returns a vector mask containing the result of a `>` comparison for each element of
@@ -223,7 +223,7 @@ impl Vec4 {
     /// elements.
     #[inline]
     pub fn cmpgt(self, rhs: Self) -> BVec4A {
-        BVec4A(f32x4::lanes_gt(self.0, rhs.0))
+        BVec4A(f32x4::simd_gt(self.0, rhs.0))
     }
 
     /// Returns a vector mask containing the result of a `<=` comparison for each element of
@@ -233,7 +233,7 @@ impl Vec4 {
     /// elements.
     #[inline]
     pub fn cmple(self, rhs: Self) -> BVec4A {
-        BVec4A(f32x4::lanes_le(self.0, rhs.0))
+        BVec4A(f32x4::simd_le(self.0, rhs.0))
     }
 
     /// Returns a vector mask containing the result of a `<` comparison for each element of
@@ -243,7 +243,7 @@ impl Vec4 {
     /// elements.
     #[inline]
     pub fn cmplt(self, rhs: Self) -> BVec4A {
-        BVec4A(f32x4::lanes_lt(self.0, rhs.0))
+        BVec4A(f32x4::simd_lt(self.0, rhs.0))
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.


### PR DESCRIPTION
- reverts your commit that removed support for std::simd from tests and readme
- updates std::simd API usage to the most recent:
  - simd_* instead of lanes_*
  - simd_min and simd_max instead of min for vertical min/max
  - splat is no longer const but there is a work around with `Simd::from_array` 

Passes:
```{bash}
$ cargo test --features core-simd
... elided ...
test result: ok. 204 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.01s

   Doc-tests glam

running 5 tests
test src/lib.rs - (line 115) ... ok
test src/lib.rs - (line 133) ... ok
test src/lib.rs - (line 64) ... ok
test src/lib.rs - (line 165) ... ok
test src/lib.rs - (line 202) ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s
```

Please verify on your machine before merging.