### PR TITLE
Add `rotate_towards` for `Vec2` and `Quat`

### DIFF
--- a/codegen/templates/quat.rs.tera
+++ b/codegen/templates/quat.rs.tera
@@ -660,6 +660,29 @@ impl {{ self_t }} {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         math::acos_approx(math::abs(self.dot(rhs))) * 2.0
     }
+    
+    /// Rotates towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `d` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    ///
+    /// Both quaternions must be normalized.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(&self, rhs: Self, d: {{ scalar_t }}) -> Self {
+        glam_assert!(self.is_normalized() && rhs.is_normalized());
+        let angle = self.angle_between(rhs);
+        if angle <= 1e-4 {
+            return *self;
+        }
+        let s = (d / angle).clamp(-1.0, 1.0);
+        self.slerp(rhs, s)
+    }
 
     /// Returns true if the absolute difference of all elements between `self` and `rhs`
     /// is less than or equal to `max_abs_diff`.

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -1878,12 +1878,12 @@ impl {{ self_t }} {
     #[must_use]
     pub fn rotate_towards(&self, rhs: Self, d: {{ scalar_t }}) -> Self {
         let a = self.angle_between(rhs);
-        let abs_a = a.abs();
+        let abs_a = math::abs(a);
         if abs_a <= 1e-4 {
             return rhs;
         }
         // When `d < 0`, rotate no further than `PI` radians away
-        let angle = d.clamp(abs_a - core::{{ scalar_t }}::consts::PI, abs_a) * a.signum();
+        let angle = d.clamp(abs_a - core::{{ scalar_t }}::consts::PI, abs_a) * math::signum(a);
         Self::from_angle(angle).rotate(*self)
     }
 {% endif %}

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -1868,6 +1868,26 @@ impl {{ self_t }} {
     }
 {% endif %}
 
+{% if is_signed and is_float and dim == 2 %}
+    /// Rotates towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `d` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(&self, rhs: Self, d: {{ scalar_t }}) -> Self {
+        let a = self.angle_between(rhs);
+        let abs_a = a.abs();
+        if abs_a <= 1e-4 {
+            return rhs;
+        }
+        // When `d < 0`, rotate no further than `PI` radians away
+        let angle = d.clamp(abs_a - core::{{ scalar_t }}::consts::PI, abs_a) * a.signum();
+        Self::from_angle(angle).rotate(*self)
+    }
+{% endif %}
+
 {% if scalar_t != "f32" %}
     {% if dim == 2 %}
     /// Casts all elements of `self` to `f32`.

--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -538,6 +538,29 @@ impl Quat {
         math::acos_approx(math::abs(self.dot(rhs))) * 2.0
     }
 
+    /// Rotates towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `d` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    ///
+    /// Both quaternions must be normalized.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(&self, rhs: Self, d: f32) -> Self {
+        glam_assert!(self.is_normalized() && rhs.is_normalized());
+        let angle = self.angle_between(rhs);
+        if angle <= 1e-4 {
+            return *self;
+        }
+        let s = (d / angle).clamp(-1.0, 1.0);
+        self.slerp(rhs, s)
+    }
+
     /// Returns true if the absolute difference of all elements between `self` and `rhs`
     /// is less than or equal to `max_abs_diff`.
     ///

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -550,6 +550,29 @@ impl Quat {
         math::acos_approx(math::abs(self.dot(rhs))) * 2.0
     }
 
+    /// Rotates towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `d` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    ///
+    /// Both quaternions must be normalized.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(&self, rhs: Self, d: f32) -> Self {
+        glam_assert!(self.is_normalized() && rhs.is_normalized());
+        let angle = self.angle_between(rhs);
+        if angle <= 1e-4 {
+            return *self;
+        }
+        let s = (d / angle).clamp(-1.0, 1.0);
+        self.slerp(rhs, s)
+    }
+
     /// Returns true if the absolute difference of all elements between `self` and `rhs`
     /// is less than or equal to `max_abs_diff`.
     ///

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -546,6 +546,29 @@ impl Quat {
         math::acos_approx(math::abs(self.dot(rhs))) * 2.0
     }
 
