### PR TITLE
Set `default-features = false` on rkyv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build-test documentation
         env:
           RUSTDOCFLAGS: -Dwarnings
-        run: cargo doc --all --all-features --no-deps --document-private-items
+        run: cargo doc --all --all-features --no-deps --document-private-items --features rkyv/size_32
 
   test:
     name: Test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ libm = { version = "0.2", optional = true, default-features = false}
 [dev-dependencies]
 # rand_xoshiro is required for tests if rand is enabled
 rand_xoshiro = "0.6"
+rkyv = "0.7"
 serde_json = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,13 +48,14 @@ mint = { version = "0.5.8", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
-bytecheck = { version = "0.6", optional = true, default-features = false}
+bytecheck = { version = "0.6", optional = true, default-features = false }
 libm = { version = "0.2", optional = true, default-features = false}
 
 [dev-dependencies]
 # rand_xoshiro is required for tests if rand is enabled
 rand_xoshiro = "0.6"
-rkyv = "0.7"
+# Set a size_xx feature so that this crate compiles properly with --all-targets --all-features
+rkyv = { version = "0.7", features = ["size_32"] }
 serde_json = "1.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ bytemuck = { version = "1.9", optional = true, default-features = false }
 mint = { version = "0.5.8", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
-rkyv = { version = "0.7", optional = true }
+rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.6", optional = true, default-features = false}
 libm = { version = "0.2", optional = true, default-features = false}
 


### PR DESCRIPTION
Using default features pulls in the `size_32` feature, but the choice of the `size_x` feature should be left to the top-level crate as it was thought of in https://github.com/bitshifter/glam-rs/pull/223#discussion_r683917210 and https://github.com/bitshifter/glam-rs/pull/223#issuecomment-895328926, and should be working now that `glam-rs` is on edition 2021 and rust >= 1.50.