### PR TITLE
Implement div_euclid, rem_euclid

### DIFF
--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -1080,7 +1080,7 @@ impl {{ self_t }} {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-    {% endif %}
+    {%- endif %}
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -1099,7 +1099,7 @@ impl {{ self_t }} {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-    {% endif %}
+    {%- endif %}
     ///
     /// [Euclidean division]: {{scalar_t}}::rem_euclid
     #[inline]

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -1074,6 +1074,48 @@ impl {{ self_t }} {
     pub fn distance_squared(self, rhs: Self) -> {{ scalar_t }} {
         (self - rhs).length_squared()
     }
+
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+    {% if is_float%}
+    {% if not is_scalar %}
+    /// This is not SIMD-accelerated.
+    {% endif %}
+    {% else %}
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+    {% endif %}
+    {% if is_float %} #[cfg(not(feature = "libm"))] {% endif %}
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..{{ dim }} {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+    {% if is_float %}
+    {% if not is_scalar %}
+    /// This is not SIMD-accelerated.
+    {% endif %}
+    {% else %}
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+    {% endif %}
+    ///
+    /// [Euclidean division]: {{scalar_t}}::rem_euclid
+    {% if is_float %} #[cfg(not(feature = "libm"))] {% endif %}
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..{{ dim }} {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
 {% endif %}
 
 {% if is_float %}

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -1076,45 +1076,43 @@ impl {{ self_t }} {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    {%- if not is_float%}
     ///
-    {% if is_float%}
-    {% if not is_scalar %}
-    /// This is not SIMD-accelerated.
-    {% endif %}
-    {% else %}
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     {% endif %}
-    {% if is_float %} #[cfg(not(feature = "libm"))] {% endif %}
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..{{ dim }} {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            {% for c in components %}
+                {% if is_float %}
+                math::div_euclid(self.{{ c }}, rhs.{{ c }}),
+                {% else %}
+                self.{{ c }}.div_euclid(rhs.{{ c }}),
+                {% endif %}
+            {%- endfor %}
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    {%- if not is_float %}
     ///
-    {% if is_float %}
-    {% if not is_scalar %}
-    /// This is not SIMD-accelerated.
-    {% endif %}
-    {% else %}
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     {% endif %}
     ///
     /// [Euclidean division]: {{scalar_t}}::rem_euclid
-    {% if is_float %} #[cfg(not(feature = "libm"))] {% endif %}
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..{{ dim }} {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            {% for c in components %}
+                {% if is_float %}
+                math::rem_euclid(self.{{ c }}, rhs.{{ c }}),
+                {% else %}
+                self.{{ c }}.rem_euclid(rhs.{{ c }}),
+                {% endif %}
+            {%- endfor %}
+        )
     }
 {% endif %}
 

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -380,35 +380,25 @@ impl Vec3A {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    /// This is not SIMD-accelerated.
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+            math::div_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    /// This is not SIMD-accelerated.
-
-    ///
     /// [Euclidean division]: f32::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+            math::rem_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -379,6 +379,38 @@ impl Vec3A {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    ///
+    /// [Euclidean division]: f32::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -352,6 +352,38 @@ impl Vec4 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    ///
+    /// [Euclidean division]: f32::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -353,35 +353,27 @@ impl Vec4 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    /// This is not SIMD-accelerated.
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+            math::div_euclid(self.z, rhs.z),
+            math::div_euclid(self.w, rhs.w),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    /// This is not SIMD-accelerated.
-
-    ///
     /// [Euclidean division]: f32::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+            math::rem_euclid(self.z, rhs.z),
+            math::rem_euclid(self.w, rhs.w),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f32/math.rs
+++ b/src/f32/math.rs
@@ -123,6 +123,26 @@ mod libm_math {
     pub(crate) fn mul_add(a: f32, b: f32, c: f32) -> f32 {
         libm::fmaf(a, b, c)
     }
+
+    #[inline]
+    pub fn div_euclid(a: f32, b: f32) -> f32 {
+        // Based on https://doc.rust-lang.org/src/std/f32.rs.html#293
+        let q = libm::truncf(a / b);
+        if a % b < 0.0 {
+            return if b > 0.0 { q - 1.0 } else { q + 1.0 };
+        }
+        q
+    }
+
+    #[inline]
+    pub fn rem_euclid(a: f32, b: f32) -> f32 {
+        let r = a % b;
+        if r < 0.0 {
+            r + abs(b)
+        } else {
+            r
+        }
+    }
 }
 
 #[cfg(not(feature = "libm"))]
@@ -211,6 +231,16 @@ mod std_math {
     #[inline(always)]
     pub(crate) fn mul_add(a: f32, b: f32, c: f32) -> f32 {
         f32::mul_add(a, b, c)
+    }
+
+    #[inline]
+    pub fn div_euclid(a: f32, b: f32) -> f32 {
+        f32::div_euclid(a, b)
+    }
+
+    #[inline]
+    pub fn rem_euclid(a: f32, b: f32) -> f32 {
+        f32::rem_euclid(a, b)
     }
 }
 

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -401,6 +401,34 @@ impl Vec3A {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    ///
+    /// [Euclidean division]: f32::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -402,31 +402,25 @@ impl Vec3A {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+            math::div_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    ///
     /// [Euclidean division]: f32::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+            math::rem_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -433,31 +433,27 @@ impl Vec4 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+            math::div_euclid(self.z, rhs.z),
+            math::div_euclid(self.w, rhs.w),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    ///
     /// [Euclidean division]: f32::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+            math::rem_euclid(self.z, rhs.z),
+            math::rem_euclid(self.w, rhs.w),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -432,6 +432,34 @@ impl Vec4 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    ///
+    /// [Euclidean division]: f32::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -416,35 +416,25 @@ impl Vec3A {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    /// This is not SIMD-accelerated.
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+            math::div_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    /// This is not SIMD-accelerated.
-
-    ///
     /// [Euclidean division]: f32::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+            math::rem_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -415,6 +415,38 @@ impl Vec3A {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    ///
+    /// [Euclidean division]: f32::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -390,35 +390,27 @@ impl Vec4 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    /// This is not SIMD-accelerated.
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+            math::div_euclid(self.z, rhs.z),
+            math::div_euclid(self.w, rhs.w),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    /// This is not SIMD-accelerated.
-
-    ///
     /// [Euclidean division]: f32::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+            math::rem_euclid(self.z, rhs.z),
+            math::rem_euclid(self.w, rhs.w),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -389,6 +389,38 @@ impl Vec4 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    ///
+    /// [Euclidean division]: f32::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -347,6 +347,34 @@ impl Vec2 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..2 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    ///
+    /// [Euclidean division]: f32::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..2 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -348,31 +348,23 @@ impl Vec2 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..2 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    ///
     /// [Euclidean division]: f32::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..2 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -392,6 +392,34 @@ impl Vec3 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    ///
+    /// [Euclidean division]: f32::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -393,31 +393,25 @@ impl Vec3 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+            math::div_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    ///
     /// [Euclidean division]: f32::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+            math::rem_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -393,35 +393,25 @@ impl Vec3A {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    /// This is not SIMD-accelerated.
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+            math::div_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    /// This is not SIMD-accelerated.
-
-    ///
     /// [Euclidean division]: f32::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+            math::rem_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -392,6 +392,38 @@ impl Vec3A {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    ///
+    /// [Euclidean division]: f32::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -374,35 +374,27 @@ impl Vec4 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    /// This is not SIMD-accelerated.
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+            math::div_euclid(self.z, rhs.z),
+            math::div_euclid(self.w, rhs.w),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    /// This is not SIMD-accelerated.
-
-    ///
     /// [Euclidean division]: f32::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+            math::rem_euclid(self.z, rhs.z),
+            math::rem_euclid(self.w, rhs.w),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -373,6 +373,38 @@ impl Vec4 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// This is not SIMD-accelerated.
+
+    ///
+    /// [Euclidean division]: f32::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -348,31 +348,23 @@ impl DVec2 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..2 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    ///
     /// [Euclidean division]: f64::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..2 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -347,6 +347,34 @@ impl DVec2 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..2 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    ///
+    /// [Euclidean division]: f64::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..2 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -393,31 +393,25 @@ impl DVec3 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+            math::div_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    ///
     /// [Euclidean division]: f64::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+            math::rem_euclid(self.z, rhs.z),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -392,6 +392,34 @@ impl DVec3 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    ///
+    /// [Euclidean division]: f64::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -424,6 +424,34 @@ impl DVec4 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    ///
+    /// [Euclidean division]: f64::rem_euclid
+    #[cfg(not(feature = "libm"))]
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns `self` normalized to length 1.0.
     ///
     /// For valid results, `self` must _not_ be of length zero, nor very close to zero.

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -425,31 +425,27 @@ impl DVec4 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
-    ///
-
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::div_euclid(self.x, rhs.x),
+            math::div_euclid(self.y, rhs.y),
+            math::div_euclid(self.z, rhs.z),
+            math::div_euclid(self.w, rhs.w),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
-    ///
     /// [Euclidean division]: f64::rem_euclid
-    #[cfg(not(feature = "libm"))]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            math::rem_euclid(self.x, rhs.x),
+            math::rem_euclid(self.y, rhs.y),
+            math::rem_euclid(self.z, rhs.z),
+            math::rem_euclid(self.w, rhs.w),
+        )
     }
 
     /// Returns `self` normalized to length 1.0.

--- a/src/f64/math.rs
+++ b/src/f64/math.rs
@@ -88,6 +88,26 @@ mod libm_math {
     pub(crate) fn mul_add(a: f64, b: f64, c: f64) -> f64 {
         libm::fma(a, b, c)
     }
+
+    #[inline]
+    pub fn div_euclid(a: f64, b: f64) -> f64 {
+        // Based on https://doc.rust-lang.org/src/std/f64.rs.html#293
+        let q = libm::trunc(a / b);
+        if a % b < 0.0 {
+            return if b > 0.0 { q - 1.0 } else { q + 1.0 };
+        }
+        q
+    }
+
+    #[inline]
+    pub fn rem_euclid(a: f64, b: f64) -> f64 {
+        let r = a % b;
+        if r < 0.0 {
+            r + abs(b)
+        } else {
+            r
+        }
+    }
 }
 
 #[cfg(not(feature = "libm"))]
@@ -175,6 +195,16 @@ mod std_math {
     #[inline(always)]
     pub(crate) fn mul_add(a: f64, b: f64, c: f64) -> f64 {
         f64::mul_add(a, b, c)
+    }
+
+    #[inline]
+    pub fn div_euclid(a: f64, b: f64) -> f64 {
+        f64::div_euclid(a, b)
+    }
+
+    #[inline]
+    pub fn rem_euclid(a: f64, b: f64) -> f64 {
+        f64::rem_euclid(a, b)
     }
 }
 

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -288,35 +288,24 @@ impl IVec2 {
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..2 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(self.x.div_euclid(rhs.x), self.y.div_euclid(rhs.y))
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     ///
     /// [Euclidean division]: i32::rem_euclid
-
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..2 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(self.x.rem_euclid(rhs.x), self.y.rem_euclid(rhs.y))
     }
 
     /// Returns a vector that is equal to `self` rotated by 90 degrees.

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -290,7 +290,6 @@ impl IVec2 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(self.x.div_euclid(rhs.x), self.y.div_euclid(rhs.y))
@@ -300,7 +299,6 @@ impl IVec2 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     ///
     /// [Euclidean division]: i32::rem_euclid
     #[inline]

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -286,6 +286,39 @@ impl IVec2 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..2 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    ///
+    /// [Euclidean division]: i32::rem_euclid
+
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..2 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns a vector that is equal to `self` rotated by 90 degrees.
     #[inline]
     pub fn perp(self) -> Self {

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -334,7 +334,6 @@ impl IVec3 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -348,7 +347,6 @@ impl IVec3 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     ///
     /// [Euclidean division]: i32::rem_euclid
     #[inline]

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -330,6 +330,39 @@ impl IVec3 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    ///
+    /// [Euclidean division]: i32::rem_euclid
+
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     pub fn as_vec3(&self) -> crate::Vec3 {

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -332,35 +332,32 @@ impl IVec3 {
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            self.x.div_euclid(rhs.x),
+            self.y.div_euclid(rhs.y),
+            self.z.div_euclid(rhs.z),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     ///
     /// [Euclidean division]: i32::rem_euclid
-
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            self.x.rem_euclid(rhs.x),
+            self.y.rem_euclid(rhs.y),
+            self.z.rem_euclid(rhs.z),
+        )
     }
 
     /// Casts all elements of `self` to `f32`.

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -360,7 +360,6 @@ impl IVec4 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -375,7 +374,6 @@ impl IVec4 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     ///
     /// [Euclidean division]: i32::rem_euclid
     #[inline]

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -358,35 +358,34 @@ impl IVec4 {
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            self.x.div_euclid(rhs.x),
+            self.y.div_euclid(rhs.y),
+            self.z.div_euclid(rhs.z),
+            self.w.div_euclid(rhs.w),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     ///
     /// [Euclidean division]: i32::rem_euclid
-
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            self.x.rem_euclid(rhs.x),
+            self.y.rem_euclid(rhs.y),
+            self.z.rem_euclid(rhs.z),
+            self.w.rem_euclid(rhs.w),
+        )
     }
 
     /// Casts all elements of `self` to `f32`.

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -356,6 +356,39 @@ impl IVec4 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    ///
+    /// [Euclidean division]: i32::rem_euclid
+
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     pub fn as_vec4(&self) -> crate::Vec4 {

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -286,6 +286,39 @@ impl I64Vec2 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..2 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    ///
+    /// [Euclidean division]: i64::rem_euclid
+
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..2 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Returns a vector that is equal to `self` rotated by 90 degrees.
     #[inline]
     pub fn perp(self) -> Self {

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -290,7 +290,6 @@ impl I64Vec2 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(self.x.div_euclid(rhs.x), self.y.div_euclid(rhs.y))
@@ -300,7 +299,6 @@ impl I64Vec2 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     ///
     /// [Euclidean division]: i64::rem_euclid
     #[inline]

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -288,35 +288,24 @@ impl I64Vec2 {
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..2 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(self.x.div_euclid(rhs.x), self.y.div_euclid(rhs.y))
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     ///
     /// [Euclidean division]: i64::rem_euclid
-
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..2 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(self.x.rem_euclid(rhs.x), self.y.rem_euclid(rhs.y))
     }
 
     /// Returns a vector that is equal to `self` rotated by 90 degrees.

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -330,6 +330,39 @@ impl I64Vec3 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    ///
+    /// [Euclidean division]: i64::rem_euclid
+
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..3 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     pub fn as_vec3(&self) -> crate::Vec3 {

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -334,7 +334,6 @@ impl I64Vec3 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -348,7 +347,6 @@ impl I64Vec3 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     ///
     /// [Euclidean division]: i64::rem_euclid
     #[inline]

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -332,35 +332,32 @@ impl I64Vec3 {
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            self.x.div_euclid(rhs.x),
+            self.y.div_euclid(rhs.y),
+            self.z.div_euclid(rhs.z),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     ///
     /// [Euclidean division]: i64::rem_euclid
-
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..3 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            self.x.rem_euclid(rhs.x),
+            self.y.rem_euclid(rhs.y),
+            self.z.rem_euclid(rhs.z),
+        )
     }
 
     /// Casts all elements of `self` to `f32`.

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -356,6 +356,39 @@ impl I64Vec4 {
         (self - rhs).length_squared()
     }
 
+    /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    #[inline]
+    pub fn div_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].div_euclid(rhs[i]);
+        }
+        out
+    }
+
+    /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
+    ///
+
+    /// # Panics
+    /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+
+    ///
+    /// [Euclidean division]: i64::rem_euclid
+
+    #[inline]
+    pub fn rem_euclid(self, rhs: Self) -> Self {
+        let mut out = Self::default();
+        for i in 0..4 {
+            out[i] = self[i].rem_euclid(rhs[i]);
+        }
+        out
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     pub fn as_vec4(&self) -> crate::Vec4 {

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -358,35 +358,34 @@ impl I64Vec4 {
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].div_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            self.x.div_euclid(rhs.x),
+            self.y.div_euclid(rhs.y),
+            self.z.div_euclid(rhs.z),
+            self.w.div_euclid(rhs.w),
+        )
     }
 
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
-
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
 
     ///
     /// [Euclidean division]: i64::rem_euclid
-
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
-        let mut out = Self::default();
-        for i in 0..4 {
-            out[i] = self[i].rem_euclid(rhs[i]);
-        }
-        out
+        Self::new(
+            self.x.rem_euclid(rhs.x),
+            self.y.rem_euclid(rhs.y),
+            self.z.rem_euclid(rhs.z),
+            self.w.rem_euclid(rhs.w),
+        )
     }
 
     /// Casts all elements of `self` to `f32`.

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -360,7 +360,6 @@ impl I64Vec4 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -375,7 +374,6 @@ impl I64Vec4 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
-
     ///
     /// [Euclidean division]: i64::rem_euclid
     #[inline]

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -560,6 +560,29 @@ macro_rules! impl_vec2_signed_tests {
                 $vec2::new(-1 as $t, 1 as $t)
             );
         });
+
+        #[cfg(not(feature = "libm"))]
+        glam_test!(test_div_euclid, {
+            let one = $vec2::ONE;
+            let two = one + one;
+            let three = two + one;
+            assert_eq!(three.div_euclid(two), one);
+            assert_eq!((-three).div_euclid(two), -two);
+            assert_eq!(three.div_euclid(-two), -one);
+            assert_eq!((-three).div_euclid(-two), two);
+        });
+
+        #[cfg(not(feature = "libm"))]
+        glam_test!(test_rem_euclid, {
+            let one = $vec2::ONE;
+            let two = one + one;
+            let three = two + one;
+            let four = three + one;
+            assert_eq!(four.rem_euclid(three), one);
+            assert_eq!((-four).rem_euclid(three), two);
+            assert_eq!(four.rem_euclid(-three), one);
+            assert_eq!((-four).rem_euclid(-three), two);
+        });
     };
 }
 

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -561,7 +561,6 @@ macro_rules! impl_vec2_signed_tests {
             );
         });
 
