### PR TITLE
Use libm::fabs() & libm::fabsf()

### DIFF
--- a/src/f32/math.rs
+++ b/src/f32/math.rs
@@ -36,13 +36,7 @@ fn acos_approx_f32(v: f32) -> f32 {
 mod libm_math {
     #[inline(always)]
     pub(crate) fn abs(f: f32) -> f32 {
-        if f.is_sign_positive() {
-            return f;
-        }
-        if f.is_sign_negative() {
-            return -f;
-        }
-        f32::NAN
+        libm::fabsf(f)
     }
 
     #[inline(always)]

--- a/src/f64/math.rs
+++ b/src/f64/math.rs
@@ -2,13 +2,7 @@
 mod libm_math {
     #[inline(always)]
     pub(crate) fn abs(f: f64) -> f64 {
-        if f.is_sign_positive() {
-            return f;
-        }
-        if f.is_sign_negative() {
-            return -f;
-        }
-        f64::NAN
+        libm::fabs(f)
     }
 
     #[inline(always)]


### PR DESCRIPTION
libm's implementation is shorter + the current approach sometimes yields _very funky_ results on Windows (I haven't investigated it deeper though, since swapping the implementation to libm solves my problem).