+    /// Rotates towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `d` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    ///
+    /// Both quaternions must be normalized.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(&self, rhs: Self, d: f32) -> Self {
+        glam_assert!(self.is_normalized() && rhs.is_normalized());
+        let angle = self.angle_between(rhs);
+        if angle <= 1e-4 {
+            return *self;
+        }
+        let s = (d / angle).clamp(-1.0, 1.0);
+        self.slerp(rhs, s)
+    }
+
     /// Returns true if the absolute difference of all elements between `self` and `rhs`
     /// is less than or equal to `max_abs_diff`.
     ///

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -827,6 +827,24 @@ impl Vec2 {
         }
     }
 
+    /// Rotates towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `d` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(&self, rhs: Self, d: f32) -> Self {
+        let a = self.angle_between(rhs);
+        let abs_a = a.abs();
+        if abs_a <= 1e-4 {
+            return rhs;
+        }
+        // When `d < 0`, rotate no further than `PI` radians away
+        let angle = d.clamp(abs_a - core::f32::consts::PI, abs_a) * a.signum();
+        Self::from_angle(angle).rotate(*self)
+    }
+
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -836,12 +836,12 @@ impl Vec2 {
     #[must_use]
     pub fn rotate_towards(&self, rhs: Self, d: f32) -> Self {
         let a = self.angle_between(rhs);
-        let abs_a = a.abs();
+        let abs_a = math::abs(a);
         if abs_a <= 1e-4 {
             return rhs;
         }
         // When `d < 0`, rotate no further than `PI` radians away
-        let angle = d.clamp(abs_a - core::f32::consts::PI, abs_a) * a.signum();
+        let angle = d.clamp(abs_a - core::f32::consts::PI, abs_a) * math::signum(a);
         Self::from_angle(angle).rotate(*self)
     }
 

--- a/src/f32/wasm32/quat.rs
+++ b/src/f32/wasm32/quat.rs
@@ -538,6 +538,29 @@ impl Quat {
         math::acos_approx(math::abs(self.dot(rhs))) * 2.0
     }
 
+    /// Rotates towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `d` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    ///
+    /// Both quaternions must be normalized.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(&self, rhs: Self, d: f32) -> Self {
+        glam_assert!(self.is_normalized() && rhs.is_normalized());
+        let angle = self.angle_between(rhs);
+        if angle <= 1e-4 {
+            return *self;
+        }
+        let s = (d / angle).clamp(-1.0, 1.0);
+        self.slerp(rhs, s)
+    }
+
     /// Returns true if the absolute difference of all elements between `self` and `rhs`
     /// is less than or equal to `max_abs_diff`.
     ///

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -539,6 +539,29 @@ impl DQuat {
         math::acos_approx(math::abs(self.dot(rhs))) * 2.0
     }
 
+    /// Rotates towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `d` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    ///
+    /// Both quaternions must be normalized.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(&self, rhs: Self, d: f64) -> Self {
+        glam_assert!(self.is_normalized() && rhs.is_normalized());
+        let angle = self.angle_between(rhs);
+        if angle <= 1e-4 {
+            return *self;
+        }
+        let s = (d / angle).clamp(-1.0, 1.0);
+        self.slerp(rhs, s)
+    }
+
     /// Returns true if the absolute difference of all elements between `self` and `rhs`
     /// is less than or equal to `max_abs_diff`.
     ///

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -836,12 +836,12 @@ impl DVec2 {
     #[must_use]
     pub fn rotate_towards(&self, rhs: Self, d: f64) -> Self {
         let a = self.angle_between(rhs);
-        let abs_a = a.abs();
+        let abs_a = math::abs(a);
         if abs_a <= 1e-4 {
             return rhs;
         }
         // When `d < 0`, rotate no further than `PI` radians away
-        let angle = d.clamp(abs_a - core::f64::consts::PI, abs_a) * a.signum();
+        let angle = d.clamp(abs_a - core::f64::consts::PI, abs_a) * math::signum(a);
         Self::from_angle(angle).rotate(*self)
     }
 

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -827,6 +827,24 @@ impl DVec2 {
         }
     }
 
+    /// Rotates towards `rhs` based on the value `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is equal to
+    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `d` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(&self, rhs: Self, d: f64) -> Self {
+        let a = self.angle_between(rhs);
+        let abs_a = a.abs();
+        if abs_a <= 1e-4 {
+            return rhs;
+        }
+        // When `d < 0`, rotate no further than `PI` radians away
+        let angle = d.clamp(abs_a - core::f64::consts::PI, abs_a) * a.signum();
+        Self::from_angle(angle).rotate(*self)
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -329,6 +329,35 @@ macro_rules! impl_quat_tests {
             assert!(s.is_normalized());
         });
 
