### PR TITLE
Add BVec::splat

### DIFF
--- a/codegen/templates/vec_mask.rs.tera
+++ b/codegen/templates/vec_mask.rs.tera
@@ -125,7 +125,49 @@ impl {{ self_t }} {
         {% endif %}
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        {% if is_scalar and is_bool %}
+            Self {
+                {% for c in components %}
+                    {{ c }}: v,
+                {%- endfor %}
+            }
+        {% elif is_scalar and is_u32 %}
+            Self {
+                {% for c in components %}
+                    {{ c }}: MASK[v as usize],
+                {%- endfor %}
+            }
+        {% elif is_sse2 or is_coresimd %}
+            unsafe {
+                UnionCast { a: [
+                    MASK[v as usize],
+                    MASK[v as usize],
+                    MASK[v as usize],
+                    {% if dim == 3 %}
+                        0,
+                    {% elif dim == 4 %}
+                        MASK[v as usize],
+                    {% endif %}
+                ] }.v
+            }
+        {% elif is_wasm32 %}
+            Self(u32x4(
+                MASK[v as usize],
+                MASK[v as usize],
+                MASK[v as usize],
+                {% if dim == 3 %}
+                    0,
+                {% elif dim == 4 %}
+                    MASK[v as usize],
+                {% endif %}
+            ))
+        {% endif %}
+    }
+
+    /// Returns a bitmask with the lowest {{ dim }} bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/codegen/templates/vec_mask.rs.tera
+++ b/codegen/templates/vec_mask.rs.tera
@@ -128,43 +128,11 @@ impl {{ self_t }} {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        {% if is_scalar and is_bool %}
-            Self {
-                {% for c in components %}
-                    {{ c }}: v,
-                {%- endfor %}
-            }
-        {% elif is_scalar and is_u32 %}
-            Self {
-                {% for c in components %}
-                    {{ c }}: MASK[v as usize],
-                {%- endfor %}
-            }
-        {% elif is_sse2 or is_coresimd %}
-            unsafe {
-                UnionCast { a: [
-                    MASK[v as usize],
-                    MASK[v as usize],
-                    MASK[v as usize],
-                    {% if dim == 3 %}
-                        0,
-                    {% elif dim == 4 %}
-                        MASK[v as usize],
-                    {% endif %}
-                ] }.v
-            }
-        {% elif is_wasm32 %}
-            Self(u32x4(
-                MASK[v as usize],
-                MASK[v as usize],
-                MASK[v as usize],
-                {% if dim == 3 %}
-                    0,
-                {% elif dim == 4 %}
-                    MASK[v as usize],
-                {% endif %}
-            ))
-        {% endif %}
+        Self::new(
+            {% for c in components %}
+                v,
+            {%- endfor %}
+        )
     }
 
     /// Returns a bitmask with the lowest {{ dim }} bits set from the elements of `self`.

