### PR TITLE
Make from_diagonal a const fn

### DIFF
--- a/codegen/templates/mat.rs.tera
+++ b/codegen/templates/mat.rs.tera
@@ -334,11 +334,30 @@ impl {{ self_t }} {
             {%- endfor %}
         ]
     }
-
+{% if dim == 4 and vecn_t != "DVec4" %}
     /// Creates a {{ nxn }} matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: {{ vecn_t }}) -> Self {
+    pub const fn from_diagonal(diagonal: {{ vecn_t }}) -> Self {
+        // diagonal.x, diagonal.y etc can't be done in a const-context
+        let [x, y, z, w] = diagonal.to_array();
+        Self::new(
+            {% for i in range(end = dim) %}
+                {% for j in range(end = dim) %}
+                    {% if i == j %}
+                        {{ components[i] }},
+                    {% else %}
+                        0.0,
+                    {% endif %}
+                {%- endfor %}
+            {%- endfor %}
+        )
+    }
+{% else %}
+    /// Creates a {{ nxn }} matrix with its diagonal set to `diagonal` and all other entries set to 0.
+    #[doc(alias = "scale")]
+    #[inline]
+    pub const fn from_diagonal(diagonal: {{ vecn_t }}) -> Self {
         Self::new(
             {% for i in range(end = dim) %}
                 {% for j in range(end = dim) %}
@@ -351,6 +370,7 @@ impl {{ self_t }} {
             {%- endfor %}
         )
     }
+{% endif %}
 
 {% if dim == 2 %}
     /// Creates a {{ nxn }} matrix containing the combining non-uniform `scale` and rotation of

--- a/src/f32/coresimd/mat2.rs
+++ b/src/f32/coresimd/mat2.rs
@@ -78,7 +78,7 @@ impl Mat2 {
     /// Creates a 2x2 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec2) -> Self {
+    pub const fn from_diagonal(diagonal: Vec2) -> Self {
         Self::new(diagonal.x, 0.0, 0.0, diagonal.y)
     }
 

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -141,7 +141,7 @@ impl Mat3A {
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec3) -> Self {
+    pub const fn from_diagonal(diagonal: Vec3) -> Self {
         Self::new(
             diagonal.x, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, diagonal.z,
         )

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -168,7 +168,7 @@ impl Mat4 {
     /// Creates a 4x4 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec4) -> Self {
+    pub const fn from_diagonal(diagonal: Vec4) -> Self {
         Self::new(
             diagonal.x, 0.0, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, 0.0, diagonal.z, 0.0, 0.0,
             0.0, 0.0, diagonal.w,

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -169,9 +169,10 @@ impl Mat4 {
     #[doc(alias = "scale")]
     #[inline]
     pub const fn from_diagonal(diagonal: Vec4) -> Self {
+        // diagonal.x, diagonal.y etc can't be done in a const-context
+        let [x, y, z, w] = diagonal.to_array();
         Self::new(
-            diagonal.x, 0.0, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, 0.0, diagonal.z, 0.0, 0.0,
-            0.0, 0.0, diagonal.w,
+            x, 0.0, 0.0, 0.0, 0.0, y, 0.0, 0.0, 0.0, 0.0, z, 0.0, 0.0, 0.0, 0.0, w,
         )
     }
 

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -139,7 +139,7 @@ impl Mat3 {
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec3) -> Self {
+    pub const fn from_diagonal(diagonal: Vec3) -> Self {
         Self::new(
             diagonal.x, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, diagonal.z,
         )

--- a/src/f32/scalar/mat2.rs
+++ b/src/f32/scalar/mat2.rs
@@ -87,7 +87,7 @@ impl Mat2 {
     /// Creates a 2x2 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec2) -> Self {
+    pub const fn from_diagonal(diagonal: Vec2) -> Self {
         Self::new(diagonal.x, 0.0, 0.0, diagonal.y)
     }
 

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -139,7 +139,7 @@ impl Mat3A {
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec3) -> Self {
+    pub const fn from_diagonal(diagonal: Vec3) -> Self {
         Self::new(
             diagonal.x, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, diagonal.z,
         )

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -174,9 +174,10 @@ impl Mat4 {
     #[doc(alias = "scale")]
     #[inline]
     pub const fn from_diagonal(diagonal: Vec4) -> Self {
+        // diagonal.x, diagonal.y etc can't be done in a const-context
+        let [x, y, z, w] = diagonal.to_array();
         Self::new(
-            diagonal.x, 0.0, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, 0.0, diagonal.z, 0.0, 0.0,
-            0.0, 0.0, diagonal.w,
+            x, 0.0, 0.0, 0.0, 0.0, y, 0.0, 0.0, 0.0, 0.0, z, 0.0, 0.0, 0.0, 0.0, w,
         )
     }
 

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -173,7 +173,7 @@ impl Mat4 {
     /// Creates a 4x4 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec4) -> Self {
+    pub const fn from_diagonal(diagonal: Vec4) -> Self {
         Self::new(
             diagonal.x, 0.0, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, 0.0, diagonal.z, 0.0, 0.0,
             0.0, 0.0, diagonal.w,

--- a/src/f32/sse2/mat2.rs
+++ b/src/f32/sse2/mat2.rs
@@ -96,7 +96,7 @@ impl Mat2 {
     /// Creates a 2x2 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec2) -> Self {
+    pub const fn from_diagonal(diagonal: Vec2) -> Self {
         Self::new(diagonal.x, 0.0, 0.0, diagonal.y)
     }
 

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -144,7 +144,7 @@ impl Mat3A {
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec3) -> Self {
+    pub const fn from_diagonal(diagonal: Vec3) -> Self {
         Self::new(
             diagonal.x, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, diagonal.z,
         )

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -175,8 +175,7 @@ impl Mat4 {
         // diagonal.x, diagonal.y etc can't be done in a const-context
         let [x, y, z, w] = diagonal.to_array();
         Self::new(
-            x, 0.0, 0.0, 0.0, 0.0, y, 0.0, 0.0, 0.0, 0.0, z, 0.0, 0.0,
-            0.0, 0.0, w,
+            x, 0.0, 0.0, 0.0, 0.0, y, 0.0, 0.0, 0.0, 0.0, z, 0.0, 0.0, 0.0, 0.0, w,
         )
     }
 

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -171,10 +171,12 @@ impl Mat4 {
     /// Creates a 4x4 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec4) -> Self {
+    pub const fn from_diagonal(diagonal: Vec4) -> Self {
+        // diagonal.x, diagonal.y etc can't be done in a const-context
+        let [x, y, z, w] = diagonal.to_array();
         Self::new(
-            diagonal.x, 0.0, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, 0.0, diagonal.z, 0.0, 0.0,
-            0.0, 0.0, diagonal.w,
+            x, 0.0, 0.0, 0.0, 0.0, y, 0.0, 0.0, 0.0, 0.0, z, 0.0, 0.0,
+            0.0, 0.0, w,
         )
     }
 

--- a/src/f32/wasm32/mat2.rs
+++ b/src/f32/wasm32/mat2.rs
@@ -78,7 +78,7 @@ impl Mat2 {
     /// Creates a 2x2 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec2) -> Self {
+    pub const fn from_diagonal(diagonal: Vec2) -> Self {
         Self::new(diagonal.x, 0.0, 0.0, diagonal.y)
     }
 

--- a/src/f32/wasm32/mat3a.rs
+++ b/src/f32/wasm32/mat3a.rs
@@ -141,7 +141,7 @@ impl Mat3A {
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec3) -> Self {
+    pub const fn from_diagonal(diagonal: Vec3) -> Self {
         Self::new(
             diagonal.x, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, diagonal.z,
         )

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -168,7 +168,7 @@ impl Mat4 {
     /// Creates a 4x4 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: Vec4) -> Self {
+    pub const fn from_diagonal(diagonal: Vec4) -> Self {
         Self::new(
             diagonal.x, 0.0, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, 0.0, diagonal.z, 0.0, 0.0,
             0.0, 0.0, diagonal.w,

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -169,9 +169,10 @@ impl Mat4 {
     #[doc(alias = "scale")]
     #[inline]
     pub const fn from_diagonal(diagonal: Vec4) -> Self {
+        // diagonal.x, diagonal.y etc can't be done in a const-context
+        let [x, y, z, w] = diagonal.to_array();
         Self::new(
-            diagonal.x, 0.0, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, 0.0, diagonal.z, 0.0, 0.0,
-            0.0, 0.0, diagonal.w,
+            x, 0.0, 0.0, 0.0, 0.0, y, 0.0, 0.0, 0.0, 0.0, z, 0.0, 0.0, 0.0, 0.0, w,
         )
     }
 

--- a/src/f64/dmat2.rs
+++ b/src/f64/dmat2.rs
@@ -83,7 +83,7 @@ impl DMat2 {
     /// Creates a 2x2 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: DVec2) -> Self {
+    pub const fn from_diagonal(diagonal: DVec2) -> Self {
         Self::new(diagonal.x, 0.0, 0.0, diagonal.y)
     }
 

--- a/src/f64/dmat3.rs
+++ b/src/f64/dmat3.rs
@@ -139,7 +139,7 @@ impl DMat3 {
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: DVec3) -> Self {
+    pub const fn from_diagonal(diagonal: DVec3) -> Self {
         Self::new(
             diagonal.x, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, diagonal.z,
         )

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -167,7 +167,7 @@ impl DMat4 {
     /// Creates a 4x4 matrix with its diagonal set to `diagonal` and all other entries set to 0.
     #[doc(alias = "scale")]
     #[inline]
-    pub fn from_diagonal(diagonal: DVec4) -> Self {
+    pub const fn from_diagonal(diagonal: DVec4) -> Self {
         Self::new(
             diagonal.x, 0.0, 0.0, 0.0, 0.0, diagonal.y, 0.0, 0.0, 0.0, 0.0, diagonal.z, 0.0, 0.0,
             0.0, 0.0, diagonal.w,


### PR DESCRIPTION
First PR! I was unsure if I should update all references outside of `src/` so I didn't.

The one oddity is `src/f32/sse2/mat4.rs`'s `from_diagonal`. I had to get the x/y/z/w via `let [x, y, z, w] = diagonal.to_array();` because I found `diagonal.x`, `diagonal.y`, etc can't be done in a const contexts for SIMD-enabled vectors like `Vec3A` and `Vec4`.

I ran `build_and_test_features.sh` and there were no errors over the various tests.