-        #[cfg(not(feature = "libm"))]
         glam_test!(test_div_euclid, {
             let one = $vec2::ONE;
             let two = one + one;
@@ -572,7 +571,6 @@ macro_rules! impl_vec2_signed_tests {
             assert_eq!((-three).div_euclid(-two), two);
         });
 
-        #[cfg(not(feature = "libm"))]
         glam_test!(test_rem_euclid, {
             let one = $vec2::ONE;
             let two = one + one;

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -627,6 +627,29 @@ macro_rules! impl_vec3_signed_tests {
             assert_eq!(2 as $t, x.distance_squared(y));
             assert_eq!(13 as $t, (2 as $t * x).distance_squared(-3 as $t * z));
         });
+
+        #[cfg(not(feature = "libm"))]
+        glam_test!(test_div_euclid, {
+            let one = $vec3::ONE;
+            let two = one + one;
+            let three = two + one;
+            assert_eq!(three.div_euclid(two), one);
+            assert_eq!((-three).div_euclid(two), -two);
+            assert_eq!(three.div_euclid(-two), -one);
+            assert_eq!((-three).div_euclid(-two), two);
+        });
+
+        #[cfg(not(feature = "libm"))]
+        glam_test!(test_rem_euclid, {
+            let one = $vec3::ONE;
+            let two = one + one;
+            let three = two + one;
+            let four = three + one;
+            assert_eq!(four.rem_euclid(three), one);
+            assert_eq!((-four).rem_euclid(three), two);
+            assert_eq!(four.rem_euclid(-three), one);
+            assert_eq!((-four).rem_euclid(-three), two);
+        });
     };
 }
 

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -628,7 +628,6 @@ macro_rules! impl_vec3_signed_tests {
             assert_eq!(13 as $t, (2 as $t * x).distance_squared(-3 as $t * z));
         });
 