--- a/src/bool/bvec2.rs
+++ b/src/bool/bvec2.rs
@@ -23,7 +23,13 @@ impl BVec2 {
         Self { x, y }
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        Self { x: v, y: v }
+    }
+
+    /// Returns a bitmask with the lowest 2 bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/src/bool/bvec2.rs
+++ b/src/bool/bvec2.rs
@@ -26,7 +26,7 @@ impl BVec2 {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a bitmask with the lowest 2 bits set from the elements of `self`.

--- a/src/bool/bvec3.rs
+++ b/src/bool/bvec3.rs
@@ -24,7 +24,13 @@ impl BVec3 {
         Self { x, y, z }
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        Self { x: v, y: v, z: v }
+    }
+
+    /// Returns a bitmask with the lowest 3 bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/src/bool/bvec3.rs
+++ b/src/bool/bvec3.rs
@@ -27,7 +27,7 @@ impl BVec3 {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a bitmask with the lowest 3 bits set from the elements of `self`.

--- a/src/bool/bvec4.rs
+++ b/src/bool/bvec4.rs
@@ -25,7 +25,18 @@ impl BVec4 {
         Self { x, y, z, w }
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        Self {
+            x: v,
+            y: v,
+            z: v,
+            w: v,
+        }
+    }
+
+    /// Returns a bitmask with the lowest 4 bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/src/bool/bvec4.rs
+++ b/src/bool/bvec4.rs
@@ -28,12 +28,7 @@ impl BVec4 {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        Self {
-            x: v,
-            y: v,
-            z: v,
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a bitmask with the lowest 4 bits set from the elements of `self`.

--- a/src/bool/coresimd/bvec3a.rs
+++ b/src/bool/coresimd/bvec3a.rs
@@ -35,7 +35,18 @@ impl BVec3A {
         }
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        unsafe {
+            UnionCast {
+                a: [MASK[v as usize], MASK[v as usize], MASK[v as usize], 0],
+            }
+            .v
+        }
+    }
+
+    /// Returns a bitmask with the lowest 3 bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/src/bool/coresimd/bvec3a.rs
+++ b/src/bool/coresimd/bvec3a.rs
@@ -38,12 +38,7 @@ impl BVec3A {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        unsafe {
-            UnionCast {
-                a: [MASK[v as usize], MASK[v as usize], MASK[v as usize], 0],
-            }
-            .v
-        }
+        Self::new(v, v, v)
     }
 
     /// Returns a bitmask with the lowest 3 bits set from the elements of `self`.

--- a/src/bool/coresimd/bvec4a.rs
+++ b/src/bool/coresimd/bvec4a.rs
@@ -40,7 +40,23 @@ impl BVec4A {
         }
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        unsafe {
+            UnionCast {
+                a: [
+                    MASK[v as usize],
+                    MASK[v as usize],
+                    MASK[v as usize],
+                    MASK[v as usize],
+                ],
+            }
+            .v
+        }
+    }
+
+    /// Returns a bitmask with the lowest 4 bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/src/bool/coresimd/bvec4a.rs
+++ b/src/bool/coresimd/bvec4a.rs
@@ -43,17 +43,7 @@ impl BVec4A {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        unsafe {
-            UnionCast {
-                a: [
-                    MASK[v as usize],
-                    MASK[v as usize],
-                    MASK[v as usize],
-                    MASK[v as usize],
-                ],
-            }
-            .v
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a bitmask with the lowest 4 bits set from the elements of `self`.

--- a/src/bool/scalar/bvec3a.rs
+++ b/src/bool/scalar/bvec3a.rs
@@ -28,7 +28,17 @@ impl BVec3A {
         }
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        Self {
+            x: MASK[v as usize],
+            y: MASK[v as usize],
+            z: MASK[v as usize],
+        }
+    }
+
+    /// Returns a bitmask with the lowest 3 bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/src/bool/scalar/bvec3a.rs
+++ b/src/bool/scalar/bvec3a.rs
@@ -31,11 +31,7 @@ impl BVec3A {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        Self {
-            x: MASK[v as usize],
-            y: MASK[v as usize],
-            z: MASK[v as usize],
-        }
+        Self::new(v, v, v)
     }
 
     /// Returns a bitmask with the lowest 3 bits set from the elements of `self`.

--- a/src/bool/scalar/bvec4a.rs
+++ b/src/bool/scalar/bvec4a.rs
@@ -30,7 +30,18 @@ impl BVec4A {
         }
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        Self {
+            x: MASK[v as usize],
+            y: MASK[v as usize],
+            z: MASK[v as usize],
+            w: MASK[v as usize],
+        }
+    }
+
+    /// Returns a bitmask with the lowest 4 bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/src/bool/scalar/bvec4a.rs
+++ b/src/bool/scalar/bvec4a.rs
@@ -33,12 +33,7 @@ impl BVec4A {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        Self {
-            x: MASK[v as usize],
-            y: MASK[v as usize],
-            z: MASK[v as usize],
-            w: MASK[v as usize],
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a bitmask with the lowest 4 bits set from the elements of `self`.

--- a/src/bool/sse2/bvec3a.rs
+++ b/src/bool/sse2/bvec3a.rs
@@ -38,7 +38,18 @@ impl BVec3A {
         }
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        unsafe {
+            UnionCast {
+                a: [MASK[v as usize], MASK[v as usize], MASK[v as usize], 0],
+            }
+            .v
+        }
+    }
+
+    /// Returns a bitmask with the lowest 3 bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/src/bool/sse2/bvec3a.rs
+++ b/src/bool/sse2/bvec3a.rs
@@ -41,12 +41,7 @@ impl BVec3A {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        unsafe {
-            UnionCast {
-                a: [MASK[v as usize], MASK[v as usize], MASK[v as usize], 0],
-            }
-            .v
-        }
+        Self::new(v, v, v)
     }
 
     /// Returns a bitmask with the lowest 3 bits set from the elements of `self`.

--- a/src/bool/sse2/bvec4a.rs
+++ b/src/bool/sse2/bvec4a.rs
@@ -43,7 +43,23 @@ impl BVec4A {
         }
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        unsafe {
+            UnionCast {
+                a: [
+                    MASK[v as usize],
+                    MASK[v as usize],
+                    MASK[v as usize],
+                    MASK[v as usize],
+                ],
+            }
+            .v
+        }
+    }
+
+    /// Returns a bitmask with the lowest 4 bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/src/bool/sse2/bvec4a.rs
+++ b/src/bool/sse2/bvec4a.rs
@@ -46,17 +46,7 @@ impl BVec4A {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        unsafe {
-            UnionCast {
-                a: [
-                    MASK[v as usize],
-                    MASK[v as usize],
-                    MASK[v as usize],
-                    MASK[v as usize],
-                ],
-            }
-            .v
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a bitmask with the lowest 4 bits set from the elements of `self`.

--- a/src/bool/wasm32/bvec3a.rs
+++ b/src/bool/wasm32/bvec3a.rs
@@ -30,7 +30,18 @@ impl BVec3A {
         ))
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        Self(u32x4(
+            MASK[v as usize],
+            MASK[v as usize],
+            MASK[v as usize],
+            0,
+        ))
+    }
+
+    /// Returns a bitmask with the lowest 3 bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/src/bool/wasm32/bvec3a.rs
+++ b/src/bool/wasm32/bvec3a.rs
@@ -33,12 +33,7 @@ impl BVec3A {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        Self(u32x4(
-            MASK[v as usize],
-            MASK[v as usize],
-            MASK[v as usize],
-            0,
-        ))
+        Self::new(v, v, v)
     }
 
     /// Returns a bitmask with the lowest 3 bits set from the elements of `self`.

--- a/src/bool/wasm32/bvec4a.rs
+++ b/src/bool/wasm32/bvec4a.rs
@@ -30,7 +30,18 @@ impl BVec4A {
         ))
     }
 
