### PR TITLE
Use right amount of column vectors in documentation

### DIFF
--- a/codegen/templates/mat.rs.tera
+++ b/codegen/templates/mat.rs.tera
@@ -55,6 +55,7 @@
 
 {% set components = ["x", "y", "z", "w"] | slice(end = dim) %}
 {% set axes = ["x_axis", "y_axis", "z_axis", "w_axis"] | slice(end = dim) %}
+{% set dimension_in_full = ["zero", "one", "two", "three", "four"] | nth(n = dim) %}
 
 use crate::{
 {% if scalar_t == "f32" %}
@@ -118,7 +119,7 @@ union UnionCast {
 }
 {% endif %}
 
-/// Creates a {{ nxn }} matrix from column vectors.
+/// Creates a {{ nxn }} matrix from {{ dimension_in_full }} column vectors.
 #[inline(always)]
 pub const fn {{ self_t | lower }}(
     {% for axis in axes %}
@@ -266,7 +267,7 @@ impl {{ self_t }} {
         {% endif %}
     }
 
-    /// Creates a {{ nxn }} matrix from two column vectors.
+    /// Creates a {{ nxn }} matrix from {{ dimension_in_full }} column vectors.
     #[inline(always)]
     pub const fn from_cols(
         {% for axis in axes %}

--- a/src/f32/coresimd/mat2.rs
+++ b/src/f32/coresimd/mat2.rs
@@ -8,7 +8,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use core::simd::{Which::*, *};
 
-/// Creates a 2x2 matrix from column vectors.
+/// Creates a 2x2 matrix from two column vectors.
 #[inline(always)]
 pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
     Mat2::from_cols(x_axis, y_axis)

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -8,7 +8,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use core::simd::{Which::*, *};
 
-/// Creates a 3x3 matrix from column vectors.
+/// Creates a 3x3 matrix from three column vectors.
 #[inline(always)]
 pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
     Mat3A::from_cols(x_axis, y_axis, z_axis)
@@ -76,7 +76,7 @@ impl Mat3A {
         }
     }
 
-    /// Creates a 3x3 matrix from two column vectors.
+    /// Creates a 3x3 matrix from three column vectors.
     #[inline(always)]
     pub const fn from_cols(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Self {
         Self {

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -10,7 +10,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use core::simd::{Which::*, *};
 
-/// Creates a 4x4 matrix from column vectors.
+/// Creates a 4x4 matrix from four column vectors.
 #[inline(always)]
 pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat4 {
     Mat4::from_cols(x_axis, y_axis, z_axis, w_axis)
@@ -92,7 +92,7 @@ impl Mat4 {
         }
     }
 
-    /// Creates a 4x4 matrix from two column vectors.
+    /// Creates a 4x4 matrix from four column vectors.
     #[inline(always)]
     pub const fn from_cols(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Self {
         Self {

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-/// Creates a 3x3 matrix from column vectors.
+/// Creates a 3x3 matrix from three column vectors.
 #[inline(always)]
 pub const fn mat3(x_axis: Vec3, y_axis: Vec3, z_axis: Vec3) -> Mat3 {
     Mat3::from_cols(x_axis, y_axis, z_axis)
@@ -74,7 +74,7 @@ impl Mat3 {
         }
     }
 
-    /// Creates a 3x3 matrix from two column vectors.
+    /// Creates a 3x3 matrix from three column vectors.
     #[inline(always)]
     pub const fn from_cols(x_axis: Vec3, y_axis: Vec3, z_axis: Vec3) -> Self {
         Self {

--- a/src/f32/scalar/mat2.rs
+++ b/src/f32/scalar/mat2.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-/// Creates a 2x2 matrix from column vectors.
+/// Creates a 2x2 matrix from two column vectors.
 #[inline(always)]
 pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
     Mat2::from_cols(x_axis, y_axis)

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-/// Creates a 3x3 matrix from column vectors.
+/// Creates a 3x3 matrix from three column vectors.
 #[inline(always)]
 pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
     Mat3A::from_cols(x_axis, y_axis, z_axis)
@@ -74,7 +74,7 @@ impl Mat3A {
         }
     }
 
-    /// Creates a 3x3 matrix from two column vectors.
+    /// Creates a 3x3 matrix from three column vectors.
     #[inline(always)]
     pub const fn from_cols(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Self {
         Self {

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-/// Creates a 4x4 matrix from column vectors.
+/// Creates a 4x4 matrix from four column vectors.
 #[inline(always)]
 pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat4 {
     Mat4::from_cols(x_axis, y_axis, z_axis, w_axis)
@@ -95,7 +95,7 @@ impl Mat4 {
         }
     }
 
-    /// Creates a 4x4 matrix from two column vectors.
+    /// Creates a 4x4 matrix from four column vectors.
     #[inline(always)]
     pub const fn from_cols(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Self {
         Self {

--- a/src/f32/sse2/mat2.rs
+++ b/src/f32/sse2/mat2.rs
@@ -17,7 +17,7 @@ union UnionCast {
     v: Mat2,
 }
 
-/// Creates a 2x2 matrix from column vectors.
+/// Creates a 2x2 matrix from two column vectors.
 #[inline(always)]
 pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
     Mat2::from_cols(x_axis, y_axis)

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -11,7 +11,7 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
-/// Creates a 3x3 matrix from column vectors.
+/// Creates a 3x3 matrix from three column vectors.
 #[inline(always)]
 pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
     Mat3A::from_cols(x_axis, y_axis, z_axis)
@@ -79,7 +79,7 @@ impl Mat3A {
         }
     }
 
-    /// Creates a 3x3 matrix from two column vectors.
+    /// Creates a 3x3 matrix from three column vectors.
     #[inline(always)]
     pub const fn from_cols(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Self {
         Self {

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -13,7 +13,7 @@ use core::arch::x86::*;
 #[cfg(target_arch = "x86_64")]
 use core::arch::x86_64::*;
 
-/// Creates a 4x4 matrix from column vectors.
+/// Creates a 4x4 matrix from four column vectors.
 #[inline(always)]
 pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat4 {
     Mat4::from_cols(x_axis, y_axis, z_axis, w_axis)
@@ -95,7 +95,7 @@ impl Mat4 {
         }
     }
 
-    /// Creates a 4x4 matrix from two column vectors.
+    /// Creates a 4x4 matrix from four column vectors.
     #[inline(always)]
     pub const fn from_cols(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Self {
         Self {

--- a/src/f32/wasm32/mat2.rs
+++ b/src/f32/wasm32/mat2.rs
@@ -8,7 +8,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use core::arch::wasm32::*;
 
-/// Creates a 2x2 matrix from column vectors.
+/// Creates a 2x2 matrix from two column vectors.
 #[inline(always)]
 pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
     Mat2::from_cols(x_axis, y_axis)

--- a/src/f32/wasm32/mat3a.rs
+++ b/src/f32/wasm32/mat3a.rs
@@ -8,7 +8,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use core::arch::wasm32::*;
 
-/// Creates a 3x3 matrix from column vectors.
+/// Creates a 3x3 matrix from three column vectors.
 #[inline(always)]
 pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
     Mat3A::from_cols(x_axis, y_axis, z_axis)
@@ -76,7 +76,7 @@ impl Mat3A {
         }
     }
 
-    /// Creates a 3x3 matrix from two column vectors.
+    /// Creates a 3x3 matrix from three column vectors.
     #[inline(always)]
     pub const fn from_cols(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Self {
         Self {

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -10,7 +10,7 @@ use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use core::arch::wasm32::*;
 
-/// Creates a 4x4 matrix from column vectors.
+/// Creates a 4x4 matrix from four column vectors.
 #[inline(always)]
 pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat4 {
     Mat4::from_cols(x_axis, y_axis, z_axis, w_axis)
@@ -92,7 +92,7 @@ impl Mat4 {
         }
     }
 
-    /// Creates a 4x4 matrix from two column vectors.
+    /// Creates a 4x4 matrix from four column vectors.
     #[inline(always)]
     pub const fn from_cols(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Self {
         Self {

--- a/src/f64/dmat2.rs
+++ b/src/f64/dmat2.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-/// Creates a 2x2 matrix from column vectors.
+/// Creates a 2x2 matrix from two column vectors.
 #[inline(always)]
 pub const fn dmat2(x_axis: DVec2, y_axis: DVec2) -> DMat2 {
     DMat2::from_cols(x_axis, y_axis)

--- a/src/f64/dmat3.rs
+++ b/src/f64/dmat3.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-/// Creates a 3x3 matrix from column vectors.
+/// Creates a 3x3 matrix from three column vectors.
 #[inline(always)]
 pub const fn dmat3(x_axis: DVec3, y_axis: DVec3, z_axis: DVec3) -> DMat3 {
     DMat3::from_cols(x_axis, y_axis, z_axis)
@@ -74,7 +74,7 @@ impl DMat3 {
         }
     }
 
-    /// Creates a 3x3 matrix from two column vectors.
+    /// Creates a 3x3 matrix from three column vectors.
     #[inline(always)]
     pub const fn from_cols(x_axis: DVec3, y_axis: DVec3, z_axis: DVec3) -> Self {
         Self {

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use core::iter::{Product, Sum};
 use core::ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign};
 
-/// Creates a 4x4 matrix from column vectors.
+/// Creates a 4x4 matrix from four column vectors.
 #[inline(always)]
 pub const fn dmat4(x_axis: DVec4, y_axis: DVec4, z_axis: DVec4, w_axis: DVec4) -> DMat4 {
     DMat4::from_cols(x_axis, y_axis, z_axis, w_axis)
@@ -89,7 +89,7 @@ impl DMat4 {
         }
     }
 
-    /// Creates a 4x4 matrix from two column vectors.
+    /// Creates a 4x4 matrix from four column vectors.
     #[inline(always)]
     pub const fn from_cols(x_axis: DVec4, y_axis: DVec4, z_axis: DVec4, w_axis: DVec4) -> Self {
         Self {


### PR DESCRIPTION
Just a simple documentation fix to correct an error most likely coming from a c/p mistake.
