### PR TITLE
CI: Build-test documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
       - name: codegen
         run: cargo run --release -p codegen -- --check
 
+      - name: Build-test documentation
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        run: cargo doc --all --all-features --no-deps --document-private-items
+
   test:
     name: Test
     strategy:


### PR DESCRIPTION
Make sure the documentation is always compiling properly and contains valid intradoc links.  Probably good to land this in advance to #392, to make sure all the intradoc link changes there are solid.
