### PR TITLE
Make `Mat[x]::new()` public.

### DIFF
--- a/codegen/templates/mat.rs.tera
+++ b/codegen/templates/mat.rs.tera
@@ -243,7 +243,8 @@ impl {{ self_t }} {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new {{ nxn }} matrix from elements in column major order.
+    pub const fn new(
         {% for i in range(end = dim) %}
             {%- for j in range(end = dim) %}
                 m{{ i }}{{ j }}: {{ scalar_t }},

--- a/src/f32/coresimd/mat2.rs
+++ b/src/f32/coresimd/mat2.rs
@@ -37,7 +37,8 @@ impl Mat2 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
+    /// Create a new 2x2 matrix from elements in column major order.
+    pub const fn new(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
         Self(f32x4::from_array([m00, m01, m10, m11]))
     }
 

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -60,7 +60,8 @@ impl Mat3A {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new 3x3 matrix from elements in column major order.
+    pub const fn new(
         m00: f32,
         m01: f32,
         m02: f32,

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -68,7 +68,8 @@ impl Mat4 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new 4x4 matrix from elements in column major order.
+    pub const fn new(
         m00: f32,
         m01: f32,
         m02: f32,

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -58,7 +58,8 @@ impl Mat3 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new 3x3 matrix from elements in column major order.
+    pub const fn new(
         m00: f32,
         m01: f32,
         m02: f32,

--- a/src/f32/scalar/mat2.rs
+++ b/src/f32/scalar/mat2.rs
@@ -39,7 +39,8 @@ impl Mat2 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
+    /// Create a new 2x2 matrix from elements in column major order.
+    pub const fn new(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
         Self {
             x_axis: Vec2::new(m00, m01),
             y_axis: Vec2::new(m10, m11),

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -58,7 +58,8 @@ impl Mat3A {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new 3x3 matrix from elements in column major order.
+    pub const fn new(
         m00: f32,
         m01: f32,
         m02: f32,

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -71,7 +71,8 @@ impl Mat4 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new 4x4 matrix from elements in column major order.
+    pub const fn new(
         m00: f32,
         m01: f32,
         m02: f32,

--- a/src/f32/sse2/mat2.rs
+++ b/src/f32/sse2/mat2.rs
@@ -46,7 +46,8 @@ impl Mat2 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
+    /// Create a new 2x2 matrix from elements in column major order.
+    pub const fn new(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
         unsafe {
             UnionCast {
                 a: [m00, m01, m10, m11],

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -63,7 +63,8 @@ impl Mat3A {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new 3x3 matrix from elements in column major order.
+    pub const fn new(
         m00: f32,
         m01: f32,
         m02: f32,

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -71,7 +71,8 @@ impl Mat4 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new 4x4 matrix from elements in column major order.
+    pub const fn new(
         m00: f32,
         m01: f32,
         m02: f32,

--- a/src/f32/wasm32/mat2.rs
+++ b/src/f32/wasm32/mat2.rs
@@ -37,7 +37,8 @@ impl Mat2 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
+    /// Create a new 2x2 matrix from elements in column major order.
+    pub const fn new(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
         Self(f32x4(m00, m01, m10, m11))
     }
 

--- a/src/f32/wasm32/mat3a.rs
+++ b/src/f32/wasm32/mat3a.rs
@@ -60,7 +60,8 @@ impl Mat3A {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new 3x3 matrix from elements in column major order.
+    pub const fn new(
         m00: f32,
         m01: f32,
         m02: f32,

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -68,7 +68,8 @@ impl Mat4 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new 4x4 matrix from elements in column major order.
+    pub const fn new(
         m00: f32,
         m01: f32,
         m02: f32,

--- a/src/f64/dmat2.rs
+++ b/src/f64/dmat2.rs
@@ -35,7 +35,8 @@ impl DMat2 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(m00: f64, m01: f64, m10: f64, m11: f64) -> Self {
+    /// Create a new 2x2 matrix from elements in column major order.
+    pub const fn new(m00: f64, m01: f64, m10: f64, m11: f64) -> Self {
         Self {
             x_axis: DVec2::new(m00, m01),
             y_axis: DVec2::new(m10, m11),

--- a/src/f64/dmat3.rs
+++ b/src/f64/dmat3.rs
@@ -58,7 +58,8 @@ impl DMat3 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new 3x3 matrix from elements in column major order.
+    pub const fn new(
         m00: f64,
         m01: f64,
         m02: f64,

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -65,7 +65,8 @@ impl DMat4 {
     #[allow(clippy::too_many_arguments)]
     #[inline(always)]
     #[must_use]
-    const fn new(
+    /// Create a new 4x4 matrix from elements in column major order.
+    pub const fn new(
         m00: f64,
         m01: f64,
         m02: f64,


### PR DESCRIPTION
`Mat` now matches `Vec` as `Vec[x]::new()` is already public. Fixes https://github.com/bitshifter/glam-rs/issues/456.