### PR TITLE
Fix clippy lints

### DIFF
--- a/src/sse2.rs
+++ b/src/sse2.rs
@@ -174,8 +174,7 @@ pub(crate) unsafe fn m128_trunc(v: __m128) -> __m128 {
     vresult = _mm_and_ps(vresult, _mm_castsi128_ps(vtest));
     // All others, use the ORIGINAL value
     vtest = _mm_andnot_si128(vtest, _mm_castps_si128(v));
-    vresult = _mm_or_ps(vresult, _mm_castsi128_ps(vtest));
-    return vresult;
+    _mm_or_ps(vresult, _mm_castsi128_ps(vtest))
 }
 
 /// Returns a vector whose components are the corresponding components of Angles modulo 2PI.

--- a/tests/affine2.rs
+++ b/tests/affine2.rs
@@ -181,10 +181,7 @@ macro_rules! impl_affine2_tests {
 
         glam_test!(test_product, {
             let ident = $affine2::IDENTITY;
-            assert_eq!(
-                vec![ident, ident].iter().product::<$affine2>(),
-                ident * ident
-            );
+            assert_eq!([ident, ident].iter().product::<$affine2>(), ident * ident);
         });
 
         glam_test!(test_affine2_is_finite, {

--- a/tests/affine3.rs
+++ b/tests/affine3.rs
@@ -331,10 +331,7 @@ macro_rules! impl_affine3_tests {
 
         glam_test!(test_product, {
             let ident = $affine3::IDENTITY;
-            assert_eq!(
-                vec![ident, ident].iter().product::<$affine3>(),
-                ident * ident
-            );
+            assert_eq!([ident, ident].iter().product::<$affine3>(), ident * ident);
         });
 
         glam_test!(test_affine3_is_finite, {

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -202,14 +202,14 @@ macro_rules! impl_mat2_tests {
 
         glam_test!(test_sum, {
             let id = $mat2::IDENTITY;
-            assert_eq!(vec![id, id].iter().sum::<$mat2>(), id + id);
-            assert_eq!(vec![id, id].into_iter().sum::<$mat2>(), id + id);
+            assert_eq!([id, id].iter().sum::<$mat2>(), id + id);
+            assert_eq!([id, id].into_iter().sum::<$mat2>(), id + id);
         });
 
         glam_test!(test_product, {
             let two = $mat2::IDENTITY + $mat2::IDENTITY;
-            assert_eq!(vec![two, two].iter().product::<$mat2>(), two * two);
-            assert_eq!(vec![two, two].into_iter().product::<$mat2>(), two * two);
+            assert_eq!([two, two].iter().product::<$mat2>(), two * two);
+            assert_eq!([two, two].into_iter().product::<$mat2>(), two * two);
         });
 
         glam_test!(test_mat2_is_finite, {

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -341,14 +341,14 @@ macro_rules! impl_mat3_tests {
 
         glam_test!(test_sum, {
             let id = $mat3::IDENTITY;
-            assert_eq!(vec![id, id].iter().sum::<$mat3>(), id + id);
-            assert_eq!(vec![id, id].into_iter().sum::<$mat3>(), id + id);
+            assert_eq!([id, id].iter().sum::<$mat3>(), id + id);
+            assert_eq!([id, id].into_iter().sum::<$mat3>(), id + id);
         });
 
         glam_test!(test_product, {
             let two = $mat3::IDENTITY + $mat3::IDENTITY;
-            assert_eq!(vec![two, two].iter().product::<$mat3>(), two * two);
-            assert_eq!(vec![two, two].into_iter().product::<$mat3>(), two * two);
+            assert_eq!([two, two].iter().product::<$mat3>(), two * two);
+            assert_eq!([two, two].into_iter().product::<$mat3>(), two * two);
         });
 
         glam_test!(test_mat3_is_finite, {

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -647,14 +647,14 @@ macro_rules! impl_mat4_tests {
 
         glam_test!(test_sum, {
             let id = $mat4::IDENTITY;
-            assert_eq!(vec![id, id].iter().sum::<$mat4>(), id + id);
-            assert_eq!(vec![id, id].into_iter().sum::<$mat4>(), id + id);
+            assert_eq!([id, id].iter().sum::<$mat4>(), id + id);
+            assert_eq!([id, id].into_iter().sum::<$mat4>(), id + id);
         });
 
         glam_test!(test_product, {
             let two = $mat4::IDENTITY + $mat4::IDENTITY;
-            assert_eq!(vec![two, two].iter().product::<$mat4>(), two * two);
-            assert_eq!(vec![two, two].into_iter().product::<$mat4>(), two * two);
+            assert_eq!([two, two].iter().product::<$mat4>(), two * two);
+            assert_eq!([two, two].into_iter().product::<$mat4>(), two * two);
         });
 
         glam_test!(test_mat4_is_finite, {

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -407,14 +407,14 @@ macro_rules! impl_quat_tests {
 
         glam_test!(test_sum, {
             let two = $new(2.0, 2.0, 2.0, 2.0);
-            assert_eq!(vec![two, two].iter().sum::<$quat>(), two + two);
-            assert_eq!(vec![two, two].into_iter().sum::<$quat>(), two + two);
+            assert_eq!([two, two].iter().sum::<$quat>(), two + two);
+            assert_eq!([two, two].into_iter().sum::<$quat>(), two + two);
         });
 
         glam_test!(test_product, {
             let two = $new(2.0, 2.0, 2.0, 2.0).normalize();
-            assert_eq!(vec![two, two].iter().product::<$quat>(), two * two);
-            assert_eq!(vec![two, two].into_iter().product::<$quat>(), two * two);
+            assert_eq!([two, two].iter().product::<$quat>(), two * two);
+            assert_eq!([two, two].into_iter().product::<$quat>(), two * two);
         });
 
         glam_test!(test_is_finite, {

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -488,14 +488,14 @@ macro_rules! impl_vec2_tests {
 
         glam_test!(test_sum, {
             let one = $vec2::ONE;
-            assert_eq!(vec![one, one].iter().sum::<$vec2>(), one + one);
-            assert_eq!(vec![one, one].into_iter().sum::<$vec2>(), one + one);
+            assert_eq!([one, one].iter().sum::<$vec2>(), one + one);
+            assert_eq!([one, one].into_iter().sum::<$vec2>(), one + one);
         });
 
         glam_test!(test_product, {
             let two = $vec2::new(2 as $t, 2 as $t);
-            assert_eq!(vec![two, two].iter().product::<$vec2>(), two * two);
-            assert_eq!(vec![two, two].into_iter().product::<$vec2>(), two * two);
+            assert_eq!([two, two].iter().product::<$vec2>(), two * two);
+            assert_eq!([two, two].into_iter().product::<$vec2>(), two * two);
         });
     };
 }

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -545,14 +545,14 @@ macro_rules! impl_vec3_tests {
 
         glam_test!(test_sum, {
             let one = $vec3::ONE;
-            assert_eq!(vec![one, one].iter().sum::<$vec3>(), one + one);
-            assert_eq!(vec![one, one].into_iter().sum::<$vec3>(), one + one);
+            assert_eq!([one, one].iter().sum::<$vec3>(), one + one);
+            assert_eq!([one, one].into_iter().sum::<$vec3>(), one + one);
         });
 
         glam_test!(test_product, {
             let two = $vec3::new(2 as $t, 2 as $t, 2 as $t);
-            assert_eq!(vec![two, two].iter().product::<$vec3>(), two * two);
-            assert_eq!(vec![two, two].into_iter().product::<$vec3>(), two * two);
+            assert_eq!([two, two].iter().product::<$vec3>(), two * two);
+            assert_eq!([two, two].into_iter().product::<$vec3>(), two * two);
         });
     };
 }

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -633,14 +633,14 @@ macro_rules! impl_vec4_tests {
 
         glam_test!(test_sum, {
             let one = $vec4::ONE;
-            assert_eq!(vec![one, one].iter().sum::<$vec4>(), one + one);
-            assert_eq!(vec![one, one].into_iter().sum::<$vec4>(), one + one);
+            assert_eq!([one, one].iter().sum::<$vec4>(), one + one);
+            assert_eq!([one, one].into_iter().sum::<$vec4>(), one + one);
         });
 
         glam_test!(test_product, {
             let two = $vec4::new(2 as $t, 2 as $t, 2 as $t, 2 as $t);
-            assert_eq!(vec![two, two].iter().product::<$vec4>(), two * two);
-            assert_eq!(vec![two, two].into_iter().product::<$vec4>(), two * two);
+            assert_eq!([two, two].iter().product::<$vec4>(), two * two);
+            assert_eq!([two, two].into_iter().product::<$vec4>(), two * two);
         });
     };
 }


### PR DESCRIPTION
Use arrays where Vecs aren't needed (no perf impact because it's just tests, but shorter).