### PR TITLE
Removed register_attr from required rust features when compiling for spirv

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -247,7 +247,7 @@ The minimum supported Rust version is `1.58.1`.
 */
 #![doc(html_root_url = "https://docs.rs/glam/0.21.3")]
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(target_arch = "spirv", feature(register_attr, repr_simd))]
+#![cfg_attr(target_arch = "spirv", feature(repr_simd))]
 #![deny(
     rust_2018_compatibility,
     rust_2018_idioms,


### PR DESCRIPTION
Hi.

I took the liberty of removing the `register_attr` feature since it's no longer supported on Rust nightly since September 2022. It doesn't seem that the feature is actively being used anywhere in the `glam` codebase.

I'm working on `rust-gpu`, which requires the Rust nightly toolchain and am in the process to update to a more recent nightly toolchain. Since one of our crates, `spirv-std`, is optionally dependent on `glam`, I'm getting compile errors because of the `feature(register_attr)`.