### PR TITLE
Removed affine transform ops that didn't make sense.

### DIFF
--- a/codegen/templates/affine.rs.tera
+++ b/codegen/templates/affine.rs.tera
@@ -47,7 +47,7 @@ use crate::{
     {{ mat_t }}, {{ col_t}}, {{ mat4_t }}, {{ quat_t }},
 {% endif %}
 };
-use core::ops::{Add, Deref, DerefMut, Mul, Sub};
+use core::ops::{Deref, DerefMut, Mul};
 
 /// A {{ dim }}D affine transform, which can represent translation, rotation, scaling and shear.
 #[derive(Copy, Clone)]
@@ -695,50 +695,6 @@ impl Mul for {{ self_t }} {
         Self {
             matrix{{ dim }}: self.matrix{{ dim }} * rhs.matrix{{ dim }},
             translation: self.matrix{{ dim }} * rhs.translation + self.translation,
-        }
-    }
-}
-
-impl Mul<{{ self_t }}> for {{ scalar_t }} {
-    type Output = {{ self_t }};
-    #[inline]
-    fn mul(self, rhs: {{ self_t }}) -> Self::Output {
-        {{ self_t }} {
-            matrix{{ dim }}: self * rhs.matrix{{ dim }},
-            translation: self * rhs.translation,
-        }
-    }
-}
-
-impl Mul<{{ scalar_t }}> for {{ self_t }} {
-    type Output = Self;
-    #[inline]
-    fn mul(self, rhs: {{ scalar_t }}) -> Self::Output {
-        Self {
-            matrix{{ dim }}: self.matrix{{ dim }} * rhs,
-            translation: self.translation * rhs,
-        }
-    }
-}
-
-impl Add<{{ self_t }}> for {{ self_t }} {
-    type Output = Self;
-    #[inline]
-    fn add(self, rhs: Self) -> Self::Output {
-        Self {
-            matrix{{ dim }}: self.matrix{{ dim }} + rhs.matrix{{ dim }},
-            translation: self.translation + rhs.translation,
-        }
-    }
-}
-
-impl Sub<{{ self_t }}> for {{ self_t }} {
-    type Output = Self;
-    #[inline]
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self {
-            matrix{{ dim }}: self.matrix{{ dim }} - rhs.matrix{{ dim }},
-            translation: self.translation - rhs.translation,
         }
     }
 }

--- a/src/f32/affine2.rs
+++ b/src/f32/affine2.rs
@@ -1,7 +1,7 @@
 // Generated from affine.rs.tera template. Edit the template, not the generated file.
 
 use crate::{Mat2, Mat3, Mat3A, Vec2, Vec3A};
-use core::ops::{Add, Deref, DerefMut, Mul, Sub};
+use core::ops::{Deref, DerefMut, Mul};
 
 /// A 2D affine transform, which can represent translation, rotation, scaling and shear.
 #[derive(Copy, Clone)]
@@ -335,50 +335,6 @@ impl Mul for Affine2 {
         Self {
             matrix2: self.matrix2 * rhs.matrix2,
             translation: self.matrix2 * rhs.translation + self.translation,
-        }
-    }
-}
-
-impl Mul<Affine2> for f32 {
-    type Output = Affine2;
-    #[inline]
-    fn mul(self, rhs: Affine2) -> Self::Output {
-        Affine2 {
-            matrix2: self * rhs.matrix2,
-            translation: self * rhs.translation,
-        }
-    }
-}
-
-impl Mul<f32> for Affine2 {
-    type Output = Self;
-    #[inline]
-    fn mul(self, rhs: f32) -> Self::Output {
-        Self {
-            matrix2: self.matrix2 * rhs,
-            translation: self.translation * rhs,
-        }
-    }
-}
-
-impl Add<Affine2> for Affine2 {
-    type Output = Self;
-    #[inline]
-    fn add(self, rhs: Self) -> Self::Output {
-        Self {
-            matrix2: self.matrix2 + rhs.matrix2,
-            translation: self.translation + rhs.translation,
-        }
-    }
-}
-
-impl Sub<Affine2> for Affine2 {
-    type Output = Self;
-    #[inline]
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self {
-            matrix2: self.matrix2 - rhs.matrix2,
-            translation: self.translation - rhs.translation,
         }
     }
 }

--- a/src/f32/affine3a.rs
+++ b/src/f32/affine3a.rs
@@ -1,7 +1,7 @@
 // Generated from affine.rs.tera template. Edit the template, not the generated file.
 
 use crate::{Mat3, Mat3A, Mat4, Quat, Vec3, Vec3A};
