### PR TITLE
Implement ref ops

### DIFF
--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -974,6 +974,250 @@ impl Rem<Vec2> for f32 {
     }
 }
 
+impl Div<&Vec2> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn div(self, rhs: &Self) -> Self {
+        Self {
+            x: self.x.div(rhs.x),
+            y: self.y.div(rhs.y),
+        }
+    }
+}
+
+impl DivAssign<&Vec2> for Vec2 {
+    #[inline]
+    fn div_assign(&mut self, rhs: &Self) {
+        self.x.div_assign(rhs.x);
+        self.y.div_assign(rhs.y);
+    }
+}
+
+impl Div<&f32> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn div(self, rhs: &f32) -> Self {
+        Self {
+            x: self.x.div(rhs),
+            y: self.y.div(rhs),
+        }
+    }
+}
+
+impl DivAssign<&f32> for Vec2 {
+    #[inline]
+    fn div_assign(&mut self, rhs: &f32) {
+        self.x.div_assign(rhs);
+        self.y.div_assign(rhs);
+    }
+}
+
+impl Div<&Vec2> for f32 {
+    type Output = Vec2;
+    #[inline]
+    fn div(self, rhs: &Vec2) -> Vec2 {
+        Vec2 {
+            x: self.div(rhs.x),
+            y: self.div(rhs.y),
+        }
+    }
+}
+
+impl Mul<&Vec2> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: &Self) -> Self {
+        Self {
+            x: self.x.mul(rhs.x),
+            y: self.y.mul(rhs.y),
+        }
+    }
+}
+
+impl MulAssign<&Vec2> for Vec2 {
+    #[inline]
+    fn mul_assign(&mut self, rhs: &Self) {
+        self.x.mul_assign(rhs.x);
+        self.y.mul_assign(rhs.y);
+    }
+}
+
+impl Mul<&f32> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: &f32) -> Self {
+        Self {
+            x: self.x.mul(rhs),
+            y: self.y.mul(rhs),
+        }
+    }
+}
+
+impl MulAssign<&f32> for Vec2 {
+    #[inline]
+    fn mul_assign(&mut self, rhs: &f32) {
+        self.x.mul_assign(rhs);
+        self.y.mul_assign(rhs);
+    }
+}
+
+impl Mul<&Vec2> for f32 {
+    type Output = Vec2;
+    #[inline]
+    fn mul(self, rhs: &Vec2) -> Vec2 {
+        Vec2 {
+            x: self.mul(rhs.x),
+            y: self.mul(rhs.y),
+        }
+    }
+}
+
+impl Add<&Vec2> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: &Self) -> Self {
+        Self {
+            x: self.x.add(rhs.x),
+            y: self.y.add(rhs.y),
+        }
+    }
+}
+
+impl AddAssign<&Vec2> for Vec2 {
+    #[inline]
+    fn add_assign(&mut self, rhs: &Self) {
+        self.x.add_assign(rhs.x);
+        self.y.add_assign(rhs.y);
+    }
+}
+
+impl Add<&f32> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: &f32) -> Self {
+        Self {
+            x: self.x.add(rhs),
+            y: self.y.add(rhs),
+        }
+    }
+}
+
+impl AddAssign<&f32> for Vec2 {
+    #[inline]
+    fn add_assign(&mut self, rhs: &f32) {
+        self.x.add_assign(rhs);
+        self.y.add_assign(rhs);
+    }
+}
+
+impl Add<&Vec2> for f32 {
+    type Output = Vec2;
+    #[inline]
+    fn add(self, rhs: &Vec2) -> Vec2 {
+        Vec2 {
+            x: self.add(rhs.x),
+            y: self.add(rhs.y),
+        }
+    }
+}
+
+impl Sub<&Vec2> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: &Self) -> Self {
+        Self {
+            x: self.x.sub(rhs.x),
+            y: self.y.sub(rhs.y),
+        }
+    }
+}
+
+impl SubAssign<&Vec2> for Vec2 {
+    #[inline]
+    fn sub_assign(&mut self, rhs: &Vec2) {
+        self.x.sub_assign(rhs.x);
+        self.y.sub_assign(rhs.y);
+    }
+}
+
+impl Sub<&f32> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: &f32) -> Self {
+        Self {
+            x: self.x.sub(rhs),
+            y: self.y.sub(rhs),
+        }
+    }
+}
+
+impl SubAssign<&f32> for Vec2 {
+    #[inline]
+    fn sub_assign(&mut self, rhs: &f32) {
+        self.x.sub_assign(rhs);
+        self.y.sub_assign(rhs);
+    }
+}
+
+impl Sub<&Vec2> for f32 {
+    type Output = Vec2;
+    #[inline]
+    fn sub(self, rhs: &Vec2) -> Vec2 {
+        Vec2 {
+            x: self.sub(rhs.x),
+            y: self.sub(rhs.y),
+        }
+    }
+}
+
+impl Rem<&Vec2> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn rem(self, rhs: &Self) -> Self {
+        Self {
+            x: self.x.rem(rhs.x),
+            y: self.y.rem(rhs.y),
+        }
+    }
+}
+
+impl RemAssign<&Vec2> for Vec2 {
+    #[inline]
+    fn rem_assign(&mut self, rhs: &Self) {
+        self.x.rem_assign(rhs.x);
+        self.y.rem_assign(rhs.y);
+    }
+}
+
+impl Rem<&f32> for Vec2 {
+    type Output = Self;
+    #[inline]
+    fn rem(self, rhs: &f32) -> Self {
+        Self {
+            x: self.x.rem(rhs),
+            y: self.y.rem(rhs),
+        }
+    }
+}
+
+impl RemAssign<&f32> for Vec2 {
+    #[inline]
+    fn rem_assign(&mut self, rhs: &f32) {
+        self.x.rem_assign(rhs);
+        self.y.rem_assign(rhs);
+    }
+}
+
+impl Rem<&Vec2> for f32 {
+    type Output = Vec2;
+    #[inline]
+    fn rem(self, rhs: &Vec2) -> Vec2 {
+        Vec2 {
+            x: self.rem(rhs.x),
+            y: self.rem(rhs.y),
+        }
+    }
+}
 #[cfg(not(target_arch = "spirv"))]
 impl AsRef<[f32; 2]> for Vec2 {
     #[inline]

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -1066,6 +1066,275 @@ impl Rem<Vec3> for f32 {
     }
 }
 
