### PR TITLE
Make BVec4A available when scalar-math feature is enabled

### DIFF
--- a/src/bool.rs
+++ b/src/bool.rs
@@ -68,12 +68,14 @@ pub use coresimd::bvec4a::BVec4A;
 ))]
 pub use scalar::bvec3a::BVec3A;
 
-#[cfg(not(any(
-    feature = "scalar-math",
-    feature = "core-simd",
-    target_feature = "sse2",
-    target_feature = "simd128"
-),))]
+#[cfg(any(
+    not(any(
+        feature = "core-simd",
+        target_feature = "sse2",
+        target_feature = "simd128"
+    )),
+    feature = "scalar-math"
+))]
 pub use scalar::bvec4a::BVec4A;
 
 mod const_test_bvec2 {


### PR DESCRIPTION
This just matches what was done for BVec3A. There's a bunch of functions in scalar/vec4.rs that return BVec4 instead of BVec4A though, like `cmpge`. I tried wrangling the template files but wasn't sure how to fix that part, its a bit annoying because switching on scalar-math creates compile errors when these functions are being used. I currently only need scalar-math to run tests in miri because miri doesn't support SIMD.