### PR TITLE
depend on `serde_derive` directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,13 +44,16 @@ fast-math = []
 # experimental nightly portable-simd support
 core-simd = []
 
+serde = ["dep:serde", "serde_derive"]
+
 [dependencies]
 approx = { version = "0.5", optional = true, default-features = false }
 bytemuck = { version = "1.5", optional = true, default-features = false }
 mint = { version = "0.5.8", optional = true, default-features = false }
 num-traits = { version = "0.2.14", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
-serde = { version = "1.0", optional = true, default-features = false, features = ["derive"] }
+serde = { version = "1.0", optional = true, default-features = false }
+serde_derive = { version = "1.0", optional = true }
 rkyv = { version = "0.7", optional = true }
 bytecheck = { version = "0.6", optional = true, default-features = false}
 

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -17,7 +17,10 @@ use num_traits::Float;
 ///
 /// YXZ can be used for yaw (y-axis), pitch (x-axis), roll (z-axis).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde_derive::Deserialize, serde_derive::Serialize)
+)]
 pub enum EulerRot {
     /// Intrinsic three-axis rotation ZYX
     ZYX,


### PR DESCRIPTION
If no crate enables the `derive` feature of `serde,` then serde and serde_derive can compile in parallel, and anything depending only on serde can compile while serde_derive is not yet done.
This can save up to 5 seconds of compilation, depending on whether this helps the critical chain and if no other crate enables the feature.

This cuts the critical chain of bevy compilation from `serde_derive -> serde -> hashbrown -> indexmap -> petgraph -> bevy_utils -> bevy_reflect` to `serde_derive -> glam -> bevy_math -> bevy_reflect`  which is faster.

![image](https://user-images.githubusercontent.com/22177966/224720751-3bdebf5a-a620-45d1-89d2-4f4a90a609a2.png)