### PR TITLE
Add repr(C) to unions used for type punning

### DIFF
--- a/codegen/templates/mat.rs.tera
+++ b/codegen/templates/mat.rs.tera
@@ -111,6 +111,7 @@ use core::simd::{Which::*, *};
 {% endif %}
 
 {% if self_t == "Mat2" and is_sse2 %}
+#[repr(C)]
 union UnionCast {
     a: [f32; 4],
     v: {{ self_t }}

--- a/codegen/templates/quat.rs.tera
+++ b/codegen/templates/quat.rs.tera
@@ -68,6 +68,7 @@ use core::ops::{
 };
 
 {% if is_sse2 %}
+#[repr(C)]
 union UnionCast {
     a: [f32; 4],
     v: {{ self_t }}

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -127,6 +127,7 @@ use std::simd::StdFloat;
 {% endif %}
 
 {% if is_sse2 or is_wasm32 %}
+#[repr(C)]
 union UnionCast {
     a: [f32; 4],
     v: {{ self_t }}

--- a/codegen/templates/vec_mask.rs.tera
+++ b/codegen/templates/vec_mask.rs.tera
@@ -35,6 +35,7 @@ use core::simd::*;
 {% endif %}
 
 {% if is_sse2 or is_coresimd %}
+#[repr(C)]
 union UnionCast {
     a: [u32; 4],
     v: {{ self_t }}

--- a/src/bool/coresimd/bvec3a.rs
+++ b/src/bool/coresimd/bvec3a.rs
@@ -6,6 +6,7 @@ use core::ops::*;
 
 use core::simd::*;
 
+#[repr(C)]
 union UnionCast {
     a: [u32; 4],
     v: BVec3A,

--- a/src/bool/coresimd/bvec4a.rs
+++ b/src/bool/coresimd/bvec4a.rs
@@ -6,6 +6,7 @@ use core::ops::*;
 
 use core::simd::*;
 
+#[repr(C)]
 union UnionCast {
     a: [u32; 4],
     v: BVec4A,

--- a/src/bool/sse2/bvec3a.rs
+++ b/src/bool/sse2/bvec3a.rs
@@ -9,6 +9,7 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+#[repr(C)]
 union UnionCast {
     a: [u32; 4],
     v: BVec3A,

--- a/src/bool/sse2/bvec4a.rs
+++ b/src/bool/sse2/bvec4a.rs
@@ -9,6 +9,7 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+#[repr(C)]
 union UnionCast {
     a: [u32; 4],
     v: BVec4A,

--- a/src/f32/sse2/mat2.rs
+++ b/src/f32/sse2/mat2.rs
@@ -11,6 +11,7 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+#[repr(C)]
 union UnionCast {
     a: [f32; 4],
     v: Mat2,

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -17,6 +17,7 @@ use core::fmt;
 use core::iter::{Product, Sum};
 use core::ops::{Add, Deref, DerefMut, Div, Mul, MulAssign, Neg, Sub};
 
+#[repr(C)]
 union UnionCast {
     a: [f32; 4],
     v: Quat,

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -12,6 +12,7 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+#[repr(C)]
 union UnionCast {
     a: [f32; 4],
     v: Vec3A,

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -12,6 +12,7 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+#[repr(C)]
 union UnionCast {
     a: [f32; 4],
     v: Vec4,

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -9,6 +9,7 @@ use core::{f32, ops::*};
 
 use core::arch::wasm32::*;
 
+#[repr(C)]
 union UnionCast {
     a: [f32; 4],
     v: Vec3A,

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -9,6 +9,7 @@ use core::{f32, ops::*};
 
 use core::arch::wasm32::*;
 
+#[repr(C)]
 union UnionCast {
     a: [f32; 4],
     v: Vec4,

--- a/src/sse2.rs
+++ b/src/sse2.rs
@@ -3,6 +3,7 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
+#[repr(C)]
 union UnionCast {
     u32x4: [u32; 4],
     f32x4: [f32; 4],


### PR DESCRIPTION
In the SSE2 code and a few other places, unions are used to initialize SIMD types from scalar arrays through type punning. However, the default representation for unions makes no guarantees about the size of the union or the offsets of its fields. Only with `#[repr(C)]` are all fields guaranteed to have an offset of 0 and thus fully overlap. It is hard to imagine how the compiler would ever deviate from this under `#[repr(Rust)]`, but as far as I understand them, these are the rules.