-    /// Returns a bitmask with the lowest two bits set from the elements of `self`.
+    /// Creates a vector with all elements set to `v`.
+    #[inline]
+    pub const fn splat(v: bool) -> Self {
+        Self(u32x4(
+            MASK[v as usize],
+            MASK[v as usize],
+            MASK[v as usize],
+            MASK[v as usize],
+        ))
+    }
+
+    /// Returns a bitmask with the lowest 4 bits set from the elements of `self`.
     ///
     /// A true element results in a `1` bit and a false element in a `0` bit.  Element `x` goes
     /// into the first lowest bit, element `y` into the second, etc.

--- a/src/bool/wasm32/bvec4a.rs
+++ b/src/bool/wasm32/bvec4a.rs
@@ -33,12 +33,7 @@ impl BVec4A {
     /// Creates a vector with all elements set to `v`.
     #[inline]
     pub const fn splat(v: bool) -> Self {
-        Self(u32x4(
-            MASK[v as usize],
-            MASK[v as usize],
-            MASK[v as usize],
-            MASK[v as usize],
-        ))
+        Self::new(v, v, v, v)
     }
 
     /// Returns a bitmask with the lowest 4 bits set from the elements of `self`.

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -268,6 +268,11 @@ macro_rules! impl_vec2_tests {
             );
         });
 
+        glam_test!(test_mask_splat, {
+            assert_eq!($mask::splat(false), $mask::new(false, false));
+            assert_eq!($mask::splat(true), $mask::new(true, true));
+        });
+
         glam_test!(test_mask_bitmask, {
             assert_eq!($mask::new(false, false).bitmask(), 0b00);
             assert_eq!($mask::new(true, false).bitmask(), 0b01);

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -316,6 +316,11 @@ macro_rules! impl_vec3_tests {
             );
         });
 
+        glam_test!(test_mask_splat, {
+            assert_eq!($mask::splat(false), $mask::new(false, false, false));
+            assert_eq!($mask::splat(true), $mask::new(true, true, true));
+        });
+
         glam_test!(test_mask_bitmask, {
             assert_eq!($mask::new(false, false, false).bitmask(), 0b000);
             assert_eq!($mask::new(true, false, false).bitmask(), 0b001);

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -386,6 +386,11 @@ macro_rules! impl_vec4_tests {
             );
         });
 
+        glam_test!(test_mask_splat, {
+            assert_eq!($mask::splat(false), $mask::new(false, false, false, false));
+            assert_eq!($mask::splat(true), $mask::new(true, true, true, true));
+        });
+
         glam_test!(test_mask_bitmask, {
             assert_eq!($mask::new(false, false, false, false).bitmask(), 0b0000);
             assert_eq!($mask::new(false, false, true, true).bitmask(), 0b1100);


### PR DESCRIPTION
For API parity with other Vecs, add tests, and opportunistically fix a doc typo. I don't absolutely *need* this function, but it would make my code nicer.