-use core::ops::{Add, Deref, DerefMut, Mul, Sub};
+use core::ops::{Deref, DerefMut, Mul};
 
 /// A 3D affine transform, which can represent translation, rotation, scaling and shear.
 #[derive(Copy, Clone)]
@@ -496,50 +496,6 @@ impl Mul for Affine3A {
         Self {
             matrix3: self.matrix3 * rhs.matrix3,
             translation: self.matrix3 * rhs.translation + self.translation,
-        }
-    }
-}
-
-impl Mul<Affine3A> for f32 {
-    type Output = Affine3A;
-    #[inline]
-    fn mul(self, rhs: Affine3A) -> Self::Output {
-        Affine3A {
-            matrix3: self * rhs.matrix3,
-            translation: self * rhs.translation,
-        }
-    }
-}
-
-impl Mul<f32> for Affine3A {
-    type Output = Self;
-    #[inline]
-    fn mul(self, rhs: f32) -> Self::Output {
-        Self {
-            matrix3: self.matrix3 * rhs,
-            translation: self.translation * rhs,
-        }
-    }
-}
-
-impl Add<Affine3A> for Affine3A {
-    type Output = Self;
-    #[inline]
-    fn add(self, rhs: Self) -> Self::Output {
-        Self {
-            matrix3: self.matrix3 + rhs.matrix3,
-            translation: self.translation + rhs.translation,
-        }
-    }
-}
-
-impl Sub<Affine3A> for Affine3A {
-    type Output = Self;
-    #[inline]
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self {
-            matrix3: self.matrix3 - rhs.matrix3,
-            translation: self.translation - rhs.translation,
         }
     }
 }

--- a/src/f64/daffine2.rs
+++ b/src/f64/daffine2.rs
@@ -1,7 +1,7 @@
 // Generated from affine.rs.tera template. Edit the template, not the generated file.
 
 use crate::{DMat2, DMat3, DVec2};
-use core::ops::{Add, Deref, DerefMut, Mul, Sub};
+use core::ops::{Deref, DerefMut, Mul};
 
 /// A 2D affine transform, which can represent translation, rotation, scaling and shear.
 #[derive(Copy, Clone)]
@@ -325,50 +325,6 @@ impl Mul for DAffine2 {
         Self {
             matrix2: self.matrix2 * rhs.matrix2,
             translation: self.matrix2 * rhs.translation + self.translation,
-        }
-    }
-}
-
-impl Mul<DAffine2> for f64 {
-    type Output = DAffine2;
-    #[inline]
-    fn mul(self, rhs: DAffine2) -> Self::Output {
-        DAffine2 {
-            matrix2: self * rhs.matrix2,
-            translation: self * rhs.translation,
-        }
-    }
-}
-
-impl Mul<f64> for DAffine2 {
-    type Output = Self;
-    #[inline]
-    fn mul(self, rhs: f64) -> Self::Output {
-        Self {
-            matrix2: self.matrix2 * rhs,
-            translation: self.translation * rhs,
-        }
-    }
-}
-
-impl Add<DAffine2> for DAffine2 {
-    type Output = Self;
-    #[inline]
-    fn add(self, rhs: Self) -> Self::Output {
-        Self {
-            matrix2: self.matrix2 + rhs.matrix2,
-            translation: self.translation + rhs.translation,
-        }
-    }
-}
-
-impl Sub<DAffine2> for DAffine2 {
-    type Output = Self;
-    #[inline]
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self {
-            matrix2: self.matrix2 - rhs.matrix2,
-            translation: self.translation - rhs.translation,
         }
     }
 }

--- a/src/f64/daffine3.rs
+++ b/src/f64/daffine3.rs
@@ -1,7 +1,7 @@
 // Generated from affine.rs.tera template. Edit the template, not the generated file.
 
 use crate::{DMat3, DMat4, DQuat, DVec3};
-use core::ops::{Add, Deref, DerefMut, Mul, Sub};
+use core::ops::{Deref, DerefMut, Mul};
 
 /// A 3D affine transform, which can represent translation, rotation, scaling and shear.
 #[derive(Copy, Clone)]
