### PR TITLE
Use BVec4A as the Vec4 mask type even when SIMD is unavailable.

### DIFF
--- a/codegen/src/outputs.rs
+++ b/codegen/src/outputs.rs
@@ -209,7 +209,7 @@ impl ContextBuilder {
     }
 
     pub fn new_vec4() -> Self {
-        Self::new_vecn(4).with_scalar_t("f32")
+        Self::new_vecn(4).with_scalar_t("f32").with_is_align(true)
     }
 
     pub fn new_dvec2() -> Self {

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -2,9 +2,8 @@
 
 // Generated from {{template_path}} template. Edit the template, not the generated file.
 
-{% if is_scalar %}
-    {% set mask_t = "BVec" ~ dim %}
-{% else %}
+{% set mask_t = "BVec" ~ dim ~ "A" %}
+{% if not is_scalar %}
     {% set is_simd = true %}
     {% if is_sse2 %}
         {% set simd_t = "__m128" %}
@@ -13,7 +12,6 @@
     {% elif is_coresimd %}
         {% set simd_t = "f32x4" %}
     {% endif %}
-    {% set mask_t = "BVec" ~ dim ~ "A" %}
 {% endif %}
 
 {% if scalar_t == "f32" or scalar_t == "f64" %}
@@ -120,8 +118,16 @@
     {% set zero = "0" %}
 {% endif %}
 
+{% if mask_t == "BVec4A" and is_scalar %}
+    #[cfg(feature = "scalar-math")]
+    use crate::BVec4 as BVec4A;
+    #[cfg(not(feature = "scalar-math"))]
+    use crate::BVec4A;
+{% else %}
+    use crate::{{ mask_t }};
+{% endif %}
+
 use crate::{
-    {{ mask_t }},
     {% if self_t != vec2_t %}
         {{ vec2_t }},
     {% endif %}

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -2,8 +2,9 @@
 
 // Generated from {{template_path}} template. Edit the template, not the generated file.
 
-{% set mask_t = "BVec" ~ dim ~ "A" %}
-{% if not is_scalar %}
+{% if is_scalar %}
+    {% set mask_t = "BVec" ~ dim %}
+{% else %}
     {% set is_simd = true %}
     {% if is_sse2 %}
         {% set simd_t = "__m128" %}
@@ -12,6 +13,11 @@
     {% elif is_coresimd %}
         {% set simd_t = "f32x4" %}
     {% endif %}
+    {% set mask_t = "BVec" ~ dim ~ "A" %}
+{% endif %}
+
+{% if scalar_t == "f32" and mask_t == "BVec4" %}
+    {% set mask_t = "BVec4A" %}
 {% endif %}
 
 {% if scalar_t == "f32" or scalar_t == "f64" %}
@@ -118,16 +124,16 @@
     {% set zero = "0" %}
 {% endif %}
 
-{% if mask_t == "BVec4A" and is_scalar %}
+{% if mask_t == "BVec4A" and scalar_t == "f32"  and is_scalar %}
     #[cfg(feature = "scalar-math")]
     use crate::BVec4 as BVec4A;
     #[cfg(not(feature = "scalar-math"))]
     use crate::BVec4A;
+    use crate::{
 {% else %}
-    use crate::{{ mask_t }};
+    use crate::{
+        {{ mask_t }},
 {% endif %}
-
-use crate::{
     {% if self_t != vec2_t %}
         {{ vec2_t }},
     {% endif %}

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -2,7 +2,7 @@
 
 // Generated from {{template_path}} template. Edit the template, not the generated file.
 
-{% if is_scalar %}
+{% if is_scalar and not is_align %}
     {% set mask_t = "BVec" ~ dim %}
 {% else %}
     {% set is_simd = true %}
@@ -12,19 +12,17 @@
         {% set simd_t = "v128" %}
     {% elif is_coresimd %}
         {% set simd_t = "f32x4" %}
+    {% else %}
+        {% set is_simd = false %}
     {% endif %}
     {% set mask_t = "BVec" ~ dim ~ "A" %}
-{% endif %}
-
-{% if scalar_t == "f32" and mask_t == "BVec4" %}
-    {% set mask_t = "BVec4A" %}
 {% endif %}
 
 {% if scalar_t == "f32" or scalar_t == "f64" %}
     {% set is_signed = true %}
     {% set is_float = true %}
     {% if scalar_t == "f32" %}
-        {% if dim == 3 and is_simd or is_align %}
+        {% if dim == 3 and is_align %}
             {% set self_t = "Vec3A" %}
             {% set mask_t = "BVec3A" %}
         {% else %}
@@ -385,11 +383,7 @@ impl {{ self_t }} {
         {% if is_scalar %}
             Self {
                 {% for c in components %}
-                    {%- if is_align %}
-                        {{ c  }}: if mask.{{ c }} != 0 { if_true.{{ c }} } else { if_false.{{ c }} },
-                    {%- else %}
-                        {{ c  }}: if mask.{{ c }} { if_true.{{ c }} } else { if_false.{{ c }} },
-                    {%- endif %}
+                    {{ c  }}: if mask.test({{ loop.index0 }}) { if_true.{{ c }} } else { if_false.{{ c }} },
                 {%- endfor %}
             }
         {% elif is_sse2 %}
@@ -525,7 +519,7 @@ impl {{ self_t }} {
         {% if is_sse2 %}
             Self(unsafe { dot{{ dim }}_into_m128(self.0, rhs.0) })
         {% elif is_wasm32 %}
-            Self(unsafe { dot{{ dim }}_into_v128(self.0, rhs.0) })
+            Self(dot{{ dim }}_into_v128(self.0, rhs.0))
         {% elif is_coresimd %}
             Self(dot{{ dim }}_into_f32x4(self.0, rhs.0))
         {% else %}

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -1,6 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::{coresimd::*, f32::math, BVec4A, Vec2, Vec3, Vec3A};
+use crate::BVec4A;
+
+use crate::{coresimd::*, f32::math, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -1,8 +1,6 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::BVec4A;
-
-use crate::{coresimd::*, f32::math, Vec2, Vec3, Vec3A};
+use crate::{coresimd::*, f32::math, BVec4A, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -98,9 +98,9 @@ impl Vec3A {
     #[inline]
     pub fn select(mask: BVec3A, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x != 0 { if_true.x } else { if_false.x },
-            y: if mask.y != 0 { if_true.y } else { if_false.y },
-            z: if mask.z != 0 { if_true.z } else { if_false.z },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
         }
     }
 

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -4,7 +4,6 @@
 use crate::BVec4 as BVec4A;
 #[cfg(not(feature = "scalar-math"))]
 use crate::BVec4A;
-
 use crate::{f32::math, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -1,6 +1,11 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::{f32::math, BVec4, Vec2, Vec3, Vec3A};
+#[cfg(feature = "scalar-math")]
+use crate::BVec4 as BVec4A;
+#[cfg(not(feature = "scalar-math"))]
+use crate::BVec4A;
+
+use crate::{f32::math, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
@@ -109,7 +114,7 @@ impl Vec4 {
     /// A true element in the mask uses the corresponding element from `if_true`, and false
     /// uses the element from `if_false`.
     #[inline]
-    pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
+    pub fn select(mask: BVec4A, if_true: Self, if_false: Self) -> Self {
         Self {
             x: if mask.x { if_true.x } else { if_false.x },
             y: if mask.y { if_true.y } else { if_false.y },
@@ -237,8 +242,8 @@ impl Vec4 {
     /// In other words, this computes `[self.x == rhs.x, self.y == rhs.y, ..]` for all
     /// elements.
     #[inline]
-    pub fn cmpeq(self, rhs: Self) -> BVec4 {
-        BVec4::new(
+    pub fn cmpeq(self, rhs: Self) -> BVec4A {
+        BVec4A::new(
             self.x.eq(&rhs.x),
             self.y.eq(&rhs.y),
             self.z.eq(&rhs.z),
@@ -252,8 +257,8 @@ impl Vec4 {
     /// In other words this computes `[self.x != rhs.x, self.y != rhs.y, ..]` for all
     /// elements.
     #[inline]
-    pub fn cmpne(self, rhs: Self) -> BVec4 {
-        BVec4::new(
+    pub fn cmpne(self, rhs: Self) -> BVec4A {
+        BVec4A::new(
             self.x.ne(&rhs.x),
             self.y.ne(&rhs.y),
             self.z.ne(&rhs.z),
@@ -267,8 +272,8 @@ impl Vec4 {
     /// In other words this computes `[self.x >= rhs.x, self.y >= rhs.y, ..]` for all
     /// elements.
     #[inline]
-    pub fn cmpge(self, rhs: Self) -> BVec4 {
-        BVec4::new(
+    pub fn cmpge(self, rhs: Self) -> BVec4A {
+        BVec4A::new(
             self.x.ge(&rhs.x),
             self.y.ge(&rhs.y),
             self.z.ge(&rhs.z),
@@ -282,8 +287,8 @@ impl Vec4 {
     /// In other words this computes `[self.x > rhs.x, self.y > rhs.y, ..]` for all
     /// elements.
     #[inline]
-    pub fn cmpgt(self, rhs: Self) -> BVec4 {
-        BVec4::new(
+    pub fn cmpgt(self, rhs: Self) -> BVec4A {
+        BVec4A::new(
             self.x.gt(&rhs.x),
             self.y.gt(&rhs.y),
             self.z.gt(&rhs.z),
@@ -297,8 +302,8 @@ impl Vec4 {
     /// In other words this computes `[self.x <= rhs.x, self.y <= rhs.y, ..]` for all
     /// elements.
     #[inline]
-    pub fn cmple(self, rhs: Self) -> BVec4 {
-        BVec4::new(
+    pub fn cmple(self, rhs: Self) -> BVec4A {
+        BVec4A::new(
             self.x.le(&rhs.x),
             self.y.le(&rhs.y),
             self.z.le(&rhs.z),
@@ -312,8 +317,8 @@ impl Vec4 {
     /// In other words this computes `[self.x < rhs.x, self.y < rhs.y, ..]` for all
     /// elements.
     #[inline]
-    pub fn cmplt(self, rhs: Self) -> BVec4 {
-        BVec4::new(
+    pub fn cmplt(self, rhs: Self) -> BVec4A {
+        BVec4A::new(
             self.x.lt(&rhs.x),
             self.y.lt(&rhs.y),
             self.z.lt(&rhs.z),
@@ -387,8 +392,8 @@ impl Vec4 {
     ///
     /// In other words, this computes `[x.is_nan(), y.is_nan(), z.is_nan(), w.is_nan()]`.
     #[inline]
-    pub fn is_nan_mask(self) -> BVec4 {
-        BVec4::new(
+    pub fn is_nan_mask(self) -> BVec4A {
+        BVec4A::new(
             self.x.is_nan(),
             self.y.is_nan(),
             self.z.is_nan(),

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -115,10 +115,10 @@ impl Vec4 {
     #[inline]
     pub fn select(mask: BVec4A, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
-            w: if mask.w { if_true.w } else { if_false.w },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
+            w: if mask.test(3) { if_true.w } else { if_false.w },
         }
     }
 

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -1,6 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::{f32::math, sse2::*, BVec4A, Vec2, Vec3, Vec3A};
+use crate::BVec4A;
+
+use crate::{f32::math, sse2::*, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -1,8 +1,6 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::BVec4A;
-
-use crate::{f32::math, sse2::*, Vec2, Vec3, Vec3A};
+use crate::{f32::math, sse2::*, BVec4A, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -83,8 +83,8 @@ impl Vec2 {
     #[inline]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
         }
     }
 

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -89,9 +89,9 @@ impl Vec3 {
     #[inline]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
         }
     }
 

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -167,7 +167,7 @@ impl Vec3A {
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
-        Self(unsafe { dot3_into_v128(self.0, rhs.0) })
+        Self(dot3_into_v128(self.0, rhs.0))
     }
 
     /// Computes the cross product of `self` and `rhs`.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -1,8 +1,6 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::BVec4A;
-
-use crate::{f32::math, wasm32::*, Vec2, Vec3, Vec3A};
+use crate::{f32::math, wasm32::*, BVec4A, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -159,7 +159,7 @@ impl Vec4 {
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
-        Self(unsafe { dot4_into_v128(self.0, rhs.0) })
+        Self(dot4_into_v128(self.0, rhs.0))
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -1,6 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::{f32::math, wasm32::*, BVec4A, Vec2, Vec3, Vec3A};
+use crate::BVec4A;
+
+use crate::{f32::math, wasm32::*, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -83,8 +83,8 @@ impl DVec2 {
     #[inline]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
         }
     }
 

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -89,9 +89,9 @@ impl DVec3 {
     #[inline]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
         }
     }
 

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -105,10 +105,10 @@ impl DVec4 {
     #[inline]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
-            w: if mask.w { if_true.w } else { if_false.w },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
+            w: if mask.test(3) { if_true.w } else { if_false.w },
         }
     }
 

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -75,8 +75,8 @@ impl I16Vec2 {
     #[inline]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
         }
     }
 

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -81,9 +81,9 @@ impl I16Vec3 {
     #[inline]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
         }
     }
 

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -97,10 +97,10 @@ impl I16Vec4 {
     #[inline]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
-            w: if mask.w { if_true.w } else { if_false.w },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
+            w: if mask.test(3) { if_true.w } else { if_false.w },
         }
     }
 

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -75,8 +75,8 @@ impl IVec2 {
     #[inline]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
         }
     }
 

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -81,9 +81,9 @@ impl IVec3 {
     #[inline]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
         }
     }
 

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -97,10 +97,10 @@ impl IVec4 {
     #[inline]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
-            w: if mask.w { if_true.w } else { if_false.w },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
+            w: if mask.test(3) { if_true.w } else { if_false.w },
         }
     }
 

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -75,8 +75,8 @@ impl I64Vec2 {
     #[inline]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
         }
     }
 

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -81,9 +81,9 @@ impl I64Vec3 {
     #[inline]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
         }
     }
 

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -97,10 +97,10 @@ impl I64Vec4 {
     #[inline]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
-            w: if mask.w { if_true.w } else { if_false.w },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
+            w: if mask.test(3) { if_true.w } else { if_false.w },
         }
     }
 

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -66,8 +66,8 @@ impl U16Vec2 {
     #[inline]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
         }
     }
 

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -69,9 +69,9 @@ impl U16Vec3 {
     #[inline]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
         }
     }
 

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -82,10 +82,10 @@ impl U16Vec4 {
     #[inline]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
-            w: if mask.w { if_true.w } else { if_false.w },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
+            w: if mask.test(3) { if_true.w } else { if_false.w },
         }
     }
 

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -66,8 +66,8 @@ impl UVec2 {
     #[inline]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
         }
     }
 

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -69,9 +69,9 @@ impl UVec3 {
     #[inline]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
         }
     }
 

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -82,10 +82,10 @@ impl UVec4 {
     #[inline]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
-            w: if mask.w { if_true.w } else { if_false.w },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
+            w: if mask.test(3) { if_true.w } else { if_false.w },
         }
     }
 

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -66,8 +66,8 @@ impl U64Vec2 {
     #[inline]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
         }
     }
 

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -69,9 +69,9 @@ impl U64Vec3 {
     #[inline]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
         }
     }
 

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -82,10 +82,10 @@ impl U64Vec4 {
     #[inline]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
         Self {
-            x: if mask.x { if_true.x } else { if_false.x },
-            y: if mask.y { if_true.y } else { if_false.y },
-            z: if mask.z { if_true.z } else { if_false.z },
-            w: if mask.w { if_true.w } else { if_false.w },
+            x: if mask.test(0) { if_true.x } else { if_false.x },
+            y: if mask.test(1) { if_true.y } else { if_false.y },
+            z: if mask.test(2) { if_true.z } else { if_false.z },
+            w: if mask.test(3) { if_true.w } else { if_false.w },
         }
     }
 

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1560,16 +1560,10 @@ mod vec4 {
         );
     });
 
-    #[cfg(all(
-        any(target_feature = "sse2", target_feature = "simd128"),
-        not(feature = "scalar-math")
-    ))]
+    #[cfg(not(feature = "scalar-math"))]
     impl_vec4_float_tests!(f32, vec4, Vec4, Vec3, Vec2, BVec4A);
 
-    #[cfg(any(
-        not(any(target_feature = "sse2", target_feature = "simd128")),
-        feature = "scalar-math"
-    ))]
+    #[cfg(feature = "scalar-math")]
     impl_vec4_float_tests!(f32, vec4, Vec4, Vec3, Vec2, BVec4);
 }
 


### PR DESCRIPTION
When the scalar-math feature is enabled BVec4 is still used.