+impl Div<&Vec3> for Vec3 {
+    type Output = Self;
+    #[inline]
+    fn div(self, rhs: &Self) -> Self {
+        Self {
+            x: self.x.div(rhs.x),
+            y: self.y.div(rhs.y),
+            z: self.z.div(rhs.z),
+        }
+    }
+}
+
+impl DivAssign<&Vec3> for Vec3 {
+    #[inline]
+    fn div_assign(&mut self, rhs: &Self) {
+        self.x.div_assign(rhs.x);
+        self.y.div_assign(rhs.y);
+        self.z.div_assign(rhs.z);
+    }
+}
+
+impl Div<&f32> for Vec3 {
+    type Output = Self;
+    #[inline]
+    fn div(self, rhs: &f32) -> Self {
+        Self {
+            x: self.x.div(rhs),
+            y: self.y.div(rhs),
+            z: self.z.div(rhs),
+        }
+    }
+}
+
+impl DivAssign<&f32> for Vec3 {
+    #[inline]
+    fn div_assign(&mut self, rhs: &f32) {
+        self.x.div_assign(rhs);
+        self.y.div_assign(rhs);
+        self.z.div_assign(rhs);
+    }
+}
+
+impl Div<&Vec3> for f32 {
+    type Output = Vec3;
+    #[inline]
+    fn div(self, rhs: &Vec3) -> Vec3 {
+        Vec3 {
+            x: self.div(rhs.x),
+            y: self.div(rhs.y),
+            z: self.div(rhs.z),
+        }
+    }
+}
+
+impl Mul<&Vec3> for Vec3 {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: &Self) -> Self {
+        Self {
+            x: self.x.mul(rhs.x),
+            y: self.y.mul(rhs.y),
+            z: self.z.mul(rhs.z),
+        }
+    }
+}
+
+impl MulAssign<&Vec3> for Vec3 {
+    #[inline]
+    fn mul_assign(&mut self, rhs: &Self) {
+        self.x.mul_assign(rhs.x);
+        self.y.mul_assign(rhs.y);
+        self.z.mul_assign(rhs.z);
+    }
+}
+
+impl Mul<&f32> for Vec3 {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: &f32) -> Self {
+        Self {
+            x: self.x.mul(rhs),
+            y: self.y.mul(rhs),
+            z: self.z.mul(rhs),
+        }
+    }
+}
+
+impl MulAssign<&f32> for Vec3 {
+    #[inline]
+    fn mul_assign(&mut self, rhs: &f32) {
+        self.x.mul_assign(rhs);
+        self.y.mul_assign(rhs);
+        self.z.mul_assign(rhs);
+    }
+}
+
+impl Mul<&Vec3> for f32 {
+    type Output = Vec3;
+    #[inline]
+    fn mul(self, rhs: &Vec3) -> Vec3 {
+        Vec3 {
+            x: self.mul(rhs.x),
+            y: self.mul(rhs.y),
+            z: self.mul(rhs.z),
+        }
+    }
+}
+
+impl Add<&Vec3> for Vec3 {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: &Self) -> Self {
+        Self {
+            x: self.x.add(rhs.x),
+            y: self.y.add(rhs.y),
+            z: self.z.add(rhs.z),
+        }
+    }
+}
+
+impl AddAssign<&Vec3> for Vec3 {
+    #[inline]
+    fn add_assign(&mut self, rhs: &Self) {
+        self.x.add_assign(rhs.x);
+        self.y.add_assign(rhs.y);
+        self.z.add_assign(rhs.z);
+    }
+}
+
+impl Add<&f32> for Vec3 {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: &f32) -> Self {
+        Self {
+            x: self.x.add(rhs),
+            y: self.y.add(rhs),
+            z: self.z.add(rhs),
+        }
+    }
+}
+
+impl AddAssign<&f32> for Vec3 {
+    #[inline]
+    fn add_assign(&mut self, rhs: &f32) {
+        self.x.add_assign(rhs);
+        self.y.add_assign(rhs);
+        self.z.add_assign(rhs);
+    }
+}
+
+impl Add<&Vec3> for f32 {
+    type Output = Vec3;
+    #[inline]
+    fn add(self, rhs: &Vec3) -> Vec3 {
+        Vec3 {
+            x: self.add(rhs.x),
+            y: self.add(rhs.y),
+            z: self.add(rhs.z),
+        }
+    }
+}
+
+impl Sub<&Vec3> for Vec3 {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: &Self) -> Self {
+        Self {
+            x: self.x.sub(rhs.x),
+            y: self.y.sub(rhs.y),
+            z: self.z.sub(rhs.z),
+        }
+    }
+}
+
+impl SubAssign<&Vec3> for Vec3 {
+    #[inline]
+    fn sub_assign(&mut self, rhs: &Vec3) {
+        self.x.sub_assign(rhs.x);
+        self.y.sub_assign(rhs.y);
+        self.z.sub_assign(rhs.z);
+    }
+}
+
+impl Sub<&f32> for Vec3 {
+    type Output = Self;
+    #[inline]
+    fn sub(self, rhs: &f32) -> Self {
+        Self {
+            x: self.x.sub(rhs),
+            y: self.y.sub(rhs),
+            z: self.z.sub(rhs),
+        }
+    }
+}
+
+impl SubAssign<&f32> for Vec3 {
+    #[inline]
+    fn sub_assign(&mut self, rhs: &f32) {
+        self.x.sub_assign(rhs);
+        self.y.sub_assign(rhs);
+        self.z.sub_assign(rhs);
+    }
+}
+
+impl Sub<&Vec3> for f32 {
+    type Output = Vec3;
+    #[inline]
+    fn sub(self, rhs: &Vec3) -> Vec3 {
+        Vec3 {
+            x: self.sub(rhs.x),
+            y: self.sub(rhs.y),
+            z: self.sub(rhs.z),
+        }
+    }
+}
+
+impl Rem<&Vec3> for Vec3 {
+    type Output = Self;
+    #[inline]
+    fn rem(self, rhs: &Self) -> Self {
+        Self {
+            x: self.x.rem(rhs.x),
+            y: self.y.rem(rhs.y),
+            z: self.z.rem(rhs.z),
+        }
+    }
+}
+
+impl RemAssign<&Vec3> for Vec3 {
+    #[inline]
+    fn rem_assign(&mut self, rhs: &Self) {
+        self.x.rem_assign(rhs.x);
+        self.y.rem_assign(rhs.y);
+        self.z.rem_assign(rhs.z);
+    }
+}
+
+impl Rem<&f32> for Vec3 {
+    type Output = Self;
+    #[inline]
+    fn rem(self, rhs: &f32) -> Self {
+        Self {
+            x: self.x.rem(rhs),
+            y: self.y.rem(rhs),
+            z: self.z.rem(rhs),
+        }
+    }
+}
+
+impl RemAssign<&f32> for Vec3 {
+    #[inline]
+    fn rem_assign(&mut self, rhs: &f32) {
+        self.x.rem_assign(rhs);
+        self.y.rem_assign(rhs);
+        self.z.rem_assign(rhs);
+    }
+}
+
+impl Rem<&Vec3> for f32 {
+    type Output = Vec3;
+    #[inline]
+    fn rem(self, rhs: &Vec3) -> Vec3 {
+        Vec3 {
+            x: self.rem(rhs.x),
+            y: self.rem(rhs.y),
+            z: self.rem(rhs.z),
+        }
+    }
+}
 #[cfg(not(target_arch = "spirv"))]
 impl AsRef<[f32; 3]> for Vec3 {
     #[inline]


### PR DESCRIPTION
As explained in #335, it is often desirable to also implement most operations on references.

I implemented them for both `Vec2` and `Vec3` as they seem to need it the most.