### PR TITLE
added-must-use

### DIFF
--- a/codegen/templates/mat.rs.tera
+++ b/codegen/templates/mat.rs.tera
@@ -1895,6 +1895,7 @@ impl {{ self_t }} {
 {% endif %}
 
     /// Multiplies two {{ nxn }} matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat{{ dim }}(&self, rhs: &Self) -> Self {
         {% if self_t == "Mat2" and is_sse2 %}
@@ -1944,6 +1945,7 @@ impl {{ self_t }} {
     }
 
     /// Adds two {{ nxn }} matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat{{ dim }}(&self, rhs: &Self) -> Self {
         {% if self_t == "Mat2" and is_sse2 %}
@@ -1962,6 +1964,7 @@ impl {{ self_t }} {
     }
 
     /// Subtracts two {{ nxn }} matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat{{ dim }}(&self, rhs: &Self) -> Self {
         {% if self_t == "Mat2" and is_sse2 %}
@@ -1980,6 +1983,7 @@ impl {{ self_t }} {
     }
 
     /// Multiplies a {{ nxn }} matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: {{ scalar_t }}) -> Self {
         {% if self_t == "Mat2" and is_sse2 %}

--- a/codegen/templates/quat.rs.tera
+++ b/codegen/templates/quat.rs.tera
@@ -652,6 +652,7 @@ impl {{ self_t }} {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     #[doc(alias = "mix")]
     pub fn lerp(self, end: Self, s: {{ scalar_t }}) -> Self {
@@ -714,6 +715,7 @@ impl {{ self_t }} {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn slerp(self, mut end: Self, s: {{ scalar_t }}) -> Self {
         // http://number-none.com/product/Understanding%20Slerp,%20Then%20Not%20Using%20It/
@@ -832,6 +834,7 @@ impl {{ self_t }} {
     /// # Panics
     ///
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn mul_quat(self, rhs: Self) -> Self {
         glam_assert!(self.is_normalized());

--- a/codegen/templates/swizzle_traits.rs.tera
+++ b/codegen/templates/swizzle_traits.rs.tera
@@ -27,16 +27,19 @@
         {% endif %}
 
         {% if dim == 4 %}
+        #[must_use]
         #[inline]
         fn xyzw(self) -> Self {
             self
         }
         {% elif dim == 3 %}
+        #[must_use]
         #[inline]
         fn xyz(self) -> Self {
             self
         }
         {% elif dim == 2 %}
+        #[must_use]
         #[inline]
         fn xy(self) -> Self {
             self

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -514,6 +514,7 @@ impl {{ self_t }} {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
+    #[must_use]
     #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         {% if is_sse2 %}
@@ -529,6 +530,7 @@ impl {{ self_t }} {
 
 {% if dim == 3 %}
     /// Computes the cross product of `self` and `rhs`.
+    #[must_use]
     #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         {% if is_scalar %}
@@ -572,6 +574,7 @@ impl {{ self_t }} {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    #[must_use]
     #[inline]
     pub fn min(self, rhs: Self) -> Self {
         {% if is_scalar %}
@@ -592,6 +595,7 @@ impl {{ self_t }} {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    #[must_use]
     #[inline]
     pub fn max(self, rhs: Self) -> Self {
         {% if is_scalar %}
@@ -616,6 +620,7 @@ impl {{ self_t }} {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
@@ -862,6 +867,7 @@ impl {{ self_t }} {
 
 {% if is_signed %}
     /// Returns a vector containing the absolute value of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn abs(self) -> Self {
         {% if is_scalar %}
@@ -894,6 +900,7 @@ impl {{ self_t }} {
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
     {%- endif %}
+    #[must_use]
     #[inline]
     pub fn signum(self) -> Self {
         {% if is_scalar %}
@@ -925,6 +932,7 @@ impl {{ self_t }} {
 
     {% if is_float %}
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
+    #[must_use]
     #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         {% if is_scalar %}
@@ -1117,6 +1125,7 @@ impl {{ self_t }} {
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     {%- endif %}
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -1138,6 +1147,7 @@ impl {{ self_t }} {
     {%- endif %}
     ///
     /// [Euclidean division]: {{scalar_t}}::rem_euclid
+    #[must_use]
     #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -1299,6 +1309,7 @@ impl {{ self_t }} {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         {% if is_scalar %}
@@ -1318,6 +1329,7 @@ impl {{ self_t }} {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         {% if is_scalar %}
@@ -1337,6 +1349,7 @@ impl {{ self_t }} {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         {% if is_scalar %}
@@ -1356,6 +1369,7 @@ impl {{ self_t }} {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         {% if is_scalar %}
@@ -1377,6 +1391,7 @@ impl {{ self_t }} {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -1384,6 +1399,7 @@ impl {{ self_t }} {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(
@@ -1394,6 +1410,7 @@ impl {{ self_t }} {
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: {{ scalar_t }}) -> Self {
         Self::new(
@@ -1404,6 +1421,7 @@ impl {{ self_t }} {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         {% if is_scalar %}
@@ -1427,6 +1445,7 @@ impl {{ self_t }} {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: {{ scalar_t }}) -> Self {
         self + ((rhs - self) * s)
@@ -1451,6 +1470,7 @@ impl {{ self_t }} {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: {{ scalar_t }}, max: {{ scalar_t }}) -> Self {
         glam_assert!(min <= max);
@@ -1465,6 +1485,7 @@ impl {{ self_t }} {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: {{ scalar_t }}) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -1475,6 +1496,7 @@ impl {{ self_t }} {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: {{ scalar_t }}) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -1491,6 +1513,7 @@ impl {{ self_t }} {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         {% if is_sse2 %}
@@ -1514,6 +1537,7 @@ impl {{ self_t }} {
     /// conjunction with the [`rotate()`][Self::rotate()] method, e.g.
     /// `{{ vec2_t }}::from_angle(PI).rotate({{ vec2_t }}::Y)` will create the vector `[-1, 0]`
     /// and rotate [`{{ vec2_t }}::Y`] around it returning `-{{ vec2_t }}::Y`.
+    #[must_use]
     #[inline]
     pub fn from_angle(angle: {{ scalar_t }}) -> Self {
         let (sin, cos) = math::sin_cos(angle);
@@ -1558,6 +1582,7 @@ impl {{ self_t }} {
     ///
     /// The output vector is not necessarily unit length. For that use
     /// [`Self::any_orthonormal_vector()`] instead.
+    #[must_use]
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -1575,6 +1600,7 @@ impl {{ self_t }} {
     /// # Panics
     ///
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn any_orthonormal_vector(&self) -> Self {
         glam_assert!(self.is_normalized());
@@ -1608,6 +1634,7 @@ impl {{ self_t }} {
 
 {% if is_signed and dim == 2 %}
     /// Returns a vector that is equal to `self` rotated by 90 degrees.
+    #[must_use]
     #[inline]
     pub fn perp(self) -> Self {
         Self {

--- a/src/f32/coresimd/mat2.rs
+++ b/src/f32/coresimd/mat2.rs
@@ -238,6 +238,7 @@ impl Mat2 {
     }
 
     /// Multiplies two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat2(&self, rhs: &Self) -> Self {
         let abcd = self.0;
@@ -253,18 +254,21 @@ impl Mat2 {
     }
 
     /// Adds two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat2(&self, rhs: &Self) -> Self {
         Self(self.0 + rhs.0)
     }
 
     /// Subtracts two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat2(&self, rhs: &Self) -> Self {
         Self(self.0 - rhs.0)
     }
 
     /// Multiplies a 2x2 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self(self.0 * f32x4::splat(rhs))

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -486,6 +486,7 @@ impl Mat3A {
     }
 
     /// Multiplies two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -496,6 +497,7 @@ impl Mat3A {
     }
 
     /// Adds two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -506,6 +508,7 @@ impl Mat3A {
     }
 
     /// Subtracts two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -516,6 +519,7 @@ impl Mat3A {
     }
 
     /// Multiplies a 3x3 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self::from_cols(

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -1107,6 +1107,7 @@ impl Mat4 {
     }
 
     /// Multiplies two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1118,6 +1119,7 @@ impl Mat4 {
     }
 
     /// Adds two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1129,6 +1131,7 @@ impl Mat4 {
     }
 
     /// Subtracts two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1140,6 +1143,7 @@ impl Mat4 {
     }
 
     /// Multiplies a 4x4 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self::from_cols(

--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -529,6 +529,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     #[doc(alias = "mix")]
     pub fn lerp(self, end: Self, s: f32) -> Self {
@@ -555,6 +556,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn slerp(self, mut end: Self, s: f32) -> Self {
         // http://number-none.com/product/Understanding%20Slerp,%20Then%20Not%20Using%20It/
@@ -615,6 +617,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn mul_quat(self, rhs: Self) -> Self {
         glam_assert!(self.is_normalized());

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -160,15 +160,15 @@ impl Vec3A {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(dot3_into_f32x4(self.0, rhs.0))
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         let lhszxy = simd_swizzle!(self.0, [2, 0, 1, 1]);
         let rhszxy = simd_swizzle!(rhs.0, [2, 0, 1, 1]);
@@ -181,8 +181,8 @@ impl Vec3A {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self(self.0.simd_min(rhs.0))
     }
@@ -190,8 +190,8 @@ impl Vec3A {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self(self.0.simd_max(rhs.0))
     }
@@ -203,8 +203,8 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -293,8 +293,8 @@ impl Vec3A {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self(self.0.abs())
     }
@@ -304,15 +304,15 @@ impl Vec3A {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self(self.0.signum())
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         Self(self.0.copysign(rhs.0))
     }
@@ -401,8 +401,8 @@ impl Vec3A {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -161,12 +161,14 @@ impl Vec3A {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(dot3_into_f32x4(self.0, rhs.0))
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         let lhszxy = simd_swizzle!(self.0, [2, 0, 1, 1]);
         let rhszxy = simd_swizzle!(rhs.0, [2, 0, 1, 1]);
@@ -180,6 +182,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self(self.0.simd_min(rhs.0))
     }
@@ -188,6 +191,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self(self.0.simd_max(rhs.0))
     }
@@ -200,6 +204,7 @@ impl Vec3A {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -289,6 +294,7 @@ impl Vec3A {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self(self.0.abs())
     }
@@ -299,12 +305,14 @@ impl Vec3A {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self(self.0.signum())
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         Self(self.0.copysign(rhs.0))
     }
@@ -380,6 +388,7 @@ impl Vec3A {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -393,6 +402,7 @@ impl Vec3A {
     ///
     /// [Euclidean division]: f32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -526,6 +536,7 @@ impl Vec3A {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self(self.0.round())
@@ -533,6 +544,7 @@ impl Vec3A {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self(self.0.floor())
@@ -540,6 +552,7 @@ impl Vec3A {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self(self.0.ceil())
@@ -547,6 +560,7 @@ impl Vec3A {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self(self.0.trunc())
@@ -556,6 +570,7 @@ impl Vec3A {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -563,12 +578,14 @@ impl Vec3A {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(math::exp(self.x), math::exp(self.y), math::exp(self.z))
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f32) -> Self {
         Self::new(
@@ -579,6 +596,7 @@ impl Vec3A {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self(self.0.recip())
@@ -590,6 +608,7 @@ impl Vec3A {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f32) -> Self {
         self + ((rhs - self) * s)
@@ -614,6 +633,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f32, max: f32) -> Self {
         glam_assert!(min <= max);
@@ -628,6 +648,7 @@ impl Vec3A {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -638,6 +659,7 @@ impl Vec3A {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -654,6 +676,7 @@ impl Vec3A {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         Self(self.0.mul_add(a.0, b.0))
@@ -676,6 +699,7 @@ impl Vec3A {
     ///
     /// The output vector is not necessarily unit length. For that use
     /// [`Self::any_orthonormal_vector()`] instead.
+    #[must_use]
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -693,6 +717,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn any_orthonormal_vector(&self) -> Self {
         glam_assert!(self.is_normalized());

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -153,6 +153,7 @@ impl Vec4 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(dot4_into_f32x4(self.0, rhs.0))
     }
@@ -161,6 +162,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self(self.0.simd_min(rhs.0))
     }
@@ -169,6 +171,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self(self.0.simd_max(rhs.0))
     }
@@ -181,6 +184,7 @@ impl Vec4 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -264,6 +268,7 @@ impl Vec4 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self(self.0.abs())
     }
@@ -274,12 +279,14 @@ impl Vec4 {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self(self.0.signum())
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         Self(self.0.copysign(rhs.0))
     }
@@ -353,6 +360,7 @@ impl Vec4 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -367,6 +375,7 @@ impl Vec4 {
     ///
     /// [Euclidean division]: f32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -501,6 +510,7 @@ impl Vec4 {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self(self.0.round())
@@ -508,6 +518,7 @@ impl Vec4 {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self(self.0.floor())
@@ -515,6 +526,7 @@ impl Vec4 {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self(self.0.ceil())
@@ -522,6 +534,7 @@ impl Vec4 {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self(self.0.trunc())
@@ -531,6 +544,7 @@ impl Vec4 {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -538,6 +552,7 @@ impl Vec4 {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(
@@ -549,6 +564,7 @@ impl Vec4 {
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f32) -> Self {
         Self::new(
@@ -560,6 +576,7 @@ impl Vec4 {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self(self.0.recip())
@@ -571,6 +588,7 @@ impl Vec4 {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f32) -> Self {
         self + ((rhs - self) * s)
@@ -595,6 +613,7 @@ impl Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f32, max: f32) -> Self {
         glam_assert!(min <= max);
@@ -609,6 +628,7 @@ impl Vec4 {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -619,6 +639,7 @@ impl Vec4 {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -635,6 +656,7 @@ impl Vec4 {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         Self(self.0.mul_add(a.0, b.0))

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -152,8 +152,8 @@ impl Vec4 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(dot4_into_f32x4(self.0, rhs.0))
     }
@@ -161,8 +161,8 @@ impl Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self(self.0.simd_min(rhs.0))
     }
@@ -170,8 +170,8 @@ impl Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self(self.0.simd_max(rhs.0))
     }
@@ -183,8 +183,8 @@ impl Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -267,8 +267,8 @@ impl Vec4 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self(self.0.abs())
     }
@@ -278,15 +278,15 @@ impl Vec4 {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self(self.0.signum())
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         Self(self.0.copysign(rhs.0))
     }
@@ -374,8 +374,8 @@ impl Vec4 {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f32/float.rs
+++ b/src/f32/float.rs
@@ -3,19 +3,16 @@
 use crate::float::FloatExt;
 
 impl FloatExt for f32 {
-    #[must_use]
     #[inline]
     fn lerp(self, rhs: f32, t: f32) -> f32 {
         self + (rhs - self) * t
     }
 
-    #[must_use]
     #[inline]
     fn inverse_lerp(a: f32, b: f32, v: f32) -> f32 {
         (v - a) / (b - a)
     }
 
-    #[must_use]
     #[inline]
     fn remap(self, in_start: f32, in_end: f32, out_start: f32, out_end: f32) -> f32 {
         let t = f32::inverse_lerp(in_start, in_end, self);

--- a/src/f32/float.rs
+++ b/src/f32/float.rs
@@ -3,16 +3,19 @@
 use crate::float::FloatExt;
 
 impl FloatExt for f32 {
+    #[must_use]
     #[inline]
     fn lerp(self, rhs: f32, t: f32) -> f32 {
         self + (rhs - self) * t
     }
 
+    #[must_use]
     #[inline]
     fn inverse_lerp(a: f32, b: f32, v: f32) -> f32 {
         (v - a) / (b - a)
     }
 
+    #[must_use]
     #[inline]
     fn remap(self, in_start: f32, in_end: f32, out_start: f32, out_end: f32) -> f32 {
         let t = f32::inverse_lerp(in_start, in_end, self);

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -480,6 +480,7 @@ impl Mat3 {
     }
 
     /// Multiplies two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -490,6 +491,7 @@ impl Mat3 {
     }
 
     /// Adds two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -500,6 +502,7 @@ impl Mat3 {
     }
 
     /// Subtracts two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -510,6 +513,7 @@ impl Mat3 {
     }
 
     /// Multiplies a 3x3 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self::from_cols(

--- a/src/f32/scalar/mat2.rs
+++ b/src/f32/scalar/mat2.rs
@@ -242,24 +242,28 @@ impl Mat2 {
     }
 
     /// Multiplies two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat2(&self, rhs: &Self) -> Self {
         Self::from_cols(self.mul(rhs.x_axis), self.mul(rhs.y_axis))
     }
 
     /// Adds two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat2(&self, rhs: &Self) -> Self {
         Self::from_cols(self.x_axis.add(rhs.x_axis), self.y_axis.add(rhs.y_axis))
     }
 
     /// Subtracts two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat2(&self, rhs: &Self) -> Self {
         Self::from_cols(self.x_axis.sub(rhs.x_axis), self.y_axis.sub(rhs.y_axis))
     }
 
     /// Multiplies a 2x2 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self::from_cols(self.x_axis.mul(rhs), self.y_axis.mul(rhs))

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -484,6 +484,7 @@ impl Mat3A {
     }
 
     /// Multiplies two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -494,6 +495,7 @@ impl Mat3A {
     }
 
     /// Adds two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -504,6 +506,7 @@ impl Mat3A {
     }
 
     /// Subtracts two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -514,6 +517,7 @@ impl Mat3A {
     }
 
     /// Multiplies a 3x3 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self::from_cols(

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -1019,6 +1019,7 @@ impl Mat4 {
     }
 
     /// Multiplies two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1030,6 +1031,7 @@ impl Mat4 {
     }
 
     /// Adds two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1041,6 +1043,7 @@ impl Mat4 {
     }
 
     /// Subtracts two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1052,6 +1055,7 @@ impl Mat4 {
     }
 
     /// Multiplies a 4x4 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self::from_cols(

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -541,6 +541,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     #[doc(alias = "mix")]
     pub fn lerp(self, end: Self, s: f32) -> Self {
@@ -563,6 +564,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn slerp(self, mut end: Self, s: f32) -> Self {
         // http://number-none.com/product/Understanding%20Slerp,%20Then%20Not%20Using%20It/
@@ -622,6 +624,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn mul_quat(self, rhs: Self) -> Self {
         glam_assert!(self.is_normalized());

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -171,15 +171,15 @@ impl Vec3A {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -191,8 +191,8 @@ impl Vec3A {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -204,8 +204,8 @@ impl Vec3A {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -221,8 +221,8 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -305,8 +305,8 @@ impl Vec3A {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -320,8 +320,8 @@ impl Vec3A {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -331,8 +331,8 @@ impl Vec3A {
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -423,8 +423,8 @@ impl Vec3A {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -172,12 +172,14 @@ impl Vec3A {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -190,6 +192,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -202,6 +205,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -218,6 +222,7 @@ impl Vec3A {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -301,6 +306,7 @@ impl Vec3A {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -315,6 +321,7 @@ impl Vec3A {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -325,6 +332,7 @@ impl Vec3A {
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -402,6 +410,7 @@ impl Vec3A {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -415,6 +424,7 @@ impl Vec3A {
     ///
     /// [Euclidean division]: f32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -547,6 +557,7 @@ impl Vec3A {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self {
@@ -558,6 +569,7 @@ impl Vec3A {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self {
@@ -569,6 +581,7 @@ impl Vec3A {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self {
@@ -580,6 +593,7 @@ impl Vec3A {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self {
@@ -593,6 +607,7 @@ impl Vec3A {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -600,12 +615,14 @@ impl Vec3A {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(math::exp(self.x), math::exp(self.y), math::exp(self.z))
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f32) -> Self {
         Self::new(
@@ -616,6 +633,7 @@ impl Vec3A {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self {
@@ -631,6 +649,7 @@ impl Vec3A {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f32) -> Self {
         self + ((rhs - self) * s)
@@ -655,6 +674,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f32, max: f32) -> Self {
         glam_assert!(min <= max);
@@ -669,6 +689,7 @@ impl Vec3A {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -679,6 +700,7 @@ impl Vec3A {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -695,6 +717,7 @@ impl Vec3A {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         Self::new(
@@ -721,6 +744,7 @@ impl Vec3A {
     ///
     /// The output vector is not necessarily unit length. For that use
     /// [`Self::any_orthonormal_vector()`] instead.
+    #[must_use]
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -738,6 +762,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn any_orthonormal_vector(&self) -> Self {
         glam_assert!(self.is_normalized());

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -175,8 +175,8 @@ impl Vec4 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -184,8 +184,8 @@ impl Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -198,8 +198,8 @@ impl Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -216,8 +216,8 @@ impl Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -330,8 +330,8 @@ impl Vec4 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -346,8 +346,8 @@ impl Vec4 {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -358,8 +358,8 @@ impl Vec4 {
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -458,8 +458,8 @@ impl Vec4 {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -176,6 +176,7 @@ impl Vec4 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -184,6 +185,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -197,6 +199,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -214,6 +217,7 @@ impl Vec4 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -327,6 +331,7 @@ impl Vec4 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -342,6 +347,7 @@ impl Vec4 {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -353,6 +359,7 @@ impl Vec4 {
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -437,6 +444,7 @@ impl Vec4 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -451,6 +459,7 @@ impl Vec4 {
     ///
     /// [Euclidean division]: f32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -584,6 +593,7 @@ impl Vec4 {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self {
@@ -596,6 +606,7 @@ impl Vec4 {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self {
@@ -608,6 +619,7 @@ impl Vec4 {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self {
@@ -620,6 +632,7 @@ impl Vec4 {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self {
@@ -634,6 +647,7 @@ impl Vec4 {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -641,6 +655,7 @@ impl Vec4 {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(
@@ -652,6 +667,7 @@ impl Vec4 {
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f32) -> Self {
         Self::new(
@@ -663,6 +679,7 @@ impl Vec4 {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self {
@@ -679,6 +696,7 @@ impl Vec4 {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f32) -> Self {
         self + ((rhs - self) * s)
@@ -703,6 +721,7 @@ impl Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f32, max: f32) -> Self {
         glam_assert!(min <= max);
@@ -717,6 +736,7 @@ impl Vec4 {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -727,6 +747,7 @@ impl Vec4 {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -743,6 +764,7 @@ impl Vec4 {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         Self::new(

--- a/src/f32/sse2/mat2.rs
+++ b/src/f32/sse2/mat2.rs
@@ -267,6 +267,7 @@ impl Mat2 {
     }
 
     /// Multiplies two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat2(&self, rhs: &Self) -> Self {
         unsafe {
@@ -285,18 +286,21 @@ impl Mat2 {
     }
 
     /// Adds two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat2(&self, rhs: &Self) -> Self {
         Self(unsafe { _mm_add_ps(self.0, rhs.0) })
     }
 
     /// Subtracts two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat2(&self, rhs: &Self) -> Self {
         Self(unsafe { _mm_sub_ps(self.0, rhs.0) })
     }
 
     /// Multiplies a 2x2 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self(unsafe { _mm_mul_ps(self.0, _mm_set_ps1(rhs)) })

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -491,6 +491,7 @@ impl Mat3A {
     }
 
     /// Multiplies two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -501,6 +502,7 @@ impl Mat3A {
     }
 
     /// Adds two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -511,6 +513,7 @@ impl Mat3A {
     }
 
     /// Subtracts two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -521,6 +524,7 @@ impl Mat3A {
     }
 
     /// Multiplies a 3x3 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self::from_cols(

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -1116,6 +1116,7 @@ impl Mat4 {
     }
 
     /// Multiplies two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1127,6 +1128,7 @@ impl Mat4 {
     }
 
     /// Adds two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1138,6 +1140,7 @@ impl Mat4 {
     }
 
     /// Subtracts two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1149,6 +1152,7 @@ impl Mat4 {
     }
 
     /// Multiplies a 4x4 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self::from_cols(

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -537,6 +537,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     #[doc(alias = "mix")]
     pub fn lerp(self, end: Self, s: f32) -> Self {
@@ -568,6 +569,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn slerp(self, mut end: Self, s: f32) -> Self {
         // http://number-none.com/product/Understanding%20Slerp,%20Then%20Not%20Using%20It/
@@ -634,6 +636,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn mul_quat(self, rhs: Self) -> Self {
         glam_assert!(self.is_normalized());

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -174,12 +174,14 @@ impl Vec3A {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(unsafe { dot3_into_m128(self.0, rhs.0) })
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         unsafe {
             // x  <-  a.y*b.z - a.z*b.y
@@ -200,6 +202,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self(unsafe { _mm_min_ps(self.0, rhs.0) })
     }
@@ -208,6 +211,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self(unsafe { _mm_max_ps(self.0, rhs.0) })
     }
@@ -220,6 +224,7 @@ impl Vec3A {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -313,6 +318,7 @@ impl Vec3A {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self(unsafe { crate::sse2::m128_abs(self.0) })
     }
@@ -323,6 +329,7 @@ impl Vec3A {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         unsafe {
             let result = Self(_mm_or_ps(_mm_and_ps(self.0, Self::NEG_ONE.0), Self::ONE.0));
@@ -333,6 +340,7 @@ impl Vec3A {
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         unsafe {
             let mask = Self::splat(-0.0);
@@ -416,6 +424,7 @@ impl Vec3A {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -429,6 +438,7 @@ impl Vec3A {
     ///
     /// [Euclidean division]: f32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -564,6 +574,7 @@ impl Vec3A {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self(unsafe { m128_round(self.0) })
@@ -571,6 +582,7 @@ impl Vec3A {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self(unsafe { m128_floor(self.0) })
@@ -578,6 +590,7 @@ impl Vec3A {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self(unsafe { m128_ceil(self.0) })
@@ -585,6 +598,7 @@ impl Vec3A {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self(unsafe { m128_trunc(self.0) })
@@ -594,6 +608,7 @@ impl Vec3A {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -601,12 +616,14 @@ impl Vec3A {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(math::exp(self.x), math::exp(self.y), math::exp(self.z))
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f32) -> Self {
         Self::new(
@@ -617,6 +634,7 @@ impl Vec3A {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self(unsafe { _mm_div_ps(Self::ONE.0, self.0) })
@@ -628,6 +646,7 @@ impl Vec3A {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f32) -> Self {
         self + ((rhs - self) * s)
@@ -652,6 +671,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f32, max: f32) -> Self {
         glam_assert!(min <= max);
@@ -666,6 +686,7 @@ impl Vec3A {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -676,6 +697,7 @@ impl Vec3A {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -692,6 +714,7 @@ impl Vec3A {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         #[cfg(target_feature = "fma")]
@@ -723,6 +746,7 @@ impl Vec3A {
     ///
     /// The output vector is not necessarily unit length. For that use
     /// [`Self::any_orthonormal_vector()`] instead.
+    #[must_use]
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -740,6 +764,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn any_orthonormal_vector(&self) -> Self {
         glam_assert!(self.is_normalized());

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -173,15 +173,15 @@ impl Vec3A {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(unsafe { dot3_into_m128(self.0, rhs.0) })
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         unsafe {
             // x  <-  a.y*b.z - a.z*b.y
@@ -201,8 +201,8 @@ impl Vec3A {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self(unsafe { _mm_min_ps(self.0, rhs.0) })
     }
@@ -210,8 +210,8 @@ impl Vec3A {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self(unsafe { _mm_max_ps(self.0, rhs.0) })
     }
@@ -223,8 +223,8 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -317,8 +317,8 @@ impl Vec3A {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self(unsafe { crate::sse2::m128_abs(self.0) })
     }
@@ -328,8 +328,8 @@ impl Vec3A {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         unsafe {
             let result = Self(_mm_or_ps(_mm_and_ps(self.0, Self::NEG_ONE.0), Self::ONE.0));
@@ -339,8 +339,8 @@ impl Vec3A {
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         unsafe {
             let mask = Self::splat(-0.0);
@@ -437,8 +437,8 @@ impl Vec3A {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -165,8 +165,8 @@ impl Vec4 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(unsafe { dot4_into_m128(self.0, rhs.0) })
     }
@@ -174,8 +174,8 @@ impl Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self(unsafe { _mm_min_ps(self.0, rhs.0) })
     }
@@ -183,8 +183,8 @@ impl Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self(unsafe { _mm_max_ps(self.0, rhs.0) })
     }
@@ -196,8 +196,8 @@ impl Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -290,8 +290,8 @@ impl Vec4 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self(unsafe { crate::sse2::m128_abs(self.0) })
     }
@@ -301,8 +301,8 @@ impl Vec4 {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         unsafe {
             let result = Self(_mm_or_ps(_mm_and_ps(self.0, Self::NEG_ONE.0), Self::ONE.0));
@@ -312,8 +312,8 @@ impl Vec4 {
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         unsafe {
             let mask = Self::splat(-0.0);
@@ -411,8 +411,8 @@ impl Vec4 {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -166,6 +166,7 @@ impl Vec4 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(unsafe { dot4_into_m128(self.0, rhs.0) })
     }
@@ -174,6 +175,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self(unsafe { _mm_min_ps(self.0, rhs.0) })
     }
@@ -182,6 +184,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self(unsafe { _mm_max_ps(self.0, rhs.0) })
     }
@@ -194,6 +197,7 @@ impl Vec4 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -287,6 +291,7 @@ impl Vec4 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self(unsafe { crate::sse2::m128_abs(self.0) })
     }
@@ -297,6 +302,7 @@ impl Vec4 {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         unsafe {
             let result = Self(_mm_or_ps(_mm_and_ps(self.0, Self::NEG_ONE.0), Self::ONE.0));
@@ -307,6 +313,7 @@ impl Vec4 {
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         unsafe {
             let mask = Self::splat(-0.0);
@@ -390,6 +397,7 @@ impl Vec4 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -404,6 +412,7 @@ impl Vec4 {
     ///
     /// [Euclidean division]: f32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -540,6 +549,7 @@ impl Vec4 {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self(unsafe { m128_round(self.0) })
@@ -547,6 +557,7 @@ impl Vec4 {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self(unsafe { m128_floor(self.0) })
@@ -554,6 +565,7 @@ impl Vec4 {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self(unsafe { m128_ceil(self.0) })
@@ -561,6 +573,7 @@ impl Vec4 {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self(unsafe { m128_trunc(self.0) })
@@ -570,6 +583,7 @@ impl Vec4 {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -577,6 +591,7 @@ impl Vec4 {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(
@@ -588,6 +603,7 @@ impl Vec4 {
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f32) -> Self {
         Self::new(
@@ -599,6 +615,7 @@ impl Vec4 {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self(unsafe { _mm_div_ps(Self::ONE.0, self.0) })
@@ -610,6 +627,7 @@ impl Vec4 {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f32) -> Self {
         self + ((rhs - self) * s)
@@ -634,6 +652,7 @@ impl Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f32, max: f32) -> Self {
         glam_assert!(min <= max);
@@ -648,6 +667,7 @@ impl Vec4 {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -658,6 +678,7 @@ impl Vec4 {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -674,6 +695,7 @@ impl Vec4 {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         #[cfg(target_feature = "fma")]

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -135,6 +135,7 @@ impl Vec2 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -143,6 +144,7 @@ impl Vec2 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -154,6 +156,7 @@ impl Vec2 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -169,6 +172,7 @@ impl Vec2 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -252,6 +256,7 @@ impl Vec2 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -265,6 +270,7 @@ impl Vec2 {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -274,6 +280,7 @@ impl Vec2 {
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -348,6 +355,7 @@ impl Vec2 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -360,6 +368,7 @@ impl Vec2 {
     ///
     /// [Euclidean division]: f32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -491,6 +500,7 @@ impl Vec2 {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self {
@@ -501,6 +511,7 @@ impl Vec2 {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self {
@@ -511,6 +522,7 @@ impl Vec2 {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self {
@@ -521,6 +533,7 @@ impl Vec2 {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self {
@@ -533,6 +546,7 @@ impl Vec2 {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -540,18 +554,21 @@ impl Vec2 {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(math::exp(self.x), math::exp(self.y))
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f32) -> Self {
         Self::new(math::powf(self.x, n), math::powf(self.y, n))
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self {
@@ -566,6 +583,7 @@ impl Vec2 {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f32) -> Self {
         self + ((rhs - self) * s)
@@ -590,6 +608,7 @@ impl Vec2 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f32, max: f32) -> Self {
         glam_assert!(min <= max);
@@ -604,6 +623,7 @@ impl Vec2 {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -614,6 +634,7 @@ impl Vec2 {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -630,6 +651,7 @@ impl Vec2 {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         Self::new(
@@ -642,6 +664,7 @@ impl Vec2 {
     /// conjunction with the [`rotate()`][Self::rotate()] method, e.g.
     /// `Vec2::from_angle(PI).rotate(Vec2::Y)` will create the vector `[-1, 0]`
     /// and rotate [`Vec2::Y`] around it returning `-Vec2::Y`.
+    #[must_use]
     #[inline]
     pub fn from_angle(angle: f32) -> Self {
         let (sin, cos) = math::sin_cos(angle);
@@ -669,6 +692,7 @@ impl Vec2 {
     }
 
     /// Returns a vector that is equal to `self` rotated by 90 degrees.
+    #[must_use]
     #[inline]
     pub fn perp(self) -> Self {
         Self {

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -134,8 +134,8 @@ impl Vec2 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -143,8 +143,8 @@ impl Vec2 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -155,8 +155,8 @@ impl Vec2 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -171,8 +171,8 @@ impl Vec2 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -255,8 +255,8 @@ impl Vec2 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -269,8 +269,8 @@ impl Vec2 {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -279,8 +279,8 @@ impl Vec2 {
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -367,8 +367,8 @@ impl Vec2 {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -163,12 +163,14 @@ impl Vec3 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -181,6 +183,7 @@ impl Vec3 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -193,6 +196,7 @@ impl Vec3 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -209,6 +213,7 @@ impl Vec3 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -292,6 +297,7 @@ impl Vec3 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -306,6 +312,7 @@ impl Vec3 {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -316,6 +323,7 @@ impl Vec3 {
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -393,6 +401,7 @@ impl Vec3 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -406,6 +415,7 @@ impl Vec3 {
     ///
     /// [Euclidean division]: f32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -538,6 +548,7 @@ impl Vec3 {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self {
@@ -549,6 +560,7 @@ impl Vec3 {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self {
@@ -560,6 +572,7 @@ impl Vec3 {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self {
@@ -571,6 +584,7 @@ impl Vec3 {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self {
@@ -584,6 +598,7 @@ impl Vec3 {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -591,12 +606,14 @@ impl Vec3 {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(math::exp(self.x), math::exp(self.y), math::exp(self.z))
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f32) -> Self {
         Self::new(
@@ -607,6 +624,7 @@ impl Vec3 {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self {
@@ -622,6 +640,7 @@ impl Vec3 {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f32) -> Self {
         self + ((rhs - self) * s)
@@ -646,6 +665,7 @@ impl Vec3 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f32, max: f32) -> Self {
         glam_assert!(min <= max);
@@ -660,6 +680,7 @@ impl Vec3 {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -670,6 +691,7 @@ impl Vec3 {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -686,6 +708,7 @@ impl Vec3 {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         Self::new(
@@ -712,6 +735,7 @@ impl Vec3 {
     ///
     /// The output vector is not necessarily unit length. For that use
     /// [`Self::any_orthonormal_vector()`] instead.
+    #[must_use]
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -729,6 +753,7 @@ impl Vec3 {
     /// # Panics
     ///
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn any_orthonormal_vector(&self) -> Self {
         glam_assert!(self.is_normalized());

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -162,15 +162,15 @@ impl Vec3 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -182,8 +182,8 @@ impl Vec3 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -195,8 +195,8 @@ impl Vec3 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -212,8 +212,8 @@ impl Vec3 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -296,8 +296,8 @@ impl Vec3 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -311,8 +311,8 @@ impl Vec3 {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -322,8 +322,8 @@ impl Vec3 {
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -414,8 +414,8 @@ impl Vec3 {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f32/wasm32/mat2.rs
+++ b/src/f32/wasm32/mat2.rs
@@ -243,6 +243,7 @@ impl Mat2 {
     }
 
     /// Multiplies two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat2(&self, rhs: &Self) -> Self {
         let abcd = self.0;
@@ -259,18 +260,21 @@ impl Mat2 {
     }
 
     /// Adds two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat2(&self, rhs: &Self) -> Self {
         Self(f32x4_add(self.0, rhs.0))
     }
 
     /// Subtracts two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat2(&self, rhs: &Self) -> Self {
         Self(f32x4_sub(self.0, rhs.0))
     }
 
     /// Multiplies a 2x2 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self(f32x4_mul(self.0, f32x4_splat(rhs)))

--- a/src/f32/wasm32/mat3a.rs
+++ b/src/f32/wasm32/mat3a.rs
@@ -486,6 +486,7 @@ impl Mat3A {
     }
 
     /// Multiplies two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -496,6 +497,7 @@ impl Mat3A {
     }
 
     /// Adds two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -506,6 +508,7 @@ impl Mat3A {
     }
 
     /// Subtracts two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -516,6 +519,7 @@ impl Mat3A {
     }
 
     /// Multiplies a 3x3 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self::from_cols(

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -1107,6 +1107,7 @@ impl Mat4 {
     }
 
     /// Multiplies two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1118,6 +1119,7 @@ impl Mat4 {
     }
 
     /// Adds two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1129,6 +1131,7 @@ impl Mat4 {
     }
 
     /// Subtracts two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1140,6 +1143,7 @@ impl Mat4 {
     }
 
     /// Multiplies a 4x4 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f32) -> Self {
         Self::from_cols(

--- a/src/f32/wasm32/quat.rs
+++ b/src/f32/wasm32/quat.rs
@@ -529,6 +529,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     #[doc(alias = "mix")]
     pub fn lerp(self, end: Self, s: f32) -> Self {
@@ -558,6 +559,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn slerp(self, mut end: Self, s: f32) -> Self {
         // http://number-none.com/product/Understanding%20Slerp,%20Then%20Not%20Using%20It/
@@ -628,6 +630,7 @@ impl Quat {
     /// # Panics
     ///
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn mul_quat(self, rhs: Self) -> Self {
         glam_assert!(self.is_normalized());

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -166,12 +166,14 @@ impl Vec3A {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(dot3_into_v128(self.0, rhs.0))
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         let lhszxy = i32x4_shuffle::<2, 0, 1, 1>(self.0, self.0);
         let rhszxy = i32x4_shuffle::<2, 0, 1, 1>(rhs.0, rhs.0);
@@ -185,6 +187,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self(f32x4_pmin(self.0, rhs.0))
     }
@@ -193,6 +196,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self(f32x4_pmax(self.0, rhs.0))
     }
@@ -205,6 +209,7 @@ impl Vec3A {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -294,6 +299,7 @@ impl Vec3A {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self(f32x4_abs(self.0))
     }
@@ -304,6 +310,7 @@ impl Vec3A {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         unsafe {
             let result = Self(v128_or(v128_and(self.0, Self::NEG_ONE.0), Self::ONE.0));
@@ -314,6 +321,7 @@ impl Vec3A {
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         unsafe {
             let mask = Self::splat(-0.0);
@@ -393,6 +401,7 @@ impl Vec3A {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -406,6 +415,7 @@ impl Vec3A {
     ///
     /// [Euclidean division]: f32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -539,6 +549,7 @@ impl Vec3A {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self(f32x4_nearest(self.0))
@@ -546,6 +557,7 @@ impl Vec3A {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self(f32x4_floor(self.0))
@@ -553,6 +565,7 @@ impl Vec3A {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self(f32x4_ceil(self.0))
@@ -560,6 +573,7 @@ impl Vec3A {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self(f32x4_trunc(self.0))
@@ -569,6 +583,7 @@ impl Vec3A {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -576,12 +591,14 @@ impl Vec3A {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(math::exp(self.x), math::exp(self.y), math::exp(self.z))
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f32) -> Self {
         Self::new(
@@ -592,6 +609,7 @@ impl Vec3A {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self(f32x4_div(Self::ONE.0, self.0))
@@ -603,6 +621,7 @@ impl Vec3A {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f32) -> Self {
         self + ((rhs - self) * s)
@@ -627,6 +646,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f32, max: f32) -> Self {
         glam_assert!(min <= max);
@@ -641,6 +661,7 @@ impl Vec3A {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -651,6 +672,7 @@ impl Vec3A {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -667,6 +689,7 @@ impl Vec3A {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         Self::new(
@@ -693,6 +716,7 @@ impl Vec3A {
     ///
     /// The output vector is not necessarily unit length. For that use
     /// [`Self::any_orthonormal_vector()`] instead.
+    #[must_use]
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -710,6 +734,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn any_orthonormal_vector(&self) -> Self {
         glam_assert!(self.is_normalized());

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -165,15 +165,15 @@ impl Vec3A {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(dot3_into_v128(self.0, rhs.0))
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         let lhszxy = i32x4_shuffle::<2, 0, 1, 1>(self.0, self.0);
         let rhszxy = i32x4_shuffle::<2, 0, 1, 1>(rhs.0, rhs.0);
@@ -186,8 +186,8 @@ impl Vec3A {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self(f32x4_pmin(self.0, rhs.0))
     }
@@ -195,8 +195,8 @@ impl Vec3A {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self(f32x4_pmax(self.0, rhs.0))
     }
@@ -208,8 +208,8 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -298,8 +298,8 @@ impl Vec3A {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self(f32x4_abs(self.0))
     }
@@ -309,8 +309,8 @@ impl Vec3A {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         unsafe {
             let result = Self(v128_or(v128_and(self.0, Self::NEG_ONE.0), Self::ONE.0));
@@ -320,8 +320,8 @@ impl Vec3A {
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         unsafe {
             let mask = Self::splat(-0.0);
@@ -414,8 +414,8 @@ impl Vec3A {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -157,8 +157,8 @@ impl Vec4 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(dot4_into_v128(self.0, rhs.0))
     }
@@ -166,8 +166,8 @@ impl Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self(f32x4_pmin(self.0, rhs.0))
     }
@@ -175,8 +175,8 @@ impl Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self(f32x4_pmax(self.0, rhs.0))
     }
@@ -188,8 +188,8 @@ impl Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -278,8 +278,8 @@ impl Vec4 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self(f32x4_abs(self.0))
     }
@@ -289,8 +289,8 @@ impl Vec4 {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         unsafe {
             let result = Self(v128_or(v128_and(self.0, Self::NEG_ONE.0), Self::ONE.0));
@@ -300,8 +300,8 @@ impl Vec4 {
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         unsafe {
             let mask = Self::splat(-0.0);
@@ -395,8 +395,8 @@ impl Vec4 {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -158,6 +158,7 @@ impl Vec4 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self(dot4_into_v128(self.0, rhs.0))
     }
@@ -166,6 +167,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self(f32x4_pmin(self.0, rhs.0))
     }
@@ -174,6 +176,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self(f32x4_pmax(self.0, rhs.0))
     }
@@ -186,6 +189,7 @@ impl Vec4 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -275,6 +279,7 @@ impl Vec4 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self(f32x4_abs(self.0))
     }
@@ -285,6 +290,7 @@ impl Vec4 {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         unsafe {
             let result = Self(v128_or(v128_and(self.0, Self::NEG_ONE.0), Self::ONE.0));
@@ -295,6 +301,7 @@ impl Vec4 {
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         unsafe {
             let mask = Self::splat(-0.0);
@@ -374,6 +381,7 @@ impl Vec4 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -388,6 +396,7 @@ impl Vec4 {
     ///
     /// [Euclidean division]: f32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -522,6 +531,7 @@ impl Vec4 {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self(f32x4_nearest(self.0))
@@ -529,6 +539,7 @@ impl Vec4 {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self(f32x4_floor(self.0))
@@ -536,6 +547,7 @@ impl Vec4 {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self(f32x4_ceil(self.0))
@@ -543,6 +555,7 @@ impl Vec4 {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self(f32x4_trunc(self.0))
@@ -552,6 +565,7 @@ impl Vec4 {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -559,6 +573,7 @@ impl Vec4 {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(
@@ -570,6 +585,7 @@ impl Vec4 {
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f32) -> Self {
         Self::new(
@@ -581,6 +597,7 @@ impl Vec4 {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self(f32x4_div(Self::ONE.0, self.0))
@@ -592,6 +609,7 @@ impl Vec4 {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f32) -> Self {
         self + ((rhs - self) * s)
@@ -616,6 +634,7 @@ impl Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f32, max: f32) -> Self {
         glam_assert!(min <= max);
@@ -630,6 +649,7 @@ impl Vec4 {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -640,6 +660,7 @@ impl Vec4 {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f32) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -656,6 +677,7 @@ impl Vec4 {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         Self::new(

--- a/src/f64/dmat2.rs
+++ b/src/f64/dmat2.rs
@@ -232,24 +232,28 @@ impl DMat2 {
     }
 
     /// Multiplies two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat2(&self, rhs: &Self) -> Self {
         Self::from_cols(self.mul(rhs.x_axis), self.mul(rhs.y_axis))
     }
 
     /// Adds two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat2(&self, rhs: &Self) -> Self {
         Self::from_cols(self.x_axis.add(rhs.x_axis), self.y_axis.add(rhs.y_axis))
     }
 
     /// Subtracts two 2x2 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat2(&self, rhs: &Self) -> Self {
         Self::from_cols(self.x_axis.sub(rhs.x_axis), self.y_axis.sub(rhs.y_axis))
     }
 
     /// Multiplies a 2x2 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f64) -> Self {
         Self::from_cols(self.x_axis.mul(rhs), self.y_axis.mul(rhs))

--- a/src/f64/dmat3.rs
+++ b/src/f64/dmat3.rs
@@ -478,6 +478,7 @@ impl DMat3 {
     }
 
     /// Multiplies two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -488,6 +489,7 @@ impl DMat3 {
     }
 
     /// Adds two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -498,6 +500,7 @@ impl DMat3 {
     }
 
     /// Subtracts two 3x3 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat3(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -508,6 +511,7 @@ impl DMat3 {
     }
 
     /// Multiplies a 3x3 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f64) -> Self {
         Self::from_cols(

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -986,6 +986,7 @@ impl DMat4 {
     }
 
     /// Multiplies two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn mul_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -997,6 +998,7 @@ impl DMat4 {
     }
 
     /// Adds two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn add_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1008,6 +1010,7 @@ impl DMat4 {
     }
 
     /// Subtracts two 4x4 matrices.
+    #[must_use]
     #[inline]
     pub fn sub_mat4(&self, rhs: &Self) -> Self {
         Self::from_cols(
@@ -1019,6 +1022,7 @@ impl DMat4 {
     }
 
     /// Multiplies a 4x4 matrix by a scalar.
+    #[must_use]
     #[inline]
     pub fn mul_scalar(&self, rhs: f64) -> Self {
         Self::from_cols(

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -531,6 +531,7 @@ impl DQuat {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     #[doc(alias = "mix")]
     pub fn lerp(self, end: Self, s: f64) -> Self {
@@ -553,6 +554,7 @@ impl DQuat {
     /// # Panics
     ///
     /// Will panic if `self` or `end` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn slerp(self, mut end: Self, s: f64) -> Self {
         // http://number-none.com/product/Understanding%20Slerp,%20Then%20Not%20Using%20It/
@@ -612,6 +614,7 @@ impl DQuat {
     /// # Panics
     ///
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn mul_quat(self, rhs: Self) -> Self {
         glam_assert!(self.is_normalized());

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -134,8 +134,8 @@ impl DVec2 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -143,8 +143,8 @@ impl DVec2 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -155,8 +155,8 @@ impl DVec2 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -171,8 +171,8 @@ impl DVec2 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -255,8 +255,8 @@ impl DVec2 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -269,8 +269,8 @@ impl DVec2 {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -279,8 +279,8 @@ impl DVec2 {
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -367,8 +367,8 @@ impl DVec2 {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f64::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -135,6 +135,7 @@ impl DVec2 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -143,6 +144,7 @@ impl DVec2 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -154,6 +156,7 @@ impl DVec2 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -169,6 +172,7 @@ impl DVec2 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -252,6 +256,7 @@ impl DVec2 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -265,6 +270,7 @@ impl DVec2 {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -274,6 +280,7 @@ impl DVec2 {
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -348,6 +355,7 @@ impl DVec2 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -360,6 +368,7 @@ impl DVec2 {
     ///
     /// [Euclidean division]: f64::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -491,6 +500,7 @@ impl DVec2 {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self {
@@ -501,6 +511,7 @@ impl DVec2 {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self {
@@ -511,6 +522,7 @@ impl DVec2 {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self {
@@ -521,6 +533,7 @@ impl DVec2 {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self {
@@ -533,6 +546,7 @@ impl DVec2 {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -540,18 +554,21 @@ impl DVec2 {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(math::exp(self.x), math::exp(self.y))
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f64) -> Self {
         Self::new(math::powf(self.x, n), math::powf(self.y, n))
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self {
@@ -566,6 +583,7 @@ impl DVec2 {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f64) -> Self {
         self + ((rhs - self) * s)
@@ -590,6 +608,7 @@ impl DVec2 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f64, max: f64) -> Self {
         glam_assert!(min <= max);
@@ -604,6 +623,7 @@ impl DVec2 {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f64) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -614,6 +634,7 @@ impl DVec2 {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f64) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -630,6 +651,7 @@ impl DVec2 {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         Self::new(
@@ -642,6 +664,7 @@ impl DVec2 {
     /// conjunction with the [`rotate()`][Self::rotate()] method, e.g.
     /// `DVec2::from_angle(PI).rotate(DVec2::Y)` will create the vector `[-1, 0]`
     /// and rotate [`DVec2::Y`] around it returning `-DVec2::Y`.
+    #[must_use]
     #[inline]
     pub fn from_angle(angle: f64) -> Self {
         let (sin, cos) = math::sin_cos(angle);
@@ -669,6 +692,7 @@ impl DVec2 {
     }
 
     /// Returns a vector that is equal to `self` rotated by 90 degrees.
+    #[must_use]
     #[inline]
     pub fn perp(self) -> Self {
         Self {

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -162,15 +162,15 @@ impl DVec3 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -182,8 +182,8 @@ impl DVec3 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -195,8 +195,8 @@ impl DVec3 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -212,8 +212,8 @@ impl DVec3 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -296,8 +296,8 @@ impl DVec3 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -311,8 +311,8 @@ impl DVec3 {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -322,8 +322,8 @@ impl DVec3 {
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -414,8 +414,8 @@ impl DVec3 {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f64::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -163,12 +163,14 @@ impl DVec3 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -181,6 +183,7 @@ impl DVec3 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -193,6 +196,7 @@ impl DVec3 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -209,6 +213,7 @@ impl DVec3 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -292,6 +297,7 @@ impl DVec3 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -306,6 +312,7 @@ impl DVec3 {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -316,6 +323,7 @@ impl DVec3 {
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -393,6 +401,7 @@ impl DVec3 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -406,6 +415,7 @@ impl DVec3 {
     ///
     /// [Euclidean division]: f64::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -538,6 +548,7 @@ impl DVec3 {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self {
@@ -549,6 +560,7 @@ impl DVec3 {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self {
@@ -560,6 +572,7 @@ impl DVec3 {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self {
@@ -571,6 +584,7 @@ impl DVec3 {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self {
@@ -584,6 +598,7 @@ impl DVec3 {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -591,12 +606,14 @@ impl DVec3 {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(math::exp(self.x), math::exp(self.y), math::exp(self.z))
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f64) -> Self {
         Self::new(
@@ -607,6 +624,7 @@ impl DVec3 {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self {
@@ -622,6 +640,7 @@ impl DVec3 {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f64) -> Self {
         self + ((rhs - self) * s)
@@ -646,6 +665,7 @@ impl DVec3 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f64, max: f64) -> Self {
         glam_assert!(min <= max);
@@ -660,6 +680,7 @@ impl DVec3 {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f64) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -670,6 +691,7 @@ impl DVec3 {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f64) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -686,6 +708,7 @@ impl DVec3 {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         Self::new(
@@ -712,6 +735,7 @@ impl DVec3 {
     ///
     /// The output vector is not necessarily unit length. For that use
     /// [`Self::any_orthonormal_vector()`] instead.
+    #[must_use]
     #[inline]
     pub fn any_orthogonal_vector(&self) -> Self {
         // This can probably be optimized
@@ -729,6 +753,7 @@ impl DVec3 {
     /// # Panics
     ///
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn any_orthonormal_vector(&self) -> Self {
         glam_assert!(self.is_normalized());

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -163,8 +163,8 @@ impl DVec4 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -172,8 +172,8 @@ impl DVec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -186,8 +186,8 @@ impl DVec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -204,8 +204,8 @@ impl DVec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -318,8 +318,8 @@ impl DVec4 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -334,8 +334,8 @@ impl DVec4 {
     /// - `1.0` if the number is positive, `+0.0` or `INFINITY`
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -346,8 +346,8 @@ impl DVec4 {
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -446,8 +446,8 @@ impl DVec4 {
     /// Returns the element-wise remainder of [Euclidean division] of `self` by `rhs`.
     ///
     /// [Euclidean division]: f64::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -164,6 +164,7 @@ impl DVec4 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -172,6 +173,7 @@ impl DVec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -185,6 +187,7 @@ impl DVec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -202,6 +205,7 @@ impl DVec4 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -315,6 +319,7 @@ impl DVec4 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: math::abs(self.x),
@@ -330,6 +335,7 @@ impl DVec4 {
     /// - `-1.0` if the number is negative, `-0.0` or `NEG_INFINITY`
     /// - `NAN` if the number is `NAN`
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: math::signum(self.x),
@@ -341,6 +347,7 @@ impl DVec4 {
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
+    #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         Self {
             x: math::copysign(self.x, rhs.x),
@@ -425,6 +432,7 @@ impl DVec4 {
     }
 
     /// Returns the element-wise quotient of [Euclidean division] of `self` by `rhs`.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -439,6 +447,7 @@ impl DVec4 {
     ///
     /// [Euclidean division]: f64::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             math::rem_euclid(self.x, rhs.x),
@@ -572,6 +581,7 @@ impl DVec4 {
 
     /// Returns a vector containing the nearest integer to a number for each element of `self`.
     /// Round half-way cases away from 0.0.
+    #[must_use]
     #[inline]
     pub fn round(self) -> Self {
         Self {
@@ -584,6 +594,7 @@ impl DVec4 {
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
     /// element of `self`.
+    #[must_use]
     #[inline]
     pub fn floor(self) -> Self {
         Self {
@@ -596,6 +607,7 @@ impl DVec4 {
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
     /// each element of `self`.
+    #[must_use]
     #[inline]
     pub fn ceil(self) -> Self {
         Self {
@@ -608,6 +620,7 @@ impl DVec4 {
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
     /// always truncated towards zero.
+    #[must_use]
     #[inline]
     pub fn trunc(self) -> Self {
         Self {
@@ -622,6 +635,7 @@ impl DVec4 {
     /// self.floor()`.
     ///
     /// Note that this is fast but not precise for large numbers.
+    #[must_use]
     #[inline]
     pub fn fract(self) -> Self {
         self - self.floor()
@@ -629,6 +643,7 @@ impl DVec4 {
 
     /// Returns a vector containing `e^self` (the exponential function) for each element of
     /// `self`.
+    #[must_use]
     #[inline]
     pub fn exp(self) -> Self {
         Self::new(
@@ -640,6 +655,7 @@ impl DVec4 {
     }
 
     /// Returns a vector containing each element of `self` raised to the power of `n`.
+    #[must_use]
     #[inline]
     pub fn powf(self, n: f64) -> Self {
         Self::new(
@@ -651,6 +667,7 @@ impl DVec4 {
     }
 
     /// Returns a vector containing the reciprocal `1.0/n` of each element of `self`.
+    #[must_use]
     #[inline]
     pub fn recip(self) -> Self {
         Self {
@@ -667,6 +684,7 @@ impl DVec4 {
     /// will be equal to `rhs`. When `s` is outside of range `[0, 1]`, the result is linearly
     /// extrapolated.
     #[doc(alias = "mix")]
+    #[must_use]
     #[inline]
     pub fn lerp(self, rhs: Self, s: f64) -> Self {
         self + ((rhs - self) * s)
@@ -691,6 +709,7 @@ impl DVec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
+    #[must_use]
     #[inline]
     pub fn clamp_length(self, min: f64, max: f64) -> Self {
         glam_assert!(min <= max);
@@ -705,6 +724,7 @@ impl DVec4 {
     }
 
     /// Returns a vector with a length no more than `max`
+    #[must_use]
     pub fn clamp_length_max(self, max: f64) -> Self {
         let length_sq = self.length_squared();
         if length_sq > max * max {
@@ -715,6 +735,7 @@ impl DVec4 {
     }
 
     /// Returns a vector with a length no less than `min`
+    #[must_use]
     pub fn clamp_length_min(self, min: f64) -> Self {
         let length_sq = self.length_squared();
         if length_sq < min * min {
@@ -731,6 +752,7 @@ impl DVec4 {
     /// architecture has a dedicated fma CPU instruction. However, this is not always true,
     /// and will be heavily dependant on designing algorithms with specific target hardware in
     /// mind.
+    #[must_use]
     #[inline]
     pub fn mul_add(self, a: Self, b: Self) -> Self {
         Self::new(

--- a/src/f64/float.rs
+++ b/src/f64/float.rs
@@ -3,16 +3,19 @@
 use crate::float::FloatExt;
 
 impl FloatExt for f64 {
+    #[must_use]
     #[inline]
     fn lerp(self, rhs: f64, t: f64) -> f64 {
         self + (rhs - self) * t
     }
 
+    #[must_use]
     #[inline]
     fn inverse_lerp(a: f64, b: f64, v: f64) -> f64 {
         (v - a) / (b - a)
     }
 
+    #[must_use]
     #[inline]
     fn remap(self, in_start: f64, in_end: f64, out_start: f64, out_end: f64) -> f64 {
         let t = f64::inverse_lerp(in_start, in_end, self);

--- a/src/f64/float.rs
+++ b/src/f64/float.rs
@@ -3,19 +3,16 @@
 use crate::float::FloatExt;
 
 impl FloatExt for f64 {
-    #[must_use]
     #[inline]
     fn lerp(self, rhs: f64, t: f64) -> f64 {
         self + (rhs - self) * t
     }
 
-    #[must_use]
     #[inline]
     fn inverse_lerp(a: f64, b: f64, v: f64) -> f64 {
         (v - a) / (b - a)
     }
 
-    #[must_use]
     #[inline]
     fn remap(self, in_start: f64, in_end: f64, out_start: f64, out_end: f64) -> f64 {
         let t = f64::inverse_lerp(in_start, in_end, self);

--- a/src/float.rs
+++ b/src/float.rs
@@ -5,6 +5,7 @@ pub trait FloatExt {
     /// When `t` is `0`, the result will be `self`.  When `t` is `1`, the result
     /// will be `rhs`. When `t` is outside of the range `[0, 1]`, the result is linearly
     /// extrapolated.
+    #[must_use]
     fn lerp(self, rhs: Self, s: Self) -> Self;
 
     /// Returns `v` normalized to the range `[a, b]`.
@@ -24,5 +25,6 @@ pub trait FloatExt {
     /// When `self` is outside of the range `[in_start, in_end]`, the result is linearly extrapolated.
     ///
     /// `in_start` and `in_end` must not be equal, otherwise the result will be either infinite or `NAN`.
+    #[must_use]
     fn remap(self, in_start: Self, in_end: Self, out_start: Self, out_end: Self) -> Self;
 }

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -127,6 +127,7 @@ impl I16Vec2 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -135,6 +136,7 @@ impl I16Vec2 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -146,6 +148,7 @@ impl I16Vec2 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -161,6 +164,7 @@ impl I16Vec2 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -244,6 +248,7 @@ impl I16Vec2 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -257,6 +262,7 @@ impl I16Vec2 {
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -290,6 +296,7 @@ impl I16Vec2 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(self.x.div_euclid(rhs.x), self.y.div_euclid(rhs.y))
@@ -302,11 +309,13 @@ impl I16Vec2 {
     ///
     /// [Euclidean division]: i16::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(self.x.rem_euclid(rhs.x), self.y.rem_euclid(rhs.y))
     }
 
     /// Returns a vector that is equal to `self` rotated by 90 degrees.
+    #[must_use]
     #[inline]
     pub fn perp(self) -> Self {
         Self {

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -126,8 +126,8 @@ impl I16Vec2 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -135,8 +135,8 @@ impl I16Vec2 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -147,8 +147,8 @@ impl I16Vec2 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -163,8 +163,8 @@ impl I16Vec2 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -247,8 +247,8 @@ impl I16Vec2 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -261,8 +261,8 @@ impl I16Vec2 {
     ///  - `0` if the number is zero
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -308,8 +308,8 @@ impl I16Vec2 {
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     ///
     /// [Euclidean division]: i16::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(self.x.rem_euclid(rhs.x), self.y.rem_euclid(rhs.y))
     }

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -154,15 +154,15 @@ impl I16Vec3 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -174,8 +174,8 @@ impl I16Vec3 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -187,8 +187,8 @@ impl I16Vec3 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -204,8 +204,8 @@ impl I16Vec3 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -288,8 +288,8 @@ impl I16Vec3 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -303,8 +303,8 @@ impl I16Vec3 {
     ///  - `0` if the number is zero
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -357,8 +357,8 @@ impl I16Vec3 {
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     ///
     /// [Euclidean division]: i16::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -155,12 +155,14 @@ impl I16Vec3 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -173,6 +175,7 @@ impl I16Vec3 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -185,6 +188,7 @@ impl I16Vec3 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -201,6 +205,7 @@ impl I16Vec3 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -284,6 +289,7 @@ impl I16Vec3 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -298,6 +304,7 @@ impl I16Vec3 {
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -334,6 +341,7 @@ impl I16Vec3 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -350,6 +358,7 @@ impl I16Vec3 {
     ///
     /// [Euclidean division]: i16::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -156,6 +156,7 @@ impl I16Vec4 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -164,6 +165,7 @@ impl I16Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -177,6 +179,7 @@ impl I16Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -194,6 +197,7 @@ impl I16Vec4 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -307,6 +311,7 @@ impl I16Vec4 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -322,6 +327,7 @@ impl I16Vec4 {
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -360,6 +366,7 @@ impl I16Vec4 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -377,6 +384,7 @@ impl I16Vec4 {
     ///
     /// [Euclidean division]: i16::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -155,8 +155,8 @@ impl I16Vec4 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -164,8 +164,8 @@ impl I16Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -178,8 +178,8 @@ impl I16Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -196,8 +196,8 @@ impl I16Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -310,8 +310,8 @@ impl I16Vec4 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -326,8 +326,8 @@ impl I16Vec4 {
     ///  - `0` if the number is zero
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -383,8 +383,8 @@ impl I16Vec4 {
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     ///
     /// [Euclidean division]: i16::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -126,8 +126,8 @@ impl IVec2 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -135,8 +135,8 @@ impl IVec2 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -147,8 +147,8 @@ impl IVec2 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -163,8 +163,8 @@ impl IVec2 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -247,8 +247,8 @@ impl IVec2 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -261,8 +261,8 @@ impl IVec2 {
     ///  - `0` if the number is zero
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -308,8 +308,8 @@ impl IVec2 {
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     ///
     /// [Euclidean division]: i32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(self.x.rem_euclid(rhs.x), self.y.rem_euclid(rhs.y))
     }

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -127,6 +127,7 @@ impl IVec2 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -135,6 +136,7 @@ impl IVec2 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -146,6 +148,7 @@ impl IVec2 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -161,6 +164,7 @@ impl IVec2 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -244,6 +248,7 @@ impl IVec2 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -257,6 +262,7 @@ impl IVec2 {
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -290,6 +296,7 @@ impl IVec2 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(self.x.div_euclid(rhs.x), self.y.div_euclid(rhs.y))
@@ -302,11 +309,13 @@ impl IVec2 {
     ///
     /// [Euclidean division]: i32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(self.x.rem_euclid(rhs.x), self.y.rem_euclid(rhs.y))
     }
 
     /// Returns a vector that is equal to `self` rotated by 90 degrees.
+    #[must_use]
     #[inline]
     pub fn perp(self) -> Self {
         Self {

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -155,12 +155,14 @@ impl IVec3 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -173,6 +175,7 @@ impl IVec3 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -185,6 +188,7 @@ impl IVec3 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -201,6 +205,7 @@ impl IVec3 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -284,6 +289,7 @@ impl IVec3 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -298,6 +304,7 @@ impl IVec3 {
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -334,6 +341,7 @@ impl IVec3 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -350,6 +358,7 @@ impl IVec3 {
     ///
     /// [Euclidean division]: i32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -154,15 +154,15 @@ impl IVec3 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -174,8 +174,8 @@ impl IVec3 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -187,8 +187,8 @@ impl IVec3 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -204,8 +204,8 @@ impl IVec3 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -288,8 +288,8 @@ impl IVec3 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -303,8 +303,8 @@ impl IVec3 {
     ///  - `0` if the number is zero
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -357,8 +357,8 @@ impl IVec3 {
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     ///
     /// [Euclidean division]: i32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -155,8 +155,8 @@ impl IVec4 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -164,8 +164,8 @@ impl IVec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -178,8 +178,8 @@ impl IVec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -196,8 +196,8 @@ impl IVec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -310,8 +310,8 @@ impl IVec4 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -326,8 +326,8 @@ impl IVec4 {
     ///  - `0` if the number is zero
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -383,8 +383,8 @@ impl IVec4 {
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     ///
     /// [Euclidean division]: i32::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -156,6 +156,7 @@ impl IVec4 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -164,6 +165,7 @@ impl IVec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -177,6 +179,7 @@ impl IVec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -194,6 +197,7 @@ impl IVec4 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -307,6 +311,7 @@ impl IVec4 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -322,6 +327,7 @@ impl IVec4 {
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -360,6 +366,7 @@ impl IVec4 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -377,6 +384,7 @@ impl IVec4 {
     ///
     /// [Euclidean division]: i32::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -126,8 +126,8 @@ impl I64Vec2 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -135,8 +135,8 @@ impl I64Vec2 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -147,8 +147,8 @@ impl I64Vec2 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -163,8 +163,8 @@ impl I64Vec2 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -247,8 +247,8 @@ impl I64Vec2 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -261,8 +261,8 @@ impl I64Vec2 {
     ///  - `0` if the number is zero
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -308,8 +308,8 @@ impl I64Vec2 {
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     ///
     /// [Euclidean division]: i64::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(self.x.rem_euclid(rhs.x), self.y.rem_euclid(rhs.y))
     }

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -127,6 +127,7 @@ impl I64Vec2 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -135,6 +136,7 @@ impl I64Vec2 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -146,6 +148,7 @@ impl I64Vec2 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -161,6 +164,7 @@ impl I64Vec2 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -244,6 +248,7 @@ impl I64Vec2 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -257,6 +262,7 @@ impl I64Vec2 {
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -290,6 +296,7 @@ impl I64Vec2 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(self.x.div_euclid(rhs.x), self.y.div_euclid(rhs.y))
@@ -302,11 +309,13 @@ impl I64Vec2 {
     ///
     /// [Euclidean division]: i64::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(self.x.rem_euclid(rhs.x), self.y.rem_euclid(rhs.y))
     }
 
     /// Returns a vector that is equal to `self` rotated by 90 degrees.
+    #[must_use]
     #[inline]
     pub fn perp(self) -> Self {
         Self {

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -154,15 +154,15 @@ impl I64Vec3 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -174,8 +174,8 @@ impl I64Vec3 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -187,8 +187,8 @@ impl I64Vec3 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -204,8 +204,8 @@ impl I64Vec3 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -288,8 +288,8 @@ impl I64Vec3 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -303,8 +303,8 @@ impl I64Vec3 {
     ///  - `0` if the number is zero
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -357,8 +357,8 @@ impl I64Vec3 {
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     ///
     /// [Euclidean division]: i64::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -155,12 +155,14 @@ impl I64Vec3 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -173,6 +175,7 @@ impl I64Vec3 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -185,6 +188,7 @@ impl I64Vec3 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -201,6 +205,7 @@ impl I64Vec3 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -284,6 +289,7 @@ impl I64Vec3 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -298,6 +304,7 @@ impl I64Vec3 {
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -334,6 +341,7 @@ impl I64Vec3 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -350,6 +358,7 @@ impl I64Vec3 {
     ///
     /// [Euclidean division]: i64::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -156,6 +156,7 @@ impl I64Vec4 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -164,6 +165,7 @@ impl I64Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -177,6 +179,7 @@ impl I64Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -194,6 +197,7 @@ impl I64Vec4 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -307,6 +311,7 @@ impl I64Vec4 {
 
     /// Returns a vector containing the absolute value of each element of `self`.
     #[inline]
+    #[must_use]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -322,6 +327,7 @@ impl I64Vec4 {
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
     #[inline]
+    #[must_use]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -360,6 +366,7 @@ impl I64Vec4 {
     ///
     /// # Panics
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
+    #[must_use]
     #[inline]
     pub fn div_euclid(self, rhs: Self) -> Self {
         Self::new(
@@ -377,6 +384,7 @@ impl I64Vec4 {
     ///
     /// [Euclidean division]: i64::rem_euclid
     #[inline]
+    #[must_use]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -155,8 +155,8 @@ impl I64Vec4 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -164,8 +164,8 @@ impl I64Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -178,8 +178,8 @@ impl I64Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -196,8 +196,8 @@ impl I64Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)
@@ -310,8 +310,8 @@ impl I64Vec4 {
     }
 
     /// Returns a vector containing the absolute value of each element of `self`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn abs(self) -> Self {
         Self {
             x: self.x.abs(),
@@ -326,8 +326,8 @@ impl I64Vec4 {
     ///  - `0` if the number is zero
     ///  - `1` if the number is positive
     ///  - `-1` if the number is negative
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn signum(self) -> Self {
         Self {
             x: self.x.signum(),
@@ -383,8 +383,8 @@ impl I64Vec4 {
     /// This function will panic if any `rhs` element is 0 or the division results in overflow.
     ///
     /// [Euclidean division]: i64::rem_euclid
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn rem_euclid(self, rhs: Self) -> Self {
         Self::new(
             self.x.rem_euclid(rhs.x),

--- a/src/swizzles/vec_traits.rs
+++ b/src/swizzles/vec_traits.rs
@@ -5,6 +5,7 @@ pub trait Vec2Swizzles: Sized + Copy + Clone {
 
     type Vec4;
 
+    #[must_use]
     #[inline]
     fn xy(self) -> Self {
         self
@@ -70,6 +71,7 @@ pub trait Vec3Swizzles: Sized + Copy + Clone {
 
     type Vec4;
 
+    #[must_use]
     #[inline]
     fn xyz(self) -> Self {
         self
@@ -313,6 +315,7 @@ pub trait Vec4Swizzles: Sized + Copy + Clone {
 
     type Vec3;
 
+    #[must_use]
     #[inline]
     fn xyzw(self) -> Self {
         self

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -118,6 +118,7 @@ impl U16Vec2 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -126,6 +127,7 @@ impl U16Vec2 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -137,6 +139,7 @@ impl U16Vec2 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -152,6 +155,7 @@ impl U16Vec2 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -117,8 +117,8 @@ impl U16Vec2 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -126,8 +126,8 @@ impl U16Vec2 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -138,8 +138,8 @@ impl U16Vec2 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -154,8 +154,8 @@ impl U16Vec2 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -142,15 +142,15 @@ impl U16Vec3 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -162,8 +162,8 @@ impl U16Vec3 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -175,8 +175,8 @@ impl U16Vec3 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -192,8 +192,8 @@ impl U16Vec3 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -143,12 +143,14 @@ impl U16Vec3 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -161,6 +163,7 @@ impl U16Vec3 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -173,6 +176,7 @@ impl U16Vec3 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -189,6 +193,7 @@ impl U16Vec3 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -140,8 +140,8 @@ impl U16Vec4 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -149,8 +149,8 @@ impl U16Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -163,8 +163,8 @@ impl U16Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -181,8 +181,8 @@ impl U16Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -141,6 +141,7 @@ impl U16Vec4 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -149,6 +150,7 @@ impl U16Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -162,6 +164,7 @@ impl U16Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -179,6 +182,7 @@ impl U16Vec4 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -118,6 +118,7 @@ impl UVec2 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -126,6 +127,7 @@ impl UVec2 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -137,6 +139,7 @@ impl UVec2 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -152,6 +155,7 @@ impl UVec2 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -117,8 +117,8 @@ impl UVec2 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -126,8 +126,8 @@ impl UVec2 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -138,8 +138,8 @@ impl UVec2 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -154,8 +154,8 @@ impl UVec2 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -143,12 +143,14 @@ impl UVec3 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -161,6 +163,7 @@ impl UVec3 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -173,6 +176,7 @@ impl UVec3 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -189,6 +193,7 @@ impl UVec3 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -142,15 +142,15 @@ impl UVec3 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -162,8 +162,8 @@ impl UVec3 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -175,8 +175,8 @@ impl UVec3 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -192,8 +192,8 @@ impl UVec3 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -140,8 +140,8 @@ impl UVec4 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -149,8 +149,8 @@ impl UVec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -163,8 +163,8 @@ impl UVec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -181,8 +181,8 @@ impl UVec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -141,6 +141,7 @@ impl UVec4 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -149,6 +150,7 @@ impl UVec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -162,6 +164,7 @@ impl UVec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -179,6 +182,7 @@ impl UVec4 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -117,8 +117,8 @@ impl U64Vec2 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -126,8 +126,8 @@ impl U64Vec2 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -138,8 +138,8 @@ impl U64Vec2 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -154,8 +154,8 @@ impl U64Vec2 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -118,6 +118,7 @@ impl U64Vec2 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -126,6 +127,7 @@ impl U64Vec2 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -137,6 +139,7 @@ impl U64Vec2 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -152,6 +155,7 @@ impl U64Vec2 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -143,12 +143,14 @@ impl U64Vec3 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -161,6 +163,7 @@ impl U64Vec3 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -173,6 +176,7 @@ impl U64Vec3 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -189,6 +193,7 @@ impl U64Vec3 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -142,15 +142,15 @@ impl U64Vec3 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
 
     /// Computes the cross product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn cross(self, rhs: Self) -> Self {
         Self {
             x: self.y * rhs.z - rhs.y * self.z,
@@ -162,8 +162,8 @@ impl U64Vec3 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -175,8 +175,8 @@ impl U64Vec3 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -192,8 +192,8 @@ impl U64Vec3 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -141,6 +141,7 @@ impl U64Vec4 {
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
     #[inline]
+    #[must_use]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -149,6 +150,7 @@ impl U64Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -162,6 +164,7 @@ impl U64Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     #[inline]
+    #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -179,6 +182,7 @@ impl U64Vec4 {
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
     #[inline]
+    #[must_use]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -140,8 +140,8 @@ impl U64Vec4 {
     }
 
     /// Returns a vector where every component is the dot product of `self` and `rhs`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn dot_into_vec(self, rhs: Self) -> Self {
         Self::splat(self.dot(rhs))
     }
@@ -149,8 +149,8 @@ impl U64Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn min(self, rhs: Self) -> Self {
         Self {
             x: self.x.min(rhs.x),
@@ -163,8 +163,8 @@ impl U64Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn max(self, rhs: Self) -> Self {
         Self {
             x: self.x.max(rhs.x),
@@ -181,8 +181,8 @@ impl U64Vec4 {
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
-    #[inline]
     #[must_use]
+    #[inline]
     pub fn clamp(self, min: Self, max: Self) -> Self {
         glam_assert!(min.cmple(max).all(), "clamp: expected min <= max");
         self.max(min).min(max)


### PR DESCRIPTION
Added `#[must_use]` to those methods which look like `(&*self ...) -> Self` (basically methods which take a self by non-mutable ref or by value, and which return a Self). However, I did not add such bounds to trait impls whose trait definition already had such a `must_use` on it (all the core::ops and all the From impls). Along those notes, I added `[#must_use]` to `FloatExt`'s trait definition.

On this (m1 mac), most of the tests except for those in "euler::quat::test_" did not work on main currently and after this, continue to not work. It appears that they work fine on the Github Actions runner, so I suspect that this PR should be fine, since this should not result in any different code generated.

I tried to check all the Tera files as appropriate, and I think I got them all, but even if I didn't, I would be comfortable with this PR merging, as it's just a continuation of efforts to match the std's new `must_use` style.

