### PR TITLE
Remove legacy `::from()` truncation mention in docs; add more intradoc links

### DIFF
--- a/codegen/templates/affine.rs.tera
+++ b/codegen/templates/affine.rs.tera
@@ -275,7 +275,7 @@ impl {{ self_t }} {
     }
 
 {% if scalar_t == "f32" %}
-    /// The given `Mat3A` must be an affine transform,
+    /// The given [`Mat3A`] must be an affine transform,
     #[inline]
     pub fn from_mat3a(m: Mat3A) -> Self {
         use crate::swizzles::Vec3Swizzles;
@@ -295,7 +295,7 @@ impl {{ self_t }} {
     /// Transforms the given 2D vector, applying shear, scale and rotation (but NOT
     /// translation).
     ///
-    /// To also apply translation, use [`Self::transform_point2`] instead.
+    /// To also apply translation, use [`Self::transform_point2()`] instead.
     #[inline]
     pub fn transform_vector2(&self, rhs: {{ vec2_t }}) -> {{ vec2_t }} {
         self.matrix2 * rhs
@@ -548,7 +548,7 @@ impl {{ self_t }} {
     /// Transforms the given 3D vector, applying shear, scale and rotation (but NOT
     /// translation).
     ///
-    /// To also apply translation, use [`Self::transform_point3`] instead.
+    /// To also apply translation, use [`Self::transform_point3()`] instead.
     #[inline]
     pub fn transform_vector3(&self, rhs: {{ vec3_t }}) -> {{ vec3_t }} {
         #[allow(clippy::useless_conversion)]
@@ -560,16 +560,16 @@ impl {{ self_t }} {
 {% endif %}
 
 {% if self_t == "Affine3A" %}
-    /// Transforms the given `Vec3A`, applying shear, scale, rotation and translation.
+    /// Transforms the given [`Vec3A`], applying shear, scale, rotation and translation.
     #[inline]
     pub fn transform_point3a(&self, rhs: Vec3A) -> Vec3A {
         self.matrix3 * rhs + self.translation
     }
 
-    /// Transforms the given `Vec3A`, applying shear, scale and rotation (but NOT
+    /// Transforms the given [`Vec3A`], applying shear, scale and rotation (but NOT
     /// translation).
     ///
-    /// To also apply translation, use [`Self::transform_point3a`] instead.
+    /// To also apply translation, use [`Self::transform_point3a()`] instead.
     #[inline]
     pub fn transform_vector3a(&self, rhs: Vec3A) -> Vec3A {
         self.matrix3 * rhs

--- a/codegen/templates/mat.rs.tera
+++ b/codegen/templates/mat.rs.tera
@@ -1774,9 +1774,9 @@ impl {{ self_t }} {
 {% endif %}
 
 {% if self_t == "Mat4" %}
-    /// Transforms the given `Vec3A` as 3D point.
+    /// Transforms the given [`Vec3A`] as 3D point.
     ///
-    /// This is the equivalent of multiplying the `Vec3A` as a 4D vector where `w` is `1.0`.
+    /// This is the equivalent of multiplying the [`Vec3A`] as a 4D vector where `w` is `1.0`.
     #[inline]
     pub fn transform_point3a(&self, rhs: Vec3A) -> Vec3A {
         {% if is_scalar %}
@@ -1791,9 +1791,9 @@ impl {{ self_t }} {
         {% endif %}
     }
 
-    /// Transforms the give `Vec3A` as 3D vector.
+    /// Transforms the give [`Vec3A`] as 3D vector.
     ///
-    /// This is the equivalent of multiplying the `Vec3A` as a 4D vector where `w` is `0.0`.
+    /// This is the equivalent of multiplying the [`Vec3A`] as a 4D vector where `w` is `0.0`.
     #[inline]
     pub fn transform_vector3a(&self, rhs: Vec3A) -> Vec3A {
         {% if is_scalar %}
@@ -1876,13 +1876,13 @@ impl {{ self_t }} {
     }
 
 {% if self_t == "Mat3" %}
-    /// Transforms a `Vec3A`.
+    /// Transforms a [`Vec3A`].
     #[inline]
     pub fn mul_vec3a(&self, rhs: Vec3A) -> Vec3A {
         self.mul_vec3(rhs.into()).into()
     }
 {% elif self_t == "Mat3A" %}
-    /// Transforms a `Vec3A`.
+    /// Transforms a [`Vec3A`].
     #[inline]
     pub fn mul_vec3a(&self, rhs: Vec3A) -> Vec3A {
         let mut res = self.x_axis.mul(rhs.xxx());

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -147,10 +147,10 @@ pub const fn {{ self_t | lower }}(
 {%- if self_t == "Vec3A" %}
 ///
 /// SIMD vector types are used for storage on supported platforms for better
-/// performance than the `Vec3` type.
+/// performance than the [`Vec3`] type.
 ///
-/// It is possible to convert between `Vec3` and `Vec3A` types using `From`
-/// trait implementations.
+/// It is possible to convert between [`Vec3`] and [`Vec3A`] types using [`From`]
+/// or [`Into`] trait implementations.
 ///
 /// This type is 16 byte aligned.
 {%- elif self_t == "Vec4" and is_simd %}
@@ -412,7 +412,7 @@ impl {{ self_t }} {
 
     /// Creates a 2D vector from the `x` and `y` elements of `self`, discarding `z`.
     ///
-    /// Truncation may also be performed by using `self.xy()` or `{{ vec2_t }}::from()`.
+    /// Truncation may also be performed by using [`self.xy()`][crate::swizzles::Vec3Swizzles::xy()].
     #[inline]
     pub fn truncate(self) -> {{ vec2_t }} {
         use crate::swizzles::Vec3Swizzles;
@@ -421,10 +421,10 @@ impl {{ self_t }} {
 {% elif dim == 4 %}
     /// Creates a 2D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.
     ///
-    /// Truncation to `{{ vec3_t }}` may also be performed by using `self.xyz()` or `{{ vec3_t }}::from()`.
+    /// Truncation to [`{{ vec3_t }}`] may also be performed by using [`self.xyz()`][crate::swizzles::Vec4Swizzles::xyz()].
 {%- if scalar_t == "f32" %}
     ///
-    /// To truncate to `Vec3A` use `Vec3A::from()`.
+    /// To truncate to [`Vec3A`] use [`Vec3A::from()`].
 {%- endif %}
     #[inline]
     pub fn truncate(self) -> {{ vec3_t }} {
@@ -1051,7 +1051,7 @@ impl {{ self_t }} {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -1092,7 +1092,7 @@ impl {{ self_t }} {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -1109,7 +1109,7 @@ impl {{ self_t }} {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {
@@ -1386,8 +1386,9 @@ impl {{ self_t }} {
 
 {% if dim == 2 %}
     /// Creates a 2D vector containing `[angle.cos(), angle.sin()]`. This can be used in
-    /// conjunction with the `rotate` method, e.g. `Vec2::from_angle(PI).rotate(Vec2::Y)` will
-    /// create the vector [-1, 0] and rotate `Vec2::Y` around it returning `-Vec2::Y`.
+    /// conjunction with the [`rotate()`][Self::rotate()] method, e.g.
+    /// `{{ vec2_t }}::from_angle(PI).rotate({{ vec2_t }}::Y)` will create the vector `[-1, 0]`
+    /// and rotate [`{{ vec2_t }}::Y`] around it returning `-{{ vec2_t }}::Y`.
     #[inline]
     pub fn from_angle(angle: {{ scalar_t }}) -> Self {
         let (sin, cos) = math::sin_cos(angle);
@@ -1423,7 +1424,7 @@ impl {{ self_t }} {
     /// The input vector must be finite and non-zero.
     ///
     /// The output vector is not necessarily unit-length.
-    /// For that use [`Self::any_orthonormal_vector`] instead.
+    /// For that use [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -2504,7 +2505,7 @@ impl From<Vec3> for Vec3A {
 }
 
 impl From<Vec4> for Vec3A {
-    /// Creates a `Vec3A` from the `x`, `y` and `z` elements of `self` discarding `w`.
+    /// Creates a [`Vec3A`] from the `x`, `y` and `z` elements of `self` discarding `w`.
     ///
     /// On architectures where SIMD is supported such as SSE2 on `x86_64` this conversion is a noop.
     #[inline]

--- a/src/f32/affine2.rs
+++ b/src/f32/affine2.rs
@@ -196,7 +196,7 @@ impl Affine2 {
         }
     }
 
-    /// The given `Mat3A` must be an affine transform,
+    /// The given [`Mat3A`] must be an affine transform,
     #[inline]
     pub fn from_mat3a(m: Mat3A) -> Self {
         use crate::swizzles::Vec3Swizzles;
@@ -215,7 +215,7 @@ impl Affine2 {
     /// Transforms the given 2D vector, applying shear, scale and rotation (but NOT
     /// translation).
     ///
-    /// To also apply translation, use [`Self::transform_point2`] instead.
+    /// To also apply translation, use [`Self::transform_point2()`] instead.
     #[inline]
     pub fn transform_vector2(&self, rhs: Vec2) -> Vec2 {
         self.matrix2 * rhs

--- a/src/f32/affine3a.rs
+++ b/src/f32/affine3a.rs
@@ -356,7 +356,7 @@ impl Affine3A {
     /// Transforms the given 3D vector, applying shear, scale and rotation (but NOT
     /// translation).
     ///
-    /// To also apply translation, use [`Self::transform_point3`] instead.
+    /// To also apply translation, use [`Self::transform_point3()`] instead.
     #[inline]
     pub fn transform_vector3(&self, rhs: Vec3) -> Vec3 {
         #[allow(clippy::useless_conversion)]
@@ -366,16 +366,16 @@ impl Affine3A {
             .into()
     }
 
-    /// Transforms the given `Vec3A`, applying shear, scale, rotation and translation.
+    /// Transforms the given [`Vec3A`], applying shear, scale, rotation and translation.
     #[inline]
     pub fn transform_point3a(&self, rhs: Vec3A) -> Vec3A {
         self.matrix3 * rhs + self.translation
     }
 
-    /// Transforms the given `Vec3A`, applying shear, scale and rotation (but NOT
+    /// Transforms the given [`Vec3A`], applying shear, scale and rotation (but NOT
     /// translation).
     ///
-    /// To also apply translation, use [`Self::transform_point3a`] instead.
+    /// To also apply translation, use [`Self::transform_point3a()`] instead.
     #[inline]
     pub fn transform_vector3a(&self, rhs: Vec3A) -> Vec3A {
         self.matrix3 * rhs

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -496,7 +496,7 @@ impl Mat3A {
         self.mul_vec3a(rhs.into()).into()
     }
 
-    /// Transforms a `Vec3A`.
+    /// Transforms a [`Vec3A`].
     #[inline]
     pub fn mul_vec3a(&self, rhs: Vec3A) -> Vec3A {
         let mut res = self.x_axis.mul(rhs.xxx());

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -1215,9 +1215,9 @@ impl Mat4 {
         res.xyz()
     }
 
-    /// Transforms the given `Vec3A` as 3D point.
+    /// Transforms the given [`Vec3A`] as 3D point.
     ///
-    /// This is the equivalent of multiplying the `Vec3A` as a 4D vector where `w` is `1.0`.
+    /// This is the equivalent of multiplying the [`Vec3A`] as a 4D vector where `w` is `1.0`.
     #[inline]
     pub fn transform_point3a(&self, rhs: Vec3A) -> Vec3A {
         glam_assert!(self.row(3).abs_diff_eq(Vec4::W, 1e-6));
@@ -1228,9 +1228,9 @@ impl Mat4 {
         res.into()
     }
 
-    /// Transforms the give `Vec3A` as 3D vector.
+    /// Transforms the give [`Vec3A`] as 3D vector.
     ///
-    /// This is the equivalent of multiplying the `Vec3A` as a 4D vector where `w` is `0.0`.
+    /// This is the equivalent of multiplying the [`Vec3A`] as a 4D vector where `w` is `0.0`.
     #[inline]
     pub fn transform_vector3a(&self, rhs: Vec3A) -> Vec3A {
         glam_assert!(self.row(3).abs_diff_eq(Vec4::W, 1e-6));

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -19,10 +19,10 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 /// A 3-dimensional vector.
 ///
 /// SIMD vector types are used for storage on supported platforms for better
-/// performance than the `Vec3` type.
+/// performance than the [`Vec3`] type.
 ///
-/// It is possible to convert between `Vec3` and `Vec3A` types using `From`
-/// trait implementations.
+/// It is possible to convert between [`Vec3`] and [`Vec3A`] types using [`From`]
+/// or [`Into`] trait implementations.
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
@@ -134,7 +134,7 @@ impl Vec3A {
 
     /// Creates a 2D vector from the `x` and `y` elements of `self`, discarding `z`.
     ///
-    /// Truncation may also be performed by using `self.xy()` or `Vec2::from()`.
+    /// Truncation may also be performed by using [`self.xy()`][crate::swizzles::Vec3Swizzles::xy()].
     #[inline]
     pub fn truncate(self) -> Vec2 {
         use crate::swizzles::Vec3Swizzles;
@@ -371,7 +371,7 @@ impl Vec3A {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -391,7 +391,7 @@ impl Vec3A {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -408,7 +408,7 @@ impl Vec3A {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {
@@ -634,7 +634,7 @@ impl Vec3A {
     /// The input vector must be finite and non-zero.
     ///
     /// The output vector is not necessarily unit-length.
-    /// For that use [`Self::any_orthonormal_vector`] instead.
+    /// For that use [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -1062,7 +1062,7 @@ impl From<Vec3> for Vec3A {
 }
 
 impl From<Vec4> for Vec3A {
-    /// Creates a `Vec3A` from the `x`, `y` and `z` elements of `self` discarding `w`.
+    /// Creates a [`Vec3A`] from the `x`, `y` and `z` elements of `self` discarding `w`.
     ///
     /// On architectures where SIMD is supported such as SSE2 on `x86_64` this conversion is a noop.
     #[inline]

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -124,9 +124,9 @@ impl Vec4 {
 
     /// Creates a 2D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.
     ///
-    /// Truncation to `Vec3` may also be performed by using `self.xyz()` or `Vec3::from()`.
+    /// Truncation to [`Vec3`] may also be performed by using [`self.xyz()`][crate::swizzles::Vec4Swizzles::xyz()].
     ///
-    /// To truncate to `Vec3A` use `Vec3A::from()`.
+    /// To truncate to [`Vec3A`] use [`Vec3A::from()`].
     #[inline]
     pub fn truncate(self) -> Vec3 {
         use crate::swizzles::Vec4Swizzles;
@@ -344,7 +344,7 @@ impl Vec4 {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -364,7 +364,7 @@ impl Vec4 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -381,7 +381,7 @@ impl Vec4 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -473,7 +473,7 @@ impl Mat3 {
         res
     }
 
-    /// Transforms a `Vec3A`.
+    /// Transforms a [`Vec3A`].
     #[inline]
     pub fn mul_vec3a(&self, rhs: Vec3A) -> Vec3A {
         self.mul_vec3(rhs.into()).into()

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -474,7 +474,7 @@ impl Mat3A {
         self.mul_vec3a(rhs.into()).into()
     }
 
-    /// Transforms a `Vec3A`.
+    /// Transforms a [`Vec3A`].
     #[inline]
     pub fn mul_vec3a(&self, rhs: Vec3A) -> Vec3A {
         let mut res = self.x_axis.mul(rhs.xxx());

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -992,17 +992,17 @@ impl Mat4 {
         res.xyz()
     }
 
-    /// Transforms the given `Vec3A` as 3D point.
+    /// Transforms the given [`Vec3A`] as 3D point.
     ///
-    /// This is the equivalent of multiplying the `Vec3A` as a 4D vector where `w` is `1.0`.
+    /// This is the equivalent of multiplying the [`Vec3A`] as a 4D vector where `w` is `1.0`.
     #[inline]
     pub fn transform_point3a(&self, rhs: Vec3A) -> Vec3A {
         self.transform_point3(rhs.into()).into()
     }
 
-    /// Transforms the give `Vec3A` as 3D vector.
+    /// Transforms the give [`Vec3A`] as 3D vector.
     ///
-    /// This is the equivalent of multiplying the `Vec3A` as a 4D vector where `w` is `0.0`.
+    /// This is the equivalent of multiplying the [`Vec3A`] as a 4D vector where `w` is `0.0`.
     #[inline]
     pub fn transform_vector3a(&self, rhs: Vec3A) -> Vec3A {
         self.transform_vector3(rhs.into()).into()

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -16,10 +16,10 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 /// A 3-dimensional vector.
 ///
 /// SIMD vector types are used for storage on supported platforms for better
-/// performance than the `Vec3` type.
+/// performance than the [`Vec3`] type.
 ///
-/// It is possible to convert between `Vec3` and `Vec3A` types using `From`
-/// trait implementations.
+/// It is possible to convert between [`Vec3`] and [`Vec3A`] types using [`From`]
+/// or [`Into`] trait implementations.
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy, PartialEq)]
@@ -145,7 +145,7 @@ impl Vec3A {
 
     /// Creates a 2D vector from the `x` and `y` elements of `self`, discarding `z`.
     ///
-    /// Truncation may also be performed by using `self.xy()` or `Vec2::from()`.
+    /// Truncation may also be performed by using [`self.xy()`][crate::swizzles::Vec3Swizzles::xy()].
     #[inline]
     pub fn truncate(self) -> Vec2 {
         use crate::swizzles::Vec3Swizzles;
@@ -393,7 +393,7 @@ impl Vec3A {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -412,7 +412,7 @@ impl Vec3A {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -429,7 +429,7 @@ impl Vec3A {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {
@@ -675,7 +675,7 @@ impl Vec3A {
     /// The input vector must be finite and non-zero.
     ///
     /// The output vector is not necessarily unit-length.
-    /// For that use [`Self::any_orthonormal_vector`] instead.
+    /// For that use [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -1176,7 +1176,7 @@ impl From<Vec3> for Vec3A {
 }
 
 impl From<Vec4> for Vec3A {
-    /// Creates a `Vec3A` from the `x`, `y` and `z` elements of `self` discarding `w`.
+    /// Creates a [`Vec3A`] from the `x`, `y` and `z` elements of `self` discarding `w`.
     ///
     /// On architectures where SIMD is supported such as SSE2 on `x86_64` this conversion is a noop.
     #[inline]

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -143,9 +143,9 @@ impl Vec4 {
 
     /// Creates a 2D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.
     ///
-    /// Truncation to `Vec3` may also be performed by using `self.xyz()` or `Vec3::from()`.
+    /// Truncation to [`Vec3`] may also be performed by using [`self.xyz()`][crate::swizzles::Vec4Swizzles::xyz()].
     ///
-    /// To truncate to `Vec3A` use `Vec3A::from()`.
+    /// To truncate to [`Vec3A`] use [`Vec3A::from()`].
     #[inline]
     pub fn truncate(self) -> Vec3 {
         use crate::swizzles::Vec4Swizzles;
@@ -424,7 +424,7 @@ impl Vec4 {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -443,7 +443,7 @@ impl Vec4 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -460,7 +460,7 @@ impl Vec4 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -481,7 +481,7 @@ impl Mat3A {
         self.mul_vec3a(rhs.into()).into()
     }
 
-    /// Transforms a `Vec3A`.
+    /// Transforms a [`Vec3A`].
     #[inline]
     pub fn mul_vec3a(&self, rhs: Vec3A) -> Vec3A {
         let mut res = self.x_axis.mul(rhs.xxx());

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -1080,9 +1080,9 @@ impl Mat4 {
         res.xyz()
     }
 
-    /// Transforms the given `Vec3A` as 3D point.
+    /// Transforms the given [`Vec3A`] as 3D point.
     ///
-    /// This is the equivalent of multiplying the `Vec3A` as a 4D vector where `w` is `1.0`.
+    /// This is the equivalent of multiplying the [`Vec3A`] as a 4D vector where `w` is `1.0`.
     #[inline]
     pub fn transform_point3a(&self, rhs: Vec3A) -> Vec3A {
         glam_assert!(self.row(3).abs_diff_eq(Vec4::W, 1e-6));
@@ -1093,9 +1093,9 @@ impl Mat4 {
         res.into()
     }
 
-    /// Transforms the give `Vec3A` as 3D vector.
+    /// Transforms the give [`Vec3A`] as 3D vector.
     ///
-    /// This is the equivalent of multiplying the `Vec3A` as a 4D vector where `w` is `0.0`.
+    /// This is the equivalent of multiplying the [`Vec3A`] as a 4D vector where `w` is `0.0`.
     #[inline]
     pub fn transform_vector3a(&self, rhs: Vec3A) -> Vec3A {
         glam_assert!(self.row(3).abs_diff_eq(Vec4::W, 1e-6));

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -26,10 +26,10 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 /// A 3-dimensional vector.
 ///
 /// SIMD vector types are used for storage on supported platforms for better
-/// performance than the `Vec3` type.
+/// performance than the [`Vec3`] type.
 ///
-/// It is possible to convert between `Vec3` and `Vec3A` types using `From`
-/// trait implementations.
+/// It is possible to convert between [`Vec3`] and [`Vec3A`] types using [`From`]
+/// or [`Into`] trait implementations.
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
@@ -146,7 +146,7 @@ impl Vec3A {
 
     /// Creates a 2D vector from the `x` and `y` elements of `self`, discarding `z`.
     ///
-    /// Truncation may also be performed by using `self.xy()` or `Vec2::from()`.
+    /// Truncation may also be performed by using [`self.xy()`][crate::swizzles::Vec3Swizzles::xy()].
     #[inline]
     pub fn truncate(self) -> Vec2 {
         use crate::swizzles::Vec3Swizzles;
@@ -406,7 +406,7 @@ impl Vec3A {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -428,7 +428,7 @@ impl Vec3A {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -445,7 +445,7 @@ impl Vec3A {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {
@@ -680,7 +680,7 @@ impl Vec3A {
     /// The input vector must be finite and non-zero.
     ///
     /// The output vector is not necessarily unit-length.
-    /// For that use [`Self::any_orthonormal_vector`] instead.
+    /// For that use [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -1133,7 +1133,7 @@ impl From<Vec3> for Vec3A {
 }
 
 impl From<Vec4> for Vec3A {
-    /// Creates a `Vec3A` from the `x`, `y` and `z` elements of `self` discarding `w`.
+    /// Creates a [`Vec3A`] from the `x`, `y` and `z` elements of `self` discarding `w`.
     ///
     /// On architectures where SIMD is supported such as SSE2 on `x86_64` this conversion is a noop.
     #[inline]

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -136,9 +136,9 @@ impl Vec4 {
 
     /// Creates a 2D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.
     ///
-    /// Truncation to `Vec3` may also be performed by using `self.xyz()` or `Vec3::from()`.
+    /// Truncation to [`Vec3`] may also be performed by using [`self.xyz()`][crate::swizzles::Vec4Swizzles::xyz()].
     ///
-    /// To truncate to `Vec3A` use `Vec3A::from()`.
+    /// To truncate to [`Vec3A`] use [`Vec3A::from()`].
     #[inline]
     pub fn truncate(self) -> Vec3 {
         use crate::swizzles::Vec4Swizzles;
@@ -380,7 +380,7 @@ impl Vec4 {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -402,7 +402,7 @@ impl Vec4 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -419,7 +419,7 @@ impl Vec4 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -339,7 +339,7 @@ impl Vec2 {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -358,7 +358,7 @@ impl Vec2 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -375,7 +375,7 @@ impl Vec2 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {
@@ -597,8 +597,9 @@ impl Vec2 {
     }
 
     /// Creates a 2D vector containing `[angle.cos(), angle.sin()]`. This can be used in
-    /// conjunction with the `rotate` method, e.g. `Vec2::from_angle(PI).rotate(Vec2::Y)` will
-    /// create the vector [-1, 0] and rotate `Vec2::Y` around it returning `-Vec2::Y`.
+    /// conjunction with the [`rotate()`][Self::rotate()] method, e.g.
+    /// `Vec2::from_angle(PI).rotate(Vec2::Y)` will create the vector `[-1, 0]`
+    /// and rotate [`Vec2::Y`] around it returning `-Vec2::Y`.
     #[inline]
     pub fn from_angle(angle: f32) -> Self {
         let (sin, cos) = math::sin_cos(angle);

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -136,7 +136,7 @@ impl Vec3 {
 
     /// Creates a 2D vector from the `x` and `y` elements of `self`, discarding `z`.
     ///
-    /// Truncation may also be performed by using `self.xy()` or `Vec2::from()`.
+    /// Truncation may also be performed by using [`self.xy()`][crate::swizzles::Vec3Swizzles::xy()].
     #[inline]
     pub fn truncate(self) -> Vec2 {
         use crate::swizzles::Vec3Swizzles;
@@ -384,7 +384,7 @@ impl Vec3 {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -403,7 +403,7 @@ impl Vec3 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -420,7 +420,7 @@ impl Vec3 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {
@@ -666,7 +666,7 @@ impl Vec3 {
     /// The input vector must be finite and non-zero.
     ///
     /// The output vector is not necessarily unit-length.
-    /// For that use [`Self::any_orthonormal_vector`] instead.
+    /// For that use [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized

--- a/src/f32/wasm32/mat3a.rs
+++ b/src/f32/wasm32/mat3a.rs
@@ -476,7 +476,7 @@ impl Mat3A {
         self.mul_vec3a(rhs.into()).into()
     }
 
-    /// Transforms a `Vec3A`.
+    /// Transforms a [`Vec3A`].
     #[inline]
     pub fn mul_vec3a(&self, rhs: Vec3A) -> Vec3A {
         let mut res = self.x_axis.mul(rhs.xxx());

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -1071,9 +1071,9 @@ impl Mat4 {
         res.xyz()
     }
 
-    /// Transforms the given `Vec3A` as 3D point.
+    /// Transforms the given [`Vec3A`] as 3D point.
     ///
-    /// This is the equivalent of multiplying the `Vec3A` as a 4D vector where `w` is `1.0`.
+    /// This is the equivalent of multiplying the [`Vec3A`] as a 4D vector where `w` is `1.0`.
     #[inline]
     pub fn transform_point3a(&self, rhs: Vec3A) -> Vec3A {
         glam_assert!(self.row(3).abs_diff_eq(Vec4::W, 1e-6));
@@ -1084,9 +1084,9 @@ impl Mat4 {
         res.into()
     }
 
-    /// Transforms the give `Vec3A` as 3D vector.
+    /// Transforms the give [`Vec3A`] as 3D vector.
     ///
-    /// This is the equivalent of multiplying the `Vec3A` as a 4D vector where `w` is `0.0`.
+    /// This is the equivalent of multiplying the [`Vec3A`] as a 4D vector where `w` is `0.0`.
     #[inline]
     pub fn transform_vector3a(&self, rhs: Vec3A) -> Vec3A {
         glam_assert!(self.row(3).abs_diff_eq(Vec4::W, 1e-6));

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -23,10 +23,10 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 /// A 3-dimensional vector.
 ///
 /// SIMD vector types are used for storage on supported platforms for better
-/// performance than the `Vec3` type.
+/// performance than the [`Vec3`] type.
 ///
-/// It is possible to convert between `Vec3` and `Vec3A` types using `From`
-/// trait implementations.
+/// It is possible to convert between [`Vec3`] and [`Vec3A`] types using [`From`]
+/// or [`Into`] trait implementations.
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
@@ -138,7 +138,7 @@ impl Vec3A {
 
     /// Creates a 2D vector from the `x` and `y` elements of `self`, discarding `z`.
     ///
-    /// Truncation may also be performed by using `self.xy()` or `Vec2::from()`.
+    /// Truncation may also be performed by using [`self.xy()`][crate::swizzles::Vec3Swizzles::xy()].
     #[inline]
     pub fn truncate(self) -> Vec2 {
         use crate::swizzles::Vec3Swizzles;
@@ -383,7 +383,7 @@ impl Vec3A {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -403,7 +403,7 @@ impl Vec3A {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -420,7 +420,7 @@ impl Vec3A {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {
@@ -650,7 +650,7 @@ impl Vec3A {
     /// The input vector must be finite and non-zero.
     ///
     /// The output vector is not necessarily unit-length.
-    /// For that use [`Self::any_orthonormal_vector`] instead.
+    /// For that use [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -1089,7 +1089,7 @@ impl From<Vec3> for Vec3A {
 }
 
 impl From<Vec4> for Vec3A {
-    /// Creates a `Vec3A` from the `x`, `y` and `z` elements of `self` discarding `w`.
+    /// Creates a [`Vec3A`] from the `x`, `y` and `z` elements of `self` discarding `w`.
     ///
     /// On architectures where SIMD is supported such as SSE2 on `x86_64` this conversion is a noop.
     #[inline]

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -128,9 +128,9 @@ impl Vec4 {
 
     /// Creates a 2D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.
     ///
-    /// Truncation to `Vec3` may also be performed by using `self.xyz()` or `Vec3::from()`.
+    /// Truncation to [`Vec3`] may also be performed by using [`self.xyz()`][crate::swizzles::Vec4Swizzles::xyz()].
     ///
-    /// To truncate to `Vec3A` use `Vec3A::from()`.
+    /// To truncate to [`Vec3A`] use [`Vec3A::from()`].
     #[inline]
     pub fn truncate(self) -> Vec3 {
         use crate::swizzles::Vec4Swizzles;
@@ -364,7 +364,7 @@ impl Vec4 {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -384,7 +384,7 @@ impl Vec4 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -401,7 +401,7 @@ impl Vec4 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {

--- a/src/f64/daffine2.rs
+++ b/src/f64/daffine2.rs
@@ -205,7 +205,7 @@ impl DAffine2 {
     /// Transforms the given 2D vector, applying shear, scale and rotation (but NOT
     /// translation).
     ///
-    /// To also apply translation, use [`Self::transform_point2`] instead.
+    /// To also apply translation, use [`Self::transform_point2()`] instead.
     #[inline]
     pub fn transform_vector2(&self, rhs: DVec2) -> DVec2 {
         self.matrix2 * rhs

--- a/src/f64/daffine3.rs
+++ b/src/f64/daffine3.rs
@@ -358,7 +358,7 @@ impl DAffine3 {
     /// Transforms the given 3D vector, applying shear, scale and rotation (but NOT
     /// translation).
     ///
-    /// To also apply translation, use [`Self::transform_point3`] instead.
+    /// To also apply translation, use [`Self::transform_point3()`] instead.
     #[inline]
     pub fn transform_vector3(&self, rhs: DVec3) -> DVec3 {
         #[allow(clippy::useless_conversion)]

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -339,7 +339,7 @@ impl DVec2 {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -358,7 +358,7 @@ impl DVec2 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -375,7 +375,7 @@ impl DVec2 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {
@@ -597,8 +597,9 @@ impl DVec2 {
     }
 
     /// Creates a 2D vector containing `[angle.cos(), angle.sin()]`. This can be used in
-    /// conjunction with the `rotate` method, e.g. `Vec2::from_angle(PI).rotate(Vec2::Y)` will
-    /// create the vector [-1, 0] and rotate `Vec2::Y` around it returning `-Vec2::Y`.
+    /// conjunction with the [`rotate()`][Self::rotate()] method, e.g.
+    /// `DVec2::from_angle(PI).rotate(DVec2::Y)` will create the vector `[-1, 0]`
+    /// and rotate [`DVec2::Y`] around it returning `-DVec2::Y`.
     #[inline]
     pub fn from_angle(angle: f64) -> Self {
         let (sin, cos) = math::sin_cos(angle);

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -136,7 +136,7 @@ impl DVec3 {
 
     /// Creates a 2D vector from the `x` and `y` elements of `self`, discarding `z`.
     ///
-    /// Truncation may also be performed by using `self.xy()` or `DVec2::from()`.
+    /// Truncation may also be performed by using [`self.xy()`][crate::swizzles::Vec3Swizzles::xy()].
     #[inline]
     pub fn truncate(self) -> DVec2 {
         use crate::swizzles::Vec3Swizzles;
@@ -384,7 +384,7 @@ impl DVec3 {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -403,7 +403,7 @@ impl DVec3 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -420,7 +420,7 @@ impl DVec3 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {
@@ -666,7 +666,7 @@ impl DVec3 {
     /// The input vector must be finite and non-zero.
     ///
     /// The output vector is not necessarily unit-length.
-    /// For that use [`Self::any_orthonormal_vector`] instead.
+    /// For that use [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -137,7 +137,7 @@ impl DVec4 {
 
     /// Creates a 2D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.
     ///
-    /// Truncation to `DVec3` may also be performed by using `self.xyz()` or `DVec3::from()`.
+    /// Truncation to [`DVec3`] may also be performed by using [`self.xyz()`][crate::swizzles::Vec4Swizzles::xyz()].
     #[inline]
     pub fn truncate(self) -> DVec3 {
         use crate::swizzles::Vec4Swizzles;
@@ -416,7 +416,7 @@ impl DVec4 {
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.
     ///
-    /// See also [`Self::try_normalize`] and [`Self::normalize_or_zero`].
+    /// See also [`Self::try_normalize()`] and [`Self::normalize_or_zero()`].
     ///
     /// Panics
     ///
@@ -435,7 +435,7 @@ impl DVec4 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     ///
-    /// See also [`Self::normalize_or_zero`].
+    /// See also [`Self::normalize_or_zero()`].
     #[must_use]
     #[inline]
     pub fn try_normalize(self) -> Option<Self> {
@@ -452,7 +452,7 @@ impl DVec4 {
     /// In particular, if the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be zero.
     ///
-    /// See also [`Self::try_normalize`].
+    /// See also [`Self::try_normalize()`].
     #[must_use]
     #[inline]
     pub fn normalize_or_zero(self) -> Self {

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -134,7 +134,7 @@ impl IVec3 {
 
     /// Creates a 2D vector from the `x` and `y` elements of `self`, discarding `z`.
     ///
-    /// Truncation may also be performed by using `self.xy()` or `IVec2::from()`.
+    /// Truncation may also be performed by using [`self.xy()`][crate::swizzles::Vec3Swizzles::xy()].
     #[inline]
     pub fn truncate(self) -> IVec2 {
         use crate::swizzles::Vec3Swizzles;

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -135,7 +135,7 @@ impl IVec4 {
 
     /// Creates a 2D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.
     ///
-    /// Truncation to `IVec3` may also be performed by using `self.xyz()` or `IVec3::from()`.
+    /// Truncation to [`IVec3`] may also be performed by using [`self.xyz()`][crate::swizzles::Vec4Swizzles::xyz()].
     #[inline]
     pub fn truncate(self) -> IVec3 {
         use crate::swizzles::Vec4Swizzles;

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -134,7 +134,7 @@ impl I64Vec3 {
 
     /// Creates a 2D vector from the `x` and `y` elements of `self`, discarding `z`.
     ///
-    /// Truncation may also be performed by using `self.xy()` or `I64Vec2::from()`.
+    /// Truncation may also be performed by using [`self.xy()`][crate::swizzles::Vec3Swizzles::xy()].
     #[inline]
     pub fn truncate(self) -> I64Vec2 {
         use crate::swizzles::Vec3Swizzles;

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -135,7 +135,7 @@ impl I64Vec4 {
 
     /// Creates a 2D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.
     ///
-    /// Truncation to `I64Vec3` may also be performed by using `self.xyz()` or `I64Vec3::from()`.
+    /// Truncation to [`I64Vec3`] may also be performed by using [`self.xyz()`][crate::swizzles::Vec4Swizzles::xyz()].
     #[inline]
     pub fn truncate(self) -> I64Vec3 {
         use crate::swizzles::Vec4Swizzles;

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -122,7 +122,7 @@ impl UVec3 {
 
     /// Creates a 2D vector from the `x` and `y` elements of `self`, discarding `z`.
     ///
-    /// Truncation may also be performed by using `self.xy()` or `UVec2::from()`.
+    /// Truncation may also be performed by using [`self.xy()`][crate::swizzles::Vec3Swizzles::xy()].
     #[inline]
     pub fn truncate(self) -> UVec2 {
         use crate::swizzles::Vec3Swizzles;

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -120,7 +120,7 @@ impl UVec4 {
 
     /// Creates a 2D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.
     ///
-    /// Truncation to `UVec3` may also be performed by using `self.xyz()` or `UVec3::from()`.
+    /// Truncation to [`UVec3`] may also be performed by using [`self.xyz()`][crate::swizzles::Vec4Swizzles::xyz()].
     #[inline]
     pub fn truncate(self) -> UVec3 {
         use crate::swizzles::Vec4Swizzles;

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -122,7 +122,7 @@ impl U64Vec3 {
 
     /// Creates a 2D vector from the `x` and `y` elements of `self`, discarding `z`.
     ///
-    /// Truncation may also be performed by using `self.xy()` or `U64Vec2::from()`.
+    /// Truncation may also be performed by using [`self.xy()`][crate::swizzles::Vec3Swizzles::xy()].
     #[inline]
     pub fn truncate(self) -> U64Vec2 {
         use crate::swizzles::Vec3Swizzles;

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -120,7 +120,7 @@ impl U64Vec4 {
 
     /// Creates a 2D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.
     ///
-    /// Truncation to `U64Vec3` may also be performed by using `self.xyz()` or `U64Vec3::from()`.
+    /// Truncation to [`U64Vec3`] may also be performed by using [`self.xyz()`][crate::swizzles::Vec4Swizzles::xyz()].
     #[inline]
     pub fn truncate(self) -> U64Vec3 {
         use crate::swizzles::Vec4Swizzles;


### PR DESCRIPTION
`::from()` to truncate `VecN` to `Vec(N - 1)` has been removed long ago in #195, and should not be mentioned anymore in the docs.  Also replace more type and function references with proper intradocs, making it easier for the reader to click through to the thing that is being mentioned as well as validate such documentation (in particular: validity of intradoc links) on the CI in the future.
