### PR TITLE
Updated int vec2 to have l1 distance and chessboard distance

### DIFF
--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -286,6 +286,22 @@ impl IVec2 {
         (self - rhs).length_squared()
     }
 
+    /// Compute the L1 distance between two points in space.
+    #[inline]
+    pub fn ldistance(self, rhs: Self) -> i64 {
+        (self.x.abs_diff(rhs.x)) as i64 + (self.y.abs_diff(rhs.y) as i64)
+    }
+
+    /// Compute the Chebyshev distance between two points in space.
+    #[inline]
+    pub fn cdistance(&self, rhs: Self) -> i64 {
+        std::cmp::max(
+            (self.x.abs_diff(rhs.x)) as i64,
+            (self.y.abs_diff(rhs.y)) as i64,
+        )
+    }
+
+
     /// Returns a vector that is equal to `self` rotated by 90 degrees.
     #[inline]
     pub fn perp(self) -> Self {

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -286,6 +286,21 @@ impl I64Vec2 {
         (self - rhs).length_squared()
     }
 
+    /// Compute the L1 distance between two points in space.
+    #[inline]
+    pub fn ldistance(self, rhs: Self) -> i128 {
+        (self.x.abs_diff(rhs.x)) as i128 + (self.y.abs_diff(rhs.y) as i128)
+    }
+
+    /// Compute the Chebyshev distance between two points in space.
+    #[inline]
+    pub fn cdistance(&self, rhs: Self) -> i128 {
+        std::cmp::max(
+            (self.x.abs_diff(rhs.x)) as i128,
+            (self.y.abs_diff(rhs.y)) as i128,
+        )
+    }
+
     /// Returns a vector that is equal to `self` rotated by 90 degrees.
     #[inline]
     pub fn perp(self) -> Self {

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -240,6 +240,21 @@ impl UVec2 {
         self.dot(self)
     }
 
+    /// Compute the L1 distance between two points in space.
+    #[inline]
+    pub fn ldistance(self, rhs: Self) -> u64 {
+        (self.x.abs_diff(rhs.x)) as u64 + (self.y.abs_diff(rhs.y) as u64)
+    }
+
+    /// Compute the Chebyshev distance between two points in space.
+    #[inline]
+    pub fn cdistance(&self, rhs: Self) -> u64 {
+        std::cmp::max(
+            (self.x.abs_diff(rhs.x)) as u64,
+            (self.y.abs_diff(rhs.y)) as u64,
+        )
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     pub fn as_vec2(&self) -> crate::Vec2 {

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -240,6 +240,21 @@ impl U64Vec2 {
         self.dot(self)
     }
 
+    /// Compute the L1 distance between two points in space.
+    #[inline]
+    pub fn ldistance(self, rhs: Self) -> u128 {
+        (self.x.abs_diff(rhs.x)) as u128 + (self.y.abs_diff(rhs.y) as u128)
+    }
+
+    /// Compute the Chebyshev distance between two points in space.
+    #[inline]
+    pub fn cdistance(&self, rhs: Self) -> u128 {
+        std::cmp::max(
+            (self.x.abs_diff(rhs.x)) as u128,
+            (self.y.abs_diff(rhs.y)) as u128,
+        )
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     pub fn as_vec2(&self) -> crate::Vec2 {


### PR DESCRIPTION
Hi,

I added L1 Distance and Chebyshev distance computation functions to all integer vecs as I've found it really useful in dealing with grid positions using integer Vec2s. They return the next biggest int size as a result because it's possible to have 2*MAX_INT as the result.

I tried to keep to the style and I added docs for it. Please let me know if you need me to do anything else and if these functions are not wanted please feel free to close this.