### PR TITLE
doc: range for Vec2 angle_between

### DIFF
--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -1447,7 +1447,7 @@ impl {{ self_t }} {
         }
     }
 
-    /// Returns the angle (in radians) between `self` and `rhs`.
+    /// Returns the angle (in radians) between `self` and `rhs` in the range `[-π, +π]`.
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     #[inline]

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -628,7 +628,7 @@ impl Vec2 {
         Self { x: cos, y: sin }
     }
 
-    /// Returns the angle (in radians) between `self` and `rhs`.
+    /// Returns the angle (in radians) between `self` and `rhs` in the range `[-π, +π]`.
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     #[inline]

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -628,7 +628,7 @@ impl DVec2 {
         Self { x: cos, y: sin }
     }
 
-    /// Returns the angle (in radians) between `self` and `rhs`.
+    /// Returns the angle (in radians) between `self` and `rhs` in the range `[-π, +π]`.
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     #[inline]


### PR DESCRIPTION
I'm not sure if there's a preference between `π`, `&pi;`, `pi`...