@@ -485,50 +485,6 @@ impl Mul for DAffine3 {
         Self {
             matrix3: self.matrix3 * rhs.matrix3,
             translation: self.matrix3 * rhs.translation + self.translation,
-        }
-    }
-}
-
-impl Mul<DAffine3> for f64 {
-    type Output = DAffine3;
-    #[inline]
-    fn mul(self, rhs: DAffine3) -> Self::Output {
-        DAffine3 {
-            matrix3: self * rhs.matrix3,
-            translation: self * rhs.translation,
-        }
-    }
-}
-
-impl Mul<f64> for DAffine3 {
-    type Output = Self;
-    #[inline]
-    fn mul(self, rhs: f64) -> Self::Output {
-        Self {
-            matrix3: self.matrix3 * rhs,
-            translation: self.translation * rhs,
-        }
-    }
-}
-
-impl Add<DAffine3> for DAffine3 {
-    type Output = Self;
-    #[inline]
-    fn add(self, rhs: Self) -> Self::Output {
-        Self {
-            matrix3: self.matrix3 + rhs.matrix3,
-            translation: self.translation + rhs.translation,
-        }
-    }
-}
-
-impl Sub<DAffine3> for DAffine3 {
-    type Output = Self;
-    #[inline]
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self {
-            matrix3: self.matrix3 - rhs.matrix3,
-            translation: self.translation - rhs.translation,
         }
     }
 }

--- a/tests/affine2.rs
+++ b/tests/affine2.rs
@@ -48,10 +48,10 @@ macro_rules! impl_affine2_tests {
             assert_eq!(MATRIX2D[2], a.z_axis.to_array());
 
             let mut b = a;
-            b.x_axis *= 2.0;
-            b.y_axis *= 2.0;
-            b.z_axis *= 2.0;
-            assert_eq!(a * 2.0, b);
+            b.x_axis *= 0.0;
+            b.y_axis *= 0.0;
+            b.z_axis *= 0.0;
+            assert_eq!($affine2::ZERO, b);
         });
 
         glam_test!(test_affine2_from_mat2, {
@@ -149,11 +149,6 @@ macro_rules! impl_affine2_tests {
 
         glam_test!(test_affine2_ops, {
             let m0 = $affine2::from_cols_array_2d(&MATRIX2D);
-            let m0x2 = $affine2::from_cols_array_2d(&[[2.0, 4.0], [6.0, 8.0], [10.0, 12.0]]);
-            assert_eq!(m0x2, m0 * 2.0);
-            assert_eq!(m0x2, 2.0 * m0);
-            assert_eq!(m0x2, m0 + m0);
-            assert_eq!($affine2::ZERO, m0 - m0);
             assert_approx_eq!(m0, m0 * $affine2::IDENTITY);
             assert_approx_eq!(m0, $affine2::IDENTITY * m0);
 

--- a/tests/affine3.rs
+++ b/tests/affine3.rs
@@ -57,11 +57,11 @@ macro_rules! impl_affine3_tests {
             assert_eq!(MATRIX2D[3], a.w_axis.to_array());
 
             let mut b = a;
-            b.x_axis *= 2.0;
-            b.y_axis *= 2.0;
-            b.z_axis *= 2.0;
-            b.w_axis *= 2.0;
-            assert_eq!(a * 2.0, b);
+            b.x_axis *= 0.0;
+            b.y_axis *= 0.0;
+            b.z_axis *= 0.0;
+            b.w_axis *= 0.0;
+            assert_eq!($affine3::ZERO, b);
         });
 
         glam_test!(test_affine3_from_mat3, {
@@ -291,16 +291,6 @@ macro_rules! impl_affine3_tests {
 
         glam_test!(test_affine3_ops, {
             let m0 = $affine3::from_cols_array_2d(&MATRIX2D);
-            let m0x2 = $affine3::from_cols_array_2d(&[
-                [2.0, 4.0, 6.0],
-                [8.0, 10.0, 12.0],
-                [14.0, 16.0, 18.0],
-                [20.0, 22.0, 24.0],
-            ]);
-            assert_eq!(m0x2, m0 * 2.0);
-            assert_eq!(m0x2, 2.0 * m0);
-            assert_eq!(m0x2, m0 + m0);
-            assert_eq!($affine3::ZERO, m0 - m0);
             assert_approx_eq!(m0, m0 * $affine3::IDENTITY);
             assert_approx_eq!(m0, $affine3::IDENTITY * m0);
 


### PR DESCRIPTION
Multiplying by scalar, adding and subtracting an affine transform don't really make sense when using a matrix to store an affine transform, therefore they don't make sense on the affine interface either.