### PR TITLE
Fix incorrect comment on `signum` function for integer vectors.

### DIFF
--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -801,9 +801,15 @@ impl {{ self_t }} {
 
     /// Returns a vector with elements representing the sign of `self`.
     ///
+    {% if is_float -%}
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
+    {%- else -%}
+    ///  - `0` if the number is zero
+    ///  - `1` if the number is positive
+    ///  - `-1` if the number is negative
+    {%- endif %}
     #[inline]
     pub fn signum(self) -> Self {
         {% if is_scalar %}

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -247,9 +247,9 @@ impl IVec2 {
 
     /// Returns a vector with elements representing the sign of `self`.
     ///
-    /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
-    /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
-    /// - `NAN` if the number is `NAN`
+    ///  - `0` if the number is zero
+    ///  - `1` if the number is positive
+    ///  - `-1` if the number is negative
     #[inline]
     pub fn signum(self) -> Self {
         Self {

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -288,9 +288,9 @@ impl IVec3 {
 
     /// Returns a vector with elements representing the sign of `self`.
     ///
-    /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
-    /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
-    /// - `NAN` if the number is `NAN`
+    ///  - `0` if the number is zero
+    ///  - `1` if the number is positive
+    ///  - `-1` if the number is negative
     #[inline]
     pub fn signum(self) -> Self {
         Self {

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -312,9 +312,9 @@ impl IVec4 {
 
     /// Returns a vector with elements representing the sign of `self`.
     ///
-    /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
-    /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
-    /// - `NAN` if the number is `NAN`
+    ///  - `0` if the number is zero
+    ///  - `1` if the number is positive
+    ///  - `-1` if the number is negative
     #[inline]
     pub fn signum(self) -> Self {
         Self {


### PR DESCRIPTION
The existing doc comment in `ivec2/3/4.rs` incorrectly states that the result of `IVec2/3/4::signum` will never have an element equal to 0. Additionally, it refers to floating point `+0.0`, `-0.0`, `INFINITY`, and `NEG_INFINITY`, which are not `i32` values. `IVec2`, `IVec3`, and `IVec4` all implement `signum` by calling the Rust standard `i32::signum` on each element of the vector. `i32::signum` returns 0 when the i32 value is 0. This PR modifies `vec.rs.tera` to generate correct comments for the integer vectors.