### PR TITLE
Quaternion rotation fix and minor documentation fix

### DIFF
--- a/codegen/templates/quat.rs.tera
+++ b/codegen/templates/quat.rs.tera
@@ -31,7 +31,7 @@
 
 use crate::{
     {{ scalar_t }}::math,
-    euler::{EulerFromQuaternion, EulerRot, EulerToQuaternion},
+    euler::{EulerRot, EulerToQuaternion},
     {% if scalar_t == "f32" %}
         DQuat, Mat3, Mat3A, Mat4, Vec2, Vec3, Vec3A, Vec4,
     {% elif scalar_t == "f64" %}
@@ -476,10 +476,33 @@ impl {{ self_t }} {
         axis * angle
     }
 
-    /// Returns the rotation angles for the given euler rotation sequence.
+    /// Returns the rotation angles for the quaternion.
     #[inline]
-    pub fn to_euler(self, euler: EulerRot) -> ({{ scalar_t }}, {{ scalar_t }}, {{ scalar_t }}) {
-        euler.convert_quat(self)
+    pub fn to_euler(self) -> {{vec3_t}} {
+        use core::{{scalar_t}}::consts::PI;
+        let q1 = self.normalize();
+        let test = q1.x * q1.y + q1.z * q1.w;
+        let mut output: {{vec3_t}} = {{vec3_t}}::default();
+        if test > 0.499 {
+            // singularity at north pole
+            output.x = PI / 2.0;
+            output.y = 2.0 * q1.x.atan2(q1.w);
+            output.z = 0.0;
+        }else if test < -0.499 {
+            // singularity at south pole
+            output.y = -2.0 * q1.x.atan2(q1.w);
+            output.x = -PI / 2.0;
+            output.z = 0.0;
+        }else{
+            let sqx: {{scalar_t}} = q1.x * q1.x;
+            let sqy: {{scalar_t}} = q1.y * q1.y;
+            let sqz: {{scalar_t}} = q1.z * q1.z;
+            output.y = (2.0 * q1.y * q1.w - 2.0 * q1.x * q1.z).atan2(1.0 - 2.0 * sqy - 2.0 * sqz);
+            output.x = (2.0 * test).asin();
+            output.z = (2.0 * q1.x * q1.w - 2.0 * q1.y * q1.z).atan2(1.0 - 2.0 * sqx - 2.0 * sqz);
+        }
+        return output;
+
     }
 
     /// `[x, y, z, w]`
@@ -633,7 +656,7 @@ impl {{ self_t }} {
     /// is less than or equal to `max_abs_diff`.
     ///
     /// This can be used to compare if two quaternions contain similar elements. It works
-    /// best when comparing with a known value. The `max_abs_diff` that should be used used
+    /// best when comparing with a known value. The `max_abs_diff` that should be used
     /// depends on the values being compared against.
     ///
     /// For more see

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -1,7 +1,7 @@
 // Generated from quat.rs.tera template. Edit the template, not the generated file.
 
 use crate::{
-    euler::{EulerFromQuaternion, EulerRot, EulerToQuaternion},
+    euler::{EulerRot, EulerToQuaternion},
     f32::math,
     DQuat, Mat3, Mat3A, Mat4, Vec2, Vec3, Vec3A, Vec4,
 };
@@ -371,10 +371,32 @@ impl Quat {
         axis * angle
     }
 
-    /// Returns the rotation angles for the given euler rotation sequence.
+    /// Returns the rotation angles for the quaternion.
     #[inline]
-    pub fn to_euler(self, euler: EulerRot) -> (f32, f32, f32) {
-        euler.convert_quat(self)
+    pub fn to_euler(self) -> Vec3 {
+        use core::f32::consts::PI;
+        let q1 = self.normalize();
+        let test = q1.x * q1.y + q1.z * q1.w;
+        let mut output: Vec3 = Vec3::default();
+        if test > 0.499 {
+            // singularity at north pole
+            output.x = PI / 2.0;
+            output.y = 2.0 * q1.x.atan2(q1.w);
+            output.z = 0.0;
+        } else if test < -0.499 {
+            // singularity at south pole
+            output.y = -2.0 * q1.x.atan2(q1.w);
+            output.x = -PI / 2.0;
+            output.z = 0.0;
+        } else {
+            let sqx: f32 = q1.x * q1.x;
+            let sqy: f32 = q1.y * q1.y;
+            let sqz: f32 = q1.z * q1.z;
+            output.y = (2.0 * q1.y * q1.w - 2.0 * q1.x * q1.z).atan2(1.0 - 2.0 * sqy - 2.0 * sqz);
+            output.x = (2.0 * test).asin();
+            output.z = (2.0 * q1.x * q1.w - 2.0 * q1.y * q1.z).atan2(1.0 - 2.0 * sqx - 2.0 * sqz);
+        }
+        return output;
     }
 
     /// `[x, y, z, w]`
@@ -522,7 +544,7 @@ impl Quat {
     /// is less than or equal to `max_abs_diff`.
     ///
     /// This can be used to compare if two quaternions contain similar elements. It works
-    /// best when comparing with a known value. The `max_abs_diff` that should be used used
+    /// best when comparing with a known value. The `max_abs_diff` that should be used
     /// depends on the values being compared against.
     ///
     /// For more see

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -518,7 +518,7 @@ impl Quat {
     /// is less than or equal to `max_abs_diff`.
     ///
     /// This can be used to compare if two quaternions contain similar elements. It works
-    /// best when comparing with a known value. The `max_abs_diff` that should be used used
+    /// best when comparing with a known value. The `max_abs_diff` that should be used
     /// depends on the values being compared against.
     ///
     /// For more see

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -1,7 +1,7 @@
 // Generated from quat.rs.tera template. Edit the template, not the generated file.
 
 use crate::{
-    euler::{EulerFromQuaternion, EulerRot, EulerToQuaternion},
+    euler::{EulerRot, EulerToQuaternion},
     f32::math,
     sse2::*,
     DQuat, Mat3, Mat3A, Mat4, Vec2, Vec3, Vec3A, Vec4,
@@ -371,10 +371,32 @@ impl Quat {
         axis * angle
     }
 
-    /// Returns the rotation angles for the given euler rotation sequence.
+    /// Returns the rotation angles for the quaternion.
     #[inline]
-    pub fn to_euler(self, euler: EulerRot) -> (f32, f32, f32) {
-        euler.convert_quat(self)
+    pub fn to_euler(self) -> Vec3 {
+        use core::f32::consts::PI;
+        let q1 = self.normalize();
+        let test = q1.x * q1.y + q1.z * q1.w;
+        let mut output: Vec3 = Vec3::default();
+        if test > 0.499 {
+            // singularity at north pole
+            output.x = PI / 2.0;
+            output.y = 2.0 * q1.x.atan2(q1.w);
+            output.z = 0.0;
+        } else if test < -0.499 {
+            // singularity at south pole
+            output.y = -2.0 * q1.x.atan2(q1.w);
+            output.x = -PI / 2.0;
+            output.z = 0.0;
+        } else {
+            let sqx: f32 = q1.x * q1.x;
+            let sqy: f32 = q1.y * q1.y;
+            let sqz: f32 = q1.z * q1.z;
+            output.y = (2.0 * q1.y * q1.w - 2.0 * q1.x * q1.z).atan2(1.0 - 2.0 * sqy - 2.0 * sqz);
+            output.x = (2.0 * test).asin();
+            output.z = (2.0 * q1.x * q1.w - 2.0 * q1.y * q1.z).atan2(1.0 - 2.0 * sqx - 2.0 * sqz);
+        }
+        return output;
     }
 
     /// `[x, y, z, w]`

--- a/src/f32/wasm32/quat.rs
+++ b/src/f32/wasm32/quat.rs
@@ -1,7 +1,7 @@
 // Generated from quat.rs.tera template. Edit the template, not the generated file.
 
 use crate::{
-    euler::{EulerFromQuaternion, EulerRot, EulerToQuaternion},
+    euler::{EulerRot, EulerToQuaternion},
     f32::math,
     wasm32::*,
     DQuat, Mat3, Mat3A, Mat4, Vec2, Vec3, Vec3A, Vec4,
@@ -363,10 +363,32 @@ impl Quat {
         axis * angle
     }
 
-    /// Returns the rotation angles for the given euler rotation sequence.
+    /// Returns the rotation angles for the quaternion.
     #[inline]
-    pub fn to_euler(self, euler: EulerRot) -> (f32, f32, f32) {
-        euler.convert_quat(self)
+    pub fn to_euler(self) -> Vec3 {
+        use core::f32::consts::PI;
+        let q1 = self.normalize();
+        let test = q1.x * q1.y + q1.z * q1.w;
+        let mut output: Vec3 = Vec3::default();
+        if test > 0.499 {
+            // singularity at north pole
+            output.x = PI / 2.0;
+            output.y = 2.0 * q1.x.atan2(q1.w);
+            output.z = 0.0;
+        } else if test < -0.499 {
+            // singularity at south pole
+            output.y = -2.0 * q1.x.atan2(q1.w);
+            output.x = -PI / 2.0;
+            output.z = 0.0;
+        } else {
+            let sqx: f32 = q1.x * q1.x;
+            let sqy: f32 = q1.y * q1.y;
+            let sqz: f32 = q1.z * q1.z;
+            output.y = (2.0 * q1.y * q1.w - 2.0 * q1.x * q1.z).atan2(1.0 - 2.0 * sqy - 2.0 * sqz);
+            output.x = (2.0 * test).asin();
+            output.z = (2.0 * q1.x * q1.w - 2.0 * q1.y * q1.z).atan2(1.0 - 2.0 * sqx - 2.0 * sqz);
+        }
+        return output;
     }
 
     /// `[x, y, z, w]`
@@ -510,7 +532,7 @@ impl Quat {
     /// is less than or equal to `max_abs_diff`.
     ///
     /// This can be used to compare if two quaternions contain similar elements. It works
-    /// best when comparing with a known value. The `max_abs_diff` that should be used used
+    /// best when comparing with a known value. The `max_abs_diff` that should be used
     /// depends on the values being compared against.
     ///
     /// For more see

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -1,7 +1,7 @@
 // Generated from quat.rs.tera template. Edit the template, not the generated file.
 
 use crate::{
-    euler::{EulerFromQuaternion, EulerRot, EulerToQuaternion},
+    euler::{EulerRot, EulerToQuaternion},
     f64::math,
     DMat3, DMat4, DVec2, DVec3, DVec4, Quat,
 };
@@ -361,10 +361,32 @@ impl DQuat {
         axis * angle
     }
 
-    /// Returns the rotation angles for the given euler rotation sequence.
+    /// Returns the rotation angles for the quaternion.
     #[inline]
-    pub fn to_euler(self, euler: EulerRot) -> (f64, f64, f64) {
-        euler.convert_quat(self)
+    pub fn to_euler(self) -> DVec3 {
+        use core::f64::consts::PI;
+        let q1 = self.normalize();
+        let test = q1.x * q1.y + q1.z * q1.w;
+        let mut output: DVec3 = DVec3::default();
+        if test > 0.499 {
+            // singularity at north pole
+            output.x = PI / 2.0;
+            output.y = 2.0 * q1.x.atan2(q1.w);
+            output.z = 0.0;
+        } else if test < -0.499 {
+            // singularity at south pole
+            output.y = -2.0 * q1.x.atan2(q1.w);
+            output.x = -PI / 2.0;
+            output.z = 0.0;
+        } else {
+            let sqx: f64 = q1.x * q1.x;
+            let sqy: f64 = q1.y * q1.y;
+            let sqz: f64 = q1.z * q1.z;
+            output.y = (2.0 * q1.y * q1.w - 2.0 * q1.x * q1.z).atan2(1.0 - 2.0 * sqy - 2.0 * sqz);
+            output.x = (2.0 * test).asin();
+            output.z = (2.0 * q1.x * q1.w - 2.0 * q1.y * q1.z).atan2(1.0 - 2.0 * sqx - 2.0 * sqz);
+        }
+        return output;
     }
 
     /// `[x, y, z, w]`
@@ -512,7 +534,7 @@ impl DQuat {
     /// is less than or equal to `max_abs_diff`.
     ///
     /// This can be used to compare if two quaternions contain similar elements. It works
-    /// best when comparing with a known value. The `max_abs_diff` that should be used used
+    /// best when comparing with a known value. The `max_abs_diff` that should be used
     /// depends on the values being compared against.
     ///
     /// For more see


### PR DESCRIPTION
Previously, quaternions were limited from `-PI / 2.0` to `PI / 2.0`, but that is now fixed and quaternions can now use all angles. Code was translated from Java to Rust using [this link](http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/)

I also fixed a minor documentation error where the word `used` was used twice on accident.