### PR TITLE
Add `move_towards` for vectors

### DIFF
--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -1615,7 +1615,7 @@ impl {{ self_t }} {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: {{ scalar_t }}) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: {{ scalar_t }}) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -1609,6 +1609,21 @@ impl {{ self_t }} {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to 
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: {{ scalar_t }}) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d 
+    }
+
     /// Calculates the midpoint between `self` and `rhs`. 
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -679,7 +679,7 @@ impl Vec3A {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -673,6 +673,21 @@ impl Vec3A {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -651,6 +651,21 @@ impl Vec4 {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -657,7 +657,7 @@ impl Vec4 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -720,7 +720,7 @@ impl Vec3A {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -714,6 +714,21 @@ impl Vec3A {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -760,6 +760,21 @@ impl Vec4 {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -766,7 +766,7 @@ impl Vec4 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -721,6 +721,21 @@ impl Vec3A {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -727,7 +727,7 @@ impl Vec3A {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -706,7 +706,7 @@ impl Vec4 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -700,6 +700,21 @@ impl Vec4 {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -652,7 +652,7 @@ impl Vec2 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -646,6 +646,21 @@ impl Vec2 {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -711,7 +711,7 @@ impl Vec3 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -705,6 +705,21 @@ impl Vec3 {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -692,6 +692,21 @@ impl Vec3A {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -698,7 +698,7 @@ impl Vec3A {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -684,7 +684,7 @@ impl Vec4 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -678,6 +678,21 @@ impl Vec4 {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f32) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -646,6 +646,21 @@ impl DVec2 {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f64) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -652,7 +652,7 @@ impl DVec2 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f64) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f64) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -705,6 +705,21 @@ impl DVec3 {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f64) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -711,7 +711,7 @@ impl DVec3 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f64) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f64) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -755,7 +755,7 @@ impl DVec4 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn towards(&self, rhs: Self, d: f64) -> Self {
+    pub fn move_towards(&self, rhs: Self, d: f64) -> Self {
         let a = rhs - *self;
         let len = a.length();
         if len <= d || len <= 1e-4 {

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -749,6 +749,21 @@ impl DVec4 {
         self + ((rhs - self) * s)
     }
 
+    /// Moves towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
+    #[inline]
+    #[must_use]
+    pub fn towards(&self, rhs: Self, d: f64) -> Self {
+        let a = rhs - *self;
+        let len = a.length();
+        if len <= d || len <= 1e-4 {
+            return rhs;
+        }
+        *self + a / len * d
+    }
+
     /// Calculates the midpoint between `self` and `rhs`.
     ///
     /// The midpoint is the average of, or halfway point between, two vectors.

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -820,6 +820,14 @@ macro_rules! impl_vec2_float_tests {
             assert_approx_eq!($vec2::ZERO, v0.lerp(v1, 0.5));
         });
 
+        glam_test!(test_towards, {
+            let v0 = $vec2::new(-1.0, -1.0);
+            let v1 = $vec2::new(1.0, 1.0);
+            assert_approx_eq!(v0, v0.towards(v1, 0.0));
+            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1)));
+            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1) + 1.0));
+        });
+
         glam_test!(test_midpoint, {
             let v0 = $vec2::new(-1.0, -1.0);
             let v1 = $vec2::new(1.0, 1.0);
@@ -1163,8 +1171,6 @@ mod vec2 {
         assert_eq!(UVec2::new(1, 2), U64Vec2::new(1, 2).as_uvec2());
         assert_eq!(I64Vec2::new(1, 2), U64Vec2::new(1, 2).as_i64vec2());
     });
-
-    impl_vec2_float_tests!(f32, vec2, Vec2, Vec3, BVec2);
 }
 
 mod dvec2 {

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -820,12 +820,12 @@ macro_rules! impl_vec2_float_tests {
             assert_approx_eq!($vec2::ZERO, v0.lerp(v1, 0.5));
         });
 
-        glam_test!(test_towards, {
+        glam_test!(test_move_towards, {
             let v0 = $vec2::new(-1.0, -1.0);
             let v1 = $vec2::new(1.0, 1.0);
-            assert_approx_eq!(v0, v0.towards(v1, 0.0));
-            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1)));
-            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1) + 1.0));
+            assert_approx_eq!(v0, v0.move_towards(v1, 0.0));
+            assert_approx_eq!(v1, v0.move_towards(v1, v0.distance(v1)));
+            assert_approx_eq!(v1, v0.move_towards(v1, v0.distance(v1) + 1.0));
         });
 
         glam_test!(test_midpoint, {

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -1171,6 +1171,8 @@ mod vec2 {
         assert_eq!(UVec2::new(1, 2), U64Vec2::new(1, 2).as_uvec2());
         assert_eq!(I64Vec2::new(1, 2), U64Vec2::new(1, 2).as_i64vec2());
     });
+
+    impl_vec2_float_tests!(f32, vec2, Vec2, Vec3, BVec2);
 }
 
 mod dvec2 {

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -955,6 +955,14 @@ macro_rules! impl_vec3_float_tests {
             assert_approx_eq!($vec3::ZERO, v0.lerp(v1, 0.5));
         });
 
+        glam_test!(test_towards, {
+            let v0 = $vec3::new(-1.0, -1.0, -1.0);
+            let v1 = $vec3::new(1.0, 1.0, 1.0);
+            assert_approx_eq!(v0, v0.towards(v1, 0.0));
+            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1)));
+            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1) + 1.0));
+        });
+
         glam_test!(test_midpoint, {
             let v0 = $vec3::new(-1.0, -1.0, -1.0);
             let v1 = $vec3::new(1.0, 1.0, 1.0);

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -955,12 +955,12 @@ macro_rules! impl_vec3_float_tests {
             assert_approx_eq!($vec3::ZERO, v0.lerp(v1, 0.5));
         });
 
-        glam_test!(test_towards, {
+        glam_test!(test_move_towards, {
             let v0 = $vec3::new(-1.0, -1.0, -1.0);
             let v1 = $vec3::new(1.0, 1.0, 1.0);
-            assert_approx_eq!(v0, v0.towards(v1, 0.0));
-            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1)));
-            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1) + 1.0));
+            assert_approx_eq!(v0, v0.move_towards(v1, 0.0));
+            assert_approx_eq!(v1, v0.move_towards(v1, v0.distance(v1)));
+            assert_approx_eq!(v1, v0.move_towards(v1, v0.distance(v1) + 1.0));
         });
 
         glam_test!(test_midpoint, {

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1075,12 +1075,12 @@ macro_rules! impl_vec4_float_tests {
             assert_approx_eq!($vec4::ZERO, v0.lerp(v1, 0.5));
         });
 
-        glam_test!(test_towards, {
+        glam_test!(test_move_towards, {
             let v0 = $vec4::new(-1.0, -1.0, -1.0, -1.0);
             let v1 = $vec4::new(1.0, 1.0, 1.0, 1.0);
-            assert_approx_eq!(v0, v0.towards(v1, 0.0));
-            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1)));
-            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1) + 1.0));
+            assert_approx_eq!(v0, v0.move_towards(v1, 0.0));
+            assert_approx_eq!(v1, v0.move_towards(v1, v0.distance(v1)));
+            assert_approx_eq!(v1, v0.move_towards(v1, v0.distance(v1) + 1.0));
         });
 
         glam_test!(test_midpoint, {

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1075,6 +1075,14 @@ macro_rules! impl_vec4_float_tests {
             assert_approx_eq!($vec4::ZERO, v0.lerp(v1, 0.5));
         });
 
+        glam_test!(test_towards, {
+            let v0 = $vec4::new(-1.0, -1.0, -1.0, -1.0);
+            let v1 = $vec4::new(1.0, 1.0, 1.0, 1.0);
+            assert_approx_eq!(v0, v0.towards(v1, 0.0));
+            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1)));
+            assert_approx_eq!(v1, v0.towards(v1, v0.distance(v1) + 1.0));
+        });
+
         glam_test!(test_midpoint, {
             let v0 = $vec4::new(-1.0, -1.0, -1.0, -1.0);
             let v1 = $vec4::new(1.0, 1.0, 1.0, 1.0);


### PR DESCRIPTION
Adds a `move_towards` function for vectors based on #477 and #265, with tests.