+        glam_test!(test_rotate_towards, {
+            use core::$t::consts::{FRAC_PI_2, FRAC_PI_4};
+            let eps = 10.0 * core::$t::EPSILON as f32;
+
+            // Setup such that `q0` is `PI/2` and `-PI/2` radians away from `q1` and `q2` respectively.
+            let q0 = $quat::from_euler(EulerRot::YXZ, 0.0, 0.0, 0.0);
+            let q1 = $quat::from_euler(EulerRot::YXZ, FRAC_PI_2, 0.0, 0.0);
+            let q2 = $quat::from_euler(EulerRot::YXZ, -FRAC_PI_2, 0.0, 0.0);
+
+            // Positive delta
+            assert_approx_eq!(q0, q0.rotate_towards(q1, 0.0), eps);
+            assert_approx_eq!(
+                $quat::from_euler(EulerRot::YXZ, FRAC_PI_4, 0.0, 0.0),
+                q0.rotate_towards(q1, FRAC_PI_4),
+                eps
+            );
+            assert_approx_eq!(q1, q0.rotate_towards(q1, FRAC_PI_2), eps);
+            assert_approx_eq!(q1, q0.rotate_towards(q1, FRAC_PI_2 * 1.5), eps);
+
+            // Negative delta
+            assert_approx_eq!(
+                $quat::from_euler(EulerRot::YXZ, -FRAC_PI_4, 0.0, 0.0),
+                q0.rotate_towards(q1, -FRAC_PI_4),
+                eps
+            );
+            assert_approx_eq!(q2, q0.rotate_towards(q1, -FRAC_PI_2), eps);
+            assert_approx_eq!(q2, q0.rotate_towards(q1, -FRAC_PI_2 * 1.5), eps);
+        });
+
         glam_test!(test_fmt, {
             let a = $quat::IDENTITY;
             assert_eq!(

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -833,6 +833,35 @@ macro_rules! impl_vec2_float_tests {
             assert_approx_eq!(v1, v0.move_towards(v1, v0.distance(v1) + 1.0));
         });
 
+        glam_test!(test_rotate_towards, {
+            use core::$t::consts::{FRAC_PI_2, FRAC_PI_4};
+            let eps = 10.0 * core::$t::EPSILON as f32;
+
+            // Setup such that `v0` is `PI/2` and `-PI/2` radians away from `v1` and `v2` respectively.
+            let v0 = $vec2::new(1.0, 0.0);
+            let v1 = $vec2::new(0.0, -1.0);
+            let v2 = $vec2::new(0.0, 1.0);
+
+            // Positive delta
+            assert_approx_eq!(v0, v0.rotate_towards(v1, 0.0), eps);
+            assert_approx_eq!(
+                $vec2::new($t::sqrt(2.0) / 2.0, -$t::sqrt(2.0) / 2.0),
+                v0.rotate_towards(v1, FRAC_PI_4),
+                eps
+            );
+            assert_approx_eq!(v1, v0.rotate_towards(v1, FRAC_PI_2), eps);
+            assert_approx_eq!(v1, v0.rotate_towards(v1, FRAC_PI_2 * 1.5), eps);
+
+            // Negative delta
+            assert_approx_eq!(
+                $vec2::new($t::sqrt(2.0) / 2.0, $t::sqrt(2.0) / 2.0),
+                v0.rotate_towards(v1, -FRAC_PI_4),
+                eps
+            );
+            assert_approx_eq!(v2, v0.rotate_towards(v1, -FRAC_PI_2), eps);
+            assert_approx_eq!(v2, v0.rotate_towards(v1, -FRAC_PI_2 * 1.5), eps);
+        });
+
         glam_test!(test_midpoint, {
             let v0 = $vec2::new(-1.0, -1.0);
             let v1 = $vec2::new(1.0, 1.0);


### PR DESCRIPTION
Adds a `rotate_towards` function for `Vec2` and `Quat`, based on discussion in #265, with tests.

I'm unsure if these tests are comprehensive enough.