-        #[cfg(not(feature = "libm"))]
         glam_test!(test_div_euclid, {
             let one = $vec3::ONE;
             let two = one + one;
@@ -639,7 +638,6 @@ macro_rules! impl_vec3_signed_tests {
             assert_eq!((-three).div_euclid(-two), two);
         });
 
-        #[cfg(not(feature = "libm"))]
         glam_test!(test_rem_euclid, {
             let one = $vec3::ONE;
             let two = one + one;

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -717,6 +717,29 @@ macro_rules! impl_vec4_signed_tests {
             assert_eq!(2 as $t, x.distance_squared(y));
             assert_eq!(13 as $t, (2 as $t * x).distance_squared(-3 as $t * z));
         });
+
+        #[cfg(not(feature = "libm"))]
+        glam_test!(test_div_euclid, {
+            let one = $vec4::ONE;
+            let two = one + one;
+            let three = two + one;
+            assert_eq!(three.div_euclid(two), one);
+            assert_eq!((-three).div_euclid(two), -two);
+            assert_eq!(three.div_euclid(-two), -one);
+            assert_eq!((-three).div_euclid(-two), two);
+        });
+
+        #[cfg(not(feature = "libm"))]
+        glam_test!(test_rem_euclid, {
+            let one = $vec4::ONE;
+            let two = one + one;
+            let three = two + one;
+            let four = three + one;
+            assert_eq!(four.rem_euclid(three), one);
+            assert_eq!((-four).rem_euclid(three), two);
+            assert_eq!(four.rem_euclid(-three), one);
+            assert_eq!((-four).rem_euclid(-three), two);
+        });
     };
 }
 

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -718,7 +718,6 @@ macro_rules! impl_vec4_signed_tests {
             assert_eq!(13 as $t, (2 as $t * x).distance_squared(-3 as $t * z));
         });
 
-        #[cfg(not(feature = "libm"))]
         glam_test!(test_div_euclid, {
             let one = $vec4::ONE;
             let two = one + one;
@@ -729,7 +728,6 @@ macro_rules! impl_vec4_signed_tests {
             assert_eq!((-three).div_euclid(-two), two);
         });
 
-        #[cfg(not(feature = "libm"))]
         glam_test!(test_rem_euclid, {
             let one = $vec4::ONE;
             let two = one + one;


### PR DESCRIPTION
Fixes #417.

I didn't find a way to vectorize this any any of the used instruction sets, but perhaps I'm just not clever enough (for floats, euclidean div is essentially a normal div followed by rounding away from the divisor).