### PR TITLE
In some build configs, BVec4 was an unused import.

### DIFF
--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1280,10 +1280,7 @@ macro_rules! impl_vec4_bit_op_tests {
 }
 
 mod vec4 {
-    #[cfg(any(
-        not(any(target_feature = "sse2", target_feature = "simd128")),
-        feature = "scalar-math"
-    ))]
+    #[cfg(feature = "scalar-math")]
     use glam::BVec4;
     #[cfg(not(feature = "scalar-math"))]
     use glam::BVec4A;


### PR DESCRIPTION
The uses of this were protected by only `scalar_math` so only protect the import by the same.