### PR TITLE
Fix clippy::legacy_numeric_constants lints.

### DIFF
--- a/codegen/templates/quat.rs.tera
+++ b/codegen/templates/quat.rs.tera
@@ -395,7 +395,7 @@ impl {{ self_t }} {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPS: {{ scalar_t }} = 1.0 - 2.0 * core::{{ scalar_t }}::EPSILON;
+        const ONE_MINUS_EPS: {{ scalar_t }} = 1.0 - 2.0 * {{ scalar_t }}::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPS {
             // 0° singularity: from ≈ to
@@ -451,7 +451,7 @@ impl {{ self_t }} {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPSILON: {{ scalar_t }} = 1.0 - 2.0 * core::{{ scalar_t }}::EPSILON;
+        const ONE_MINUS_EPSILON: {{ scalar_t }} = 1.0 - 2.0 * {{ scalar_t }}::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPSILON {
             // 0° singularity: from ≈ to

--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -282,7 +282,7 @@ impl Quat {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPS: f32 = 1.0 - 2.0 * core::f32::EPSILON;
+        const ONE_MINUS_EPS: f32 = 1.0 - 2.0 * f32::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPS {
             // 0° singularity: from ≈ to
@@ -338,7 +338,7 @@ impl Quat {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPSILON: f32 = 1.0 - 2.0 * core::f32::EPSILON;
+        const ONE_MINUS_EPSILON: f32 = 1.0 - 2.0 * f32::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPSILON {
             // 0° singularity: from ≈ to

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -290,7 +290,7 @@ impl Quat {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPS: f32 = 1.0 - 2.0 * core::f32::EPSILON;
+        const ONE_MINUS_EPS: f32 = 1.0 - 2.0 * f32::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPS {
             // 0° singularity: from ≈ to
@@ -346,7 +346,7 @@ impl Quat {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPSILON: f32 = 1.0 - 2.0 * core::f32::EPSILON;
+        const ONE_MINUS_EPSILON: f32 = 1.0 - 2.0 * f32::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPSILON {
             // 0° singularity: from ≈ to

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -290,7 +290,7 @@ impl Quat {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPS: f32 = 1.0 - 2.0 * core::f32::EPSILON;
+        const ONE_MINUS_EPS: f32 = 1.0 - 2.0 * f32::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPS {
             // 0° singularity: from ≈ to
@@ -346,7 +346,7 @@ impl Quat {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPSILON: f32 = 1.0 - 2.0 * core::f32::EPSILON;
+        const ONE_MINUS_EPSILON: f32 = 1.0 - 2.0 * f32::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPSILON {
             // 0° singularity: from ≈ to

--- a/src/f32/wasm32/quat.rs
+++ b/src/f32/wasm32/quat.rs
@@ -282,7 +282,7 @@ impl Quat {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPS: f32 = 1.0 - 2.0 * core::f32::EPSILON;
+        const ONE_MINUS_EPS: f32 = 1.0 - 2.0 * f32::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPS {
             // 0° singularity: from ≈ to
@@ -338,7 +338,7 @@ impl Quat {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPSILON: f32 = 1.0 - 2.0 * core::f32::EPSILON;
+        const ONE_MINUS_EPSILON: f32 = 1.0 - 2.0 * f32::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPSILON {
             // 0° singularity: from ≈ to

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -279,7 +279,7 @@ impl DQuat {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPS: f64 = 1.0 - 2.0 * core::f64::EPSILON;
+        const ONE_MINUS_EPS: f64 = 1.0 - 2.0 * f64::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPS {
             // 0° singularity: from ≈ to
@@ -335,7 +335,7 @@ impl DQuat {
         glam_assert!(from.is_normalized());
         glam_assert!(to.is_normalized());
 
-        const ONE_MINUS_EPSILON: f64 = 1.0 - 2.0 * core::f64::EPSILON;
+        const ONE_MINUS_EPSILON: f64 = 1.0 - 2.0 * f64::EPSILON;
         let dot = from.dot(to);
         if dot > ONE_MINUS_EPSILON {
             // 0° singularity: from ≈ to

--- a/tests/affine2.rs
+++ b/tests/affine2.rs
@@ -6,9 +6,6 @@ macro_rules! impl_affine2_tests {
         const MATRIX1D: [$t; 6] = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
         const MATRIX2D: [[$t; 2]; 3] = [[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]];
 
-        use core::$t::NAN;
-        use core::$t::NEG_INFINITY;
-
         glam_test!(test_affine2_identity, {
             assert_eq!($affine2::IDENTITY, $affine2::IDENTITY * $affine2::IDENTITY);
             assert_eq!($affine2::IDENTITY, $affine2::default());
@@ -260,8 +257,8 @@ macro_rules! impl_affine2_tests {
         glam_test!(test_affine2_is_finite, {
             assert!($affine2::from_scale($vec2::new(1.0, 1.0)).is_finite());
             assert!($affine2::from_scale($vec2::new(0.0, 1.0)).is_finite());
-            assert!(!$affine2::from_scale($vec2::new(1.0, NAN)).is_finite());
-            assert!(!$affine2::from_scale($vec2::new(1.0, NEG_INFINITY)).is_finite());
+            assert!(!$affine2::from_scale($vec2::new(1.0, $t::NAN)).is_finite());
+            assert!(!$affine2::from_scale($vec2::new(1.0, $t::NEG_INFINITY)).is_finite());
         });
     };
 }

--- a/tests/affine3.rs
+++ b/tests/affine3.rs
@@ -13,9 +13,6 @@ macro_rules! impl_affine3_tests {
             [10.0, 11.0, 12.0],
         ];
 
-        use core::$t::NAN;
-        use core::$t::NEG_INFINITY;
-
         glam_test!(test_affine3_identity, {
             assert_eq!($affine3::IDENTITY, $affine3::IDENTITY * $affine3::IDENTITY);
             assert_eq!($affine3::IDENTITY, $affine3::default());
@@ -98,7 +95,7 @@ macro_rules! impl_affine3_tests {
         });
 
         glam_test!(test_from_rotation, {
-            let eps = 2.0 * core::f32::EPSILON;
+            let eps = 2.0 * f32::EPSILON;
             let rot_x1 = $affine3::from_rotation_x(deg(180.0));
             let rot_x2 = $affine3::from_axis_angle($vec3::X, deg(180.0));
             assert_approx_eq!(rot_x1, rot_x2, eps);
@@ -345,8 +342,8 @@ macro_rules! impl_affine3_tests {
         glam_test!(test_affine3_is_finite, {
             assert!($affine3::from_scale($vec3::new(1.0, 1.0, 1.0)).is_finite());
             assert!($affine3::from_scale($vec3::new(0.0, 1.0, 1.0)).is_finite());
-            assert!(!$affine3::from_scale($vec3::new(1.0, NAN, 1.0)).is_finite());
-            assert!(!$affine3::from_scale($vec3::new(1.0, 1.0, NEG_INFINITY)).is_finite());
+            assert!(!$affine3::from_scale($vec3::new(1.0, $t::NAN, 1.0)).is_finite());
+            assert!(!$affine3::from_scale($vec3::new(1.0, 1.0, $t::NEG_INFINITY)).is_finite());
         });
     };
 }

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -220,13 +220,10 @@ macro_rules! impl_mat2_tests {
         });
 
         glam_test!(test_mat2_is_finite, {
-            use std::$t::INFINITY;
-            use std::$t::NAN;
-            use std::$t::NEG_INFINITY;
             assert!($mat2::IDENTITY.is_finite());
-            assert!(!($mat2::IDENTITY * INFINITY).is_finite());
-            assert!(!($mat2::IDENTITY * NEG_INFINITY).is_finite());
-            assert!(!($mat2::IDENTITY * NAN).is_finite());
+            assert!(!($mat2::IDENTITY * $t::INFINITY).is_finite());
+            assert!(!($mat2::IDENTITY * $t::NEG_INFINITY).is_finite());
+            assert!(!($mat2::IDENTITY * $t::NAN).is_finite());
         });
     };
 }

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -3,10 +3,6 @@ mod support;
 
 macro_rules! impl_mat3_tests {
     ($t:ident, $newmat3:ident, $mat3:ident, $mat2:ident, $mat4:ident, $quat:ident, $newvec3:ident, $vec3:ident, $vec2:ident) => {
-        use core::$t::INFINITY;
-        use core::$t::NAN;
-        use core::$t::NEG_INFINITY;
-
         const IDENTITY: [[$t; 3]; 3] = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]];
 
         const MATRIX: [[$t; 3]; 3] = [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]];
@@ -363,9 +359,9 @@ macro_rules! impl_mat3_tests {
 
         glam_test!(test_mat3_is_finite, {
             assert!($mat3::IDENTITY.is_finite());
-            assert!(!($mat3::IDENTITY * INFINITY).is_finite());
-            assert!(!($mat3::IDENTITY * NEG_INFINITY).is_finite());
-            assert!(!($mat3::IDENTITY * NAN).is_finite());
+            assert!(!($mat3::IDENTITY * $t::INFINITY).is_finite());
+            assert!(!($mat3::IDENTITY * $t::NEG_INFINITY).is_finite());
+            assert!(!($mat3::IDENTITY * $t::NAN).is_finite());
         });
     };
 }

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -3,10 +3,6 @@ mod support;
 
 macro_rules! impl_mat4_tests {
     ($t:ident, $newmat4:ident, $newvec4:ident, $newvec3:ident, $mat4:ident, $mat3:ident, $quat:ident, $vec4:ident, $vec3:ident) => {
-        use core::$t::INFINITY;
-        use core::$t::NAN;
-        use core::$t::NEG_INFINITY;
-
         const IDENTITY: [[$t; 4]; 4] = [
             [1.0, 0.0, 0.0, 0.0],
             [0.0, 1.0, 0.0, 0.0],
@@ -669,9 +665,9 @@ macro_rules! impl_mat4_tests {
 
         glam_test!(test_mat4_is_finite, {
             assert!($mat4::IDENTITY.is_finite());
-            assert!(!($mat4::IDENTITY * INFINITY).is_finite());
-            assert!(!($mat4::IDENTITY * NEG_INFINITY).is_finite());
-            assert!(!($mat4::IDENTITY * NAN).is_finite());
+            assert!(!($mat4::IDENTITY * $t::INFINITY).is_finite());
+            assert!(!($mat4::IDENTITY * $t::NEG_INFINITY).is_finite());
+            assert!(!($mat4::IDENTITY * $t::NAN).is_finite());
         });
 
         glam_test!(test_mat4_abs, {

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -5,10 +5,6 @@ mod support;
 
 macro_rules! impl_quat_tests {
     ($t:ident, $new:ident, $mat3:ident, $mat4:ident, $quat:ident, $vec2:ident, $vec3:ident, $vec4:ident) => {
-        use core::$t::INFINITY;
-        use core::$t::NAN;
-        use core::$t::NEG_INFINITY;
-
         glam_test!(test_const, {
             const Q0: $quat = $quat::from_xyzw(1.0, 2.0, 3.0, 4.0);
             const Q1: $quat = $quat::from_array([1.0, 2.0, 3.0, 4.0]);
@@ -236,7 +232,7 @@ macro_rules! impl_quat_tests {
 
         glam_test!(test_angle_between, {
             const TAU: $t = 2.0 * core::$t::consts::PI;
-            let eps = 10.0 * core::$t::EPSILON as f32;
+            let eps = 10.0 * $t::EPSILON as f32;
             let q1 = $quat::from_euler(EulerRot::YXZ, 0.0, 0.0, 0.0);
             let q2 = $quat::from_euler(EulerRot::YXZ, TAU * 0.25, 0.0, 0.0);
             let q3 = $quat::from_euler(EulerRot::YXZ, TAU * 0.5, 0.0, 0.0);
@@ -421,14 +417,14 @@ macro_rules! impl_quat_tests {
         glam_test!(test_is_finite, {
             assert!($quat::from_xyzw(0.0, 0.0, 0.0, 0.0).is_finite());
             assert!($quat::from_xyzw(-1e-10, 1.0, 1e10, 42.0).is_finite());
-            assert!(!$quat::from_xyzw(INFINITY, 0.0, 0.0, 0.0).is_finite());
-            assert!(!$quat::from_xyzw(0.0, NAN, 0.0, 0.0).is_finite());
-            assert!(!$quat::from_xyzw(0.0, 0.0, NEG_INFINITY, 0.0).is_finite());
-            assert!(!$quat::from_xyzw(0.0, 0.0, 0.0, NAN).is_finite());
+            assert!(!$quat::from_xyzw($t::INFINITY, 0.0, 0.0, 0.0).is_finite());
+            assert!(!$quat::from_xyzw(0.0, $t::NAN, 0.0, 0.0).is_finite());
+            assert!(!$quat::from_xyzw(0.0, 0.0, $t::NEG_INFINITY, 0.0).is_finite());
+            assert!(!$quat::from_xyzw(0.0, 0.0, 0.0, $t::NAN).is_finite());
         });
 
         glam_test!(test_rotation_arc, {
-            let eps = 2.0 * core::$t::EPSILON.sqrt();
+            let eps = 2.0 * $t::EPSILON.sqrt();
 
             for &from in &vec3_float_test_vectors!($vec3) {
                 let from = from.normalize();

--- a/tests/support/macros.rs
+++ b/tests/support/macros.rs
@@ -30,7 +30,7 @@ macro_rules! assert_approx_eq {
     ($a:expr, $b:expr) => {{
         #[allow(unused_imports)]
         use $crate::support::FloatCompare;
-        let eps = core::f32::EPSILON;
+        let eps = f32::EPSILON;
         let (a, b) = (&$a, &$b);
         assert!(
             a.approx_eq(b, eps),
@@ -78,9 +78,6 @@ macro_rules! assert_approx_eq {
 #[macro_export]
 macro_rules! impl_vec_float_normalize_tests {
     ($t:ident, $vec:ident) => {
-        use core::$t::MAX;
-        use core::$t::MIN_POSITIVE;
-
         /// Works for vec2, vec3, vec4
         fn from_x_y(x: $t, y: $t) -> $vec {
             let mut v = $vec::ZERO;
@@ -91,27 +88,30 @@ macro_rules! impl_vec_float_normalize_tests {
 
         glam_test!(test_normalize, {
             assert_eq!(from_x_y(-42.0, 0.0).normalize(), from_x_y(-1.0, 0.0));
-            assert_eq!(from_x_y(MAX.sqrt(), 0.0).normalize(), from_x_y(1.0, 0.0));
-            // assert_eq!(from_x_y(MAX, 0.0).normalize(), from_x_y(1.0, 0.0)); // normalize fails for huge vectors and returns zero
+            assert_eq!(
+                from_x_y($t::MAX.sqrt(), 0.0).normalize(),
+                from_x_y(1.0, 0.0)
+            );
+            // assert_eq!(from_x_y($t::MAX, 0.0).normalize(), from_x_y(1.0, 0.0)); // normalize fails for huge vectors and returns zero
 
             // We expect not to be able to normalize small numbers:
             should_glam_assert!({ from_x_y(0.0, 0.0).normalize() });
-            should_glam_assert!({ from_x_y(MIN_POSITIVE, 0.0).normalize() });
+            should_glam_assert!({ from_x_y($t::MIN_POSITIVE, 0.0).normalize() });
 
             // We expect not to be able to normalize non-finite vectors:
-            should_glam_assert!({ from_x_y(INFINITY, 0.0).normalize() });
-            should_glam_assert!({ from_x_y(NAN, 0.0).normalize() });
+            should_glam_assert!({ from_x_y($t::INFINITY, 0.0).normalize() });
+            should_glam_assert!({ from_x_y($t::NAN, 0.0).normalize() });
         });
 
         #[cfg(not(any(feature = "debug-glam-assert", feature = "glam-assert")))]
         glam_test!(test_normalize_no_glam_assert, {
             // We expect not to be able to normalize small numbers:
             assert!(!from_x_y(0.0, 0.0).normalize().is_finite());
-            assert!(!from_x_y(MIN_POSITIVE, 0.0).normalize().is_finite());
+            assert!(!from_x_y($t::MIN_POSITIVE, 0.0).normalize().is_finite());
 
             // We expect not to be able to normalize non-finite vectors:
-            assert!(!from_x_y(INFINITY, 0.0).normalize().is_finite());
-            assert!(!from_x_y(NAN, 0.0).normalize().is_finite());
+            assert!(!from_x_y($t::INFINITY, 0.0).normalize().is_finite());
+            assert!(!from_x_y($t::NAN, 0.0).normalize().is_finite());
         });
 
         glam_test!(test_try_normalize, {
@@ -120,21 +120,21 @@ macro_rules! impl_vec_float_normalize_tests {
                 Some(from_x_y(-1.0, 0.0))
             );
             assert_eq!(
-                from_x_y(MAX.sqrt(), 0.0).try_normalize(),
+                from_x_y($t::MAX.sqrt(), 0.0).try_normalize(),
                 Some(from_x_y(1.0, 0.0))
             );
 
             // We expect `try_normalize` to return None when inputs are very small:
             assert_eq!(from_x_y(0.0, 0.0).try_normalize(), None);
-            assert_eq!(from_x_y(MIN_POSITIVE, 0.0).try_normalize(), None);
+            assert_eq!(from_x_y($t::MIN_POSITIVE, 0.0).try_normalize(), None);
 
             // We expect `try_normalize` to return None when inputs are non-finite:
-            assert_eq!(from_x_y(INFINITY, 0.0).try_normalize(), None);
-            assert_eq!(from_x_y(NAN, 0.0).try_normalize(), None);
+            assert_eq!(from_x_y($t::INFINITY, 0.0).try_normalize(), None);
+            assert_eq!(from_x_y($t::NAN, 0.0).try_normalize(), None);
 
             // We expect `try_normalize` to return None when inputs are very large:
-            assert_eq!(from_x_y(MAX, 0.0).try_normalize(), None);
-            assert_eq!(from_x_y(MAX, MAX).try_normalize(), None);
+            assert_eq!(from_x_y($t::MAX, 0.0).try_normalize(), None);
+            assert_eq!(from_x_y($t::MAX, $t::MAX).try_normalize(), None);
         });
 
         glam_test!(test_normalize_or, {
@@ -143,21 +143,24 @@ macro_rules! impl_vec_float_normalize_tests {
                 from_x_y(-1.0, 0.0)
             );
             assert_eq!(
-                from_x_y(MAX.sqrt(), 0.0).normalize_or($vec::Y),
+                from_x_y($t::MAX.sqrt(), 0.0).normalize_or($vec::Y),
                 from_x_y(1.0, 0.0)
             );
 
             // We expect `normalize_or` to return the fallback value when inputs are very small:
             assert_eq!(from_x_y(0.0, 0.0).normalize_or($vec::Y), $vec::Y);
-            assert_eq!(from_x_y(MIN_POSITIVE, 0.0).normalize_or($vec::Y), $vec::Y);
+            assert_eq!(
+                from_x_y($t::MIN_POSITIVE, 0.0).normalize_or($vec::Y),
+                $vec::Y
+            );
 
             // We expect `normalize` to return zero when inputs are non-finite:
-            assert_eq!(from_x_y(INFINITY, 0.0).normalize_or($vec::Y), $vec::Y);
-            assert_eq!(from_x_y(NAN, 0.0).normalize_or($vec::Y), $vec::Y);
+            assert_eq!(from_x_y($t::INFINITY, 0.0).normalize_or($vec::Y), $vec::Y);
+            assert_eq!(from_x_y($t::NAN, 0.0).normalize_or($vec::Y), $vec::Y);
 
             // We expect `normalize` to return zero when inputs are very large:
-            assert_eq!(from_x_y(MAX, 0.0).normalize_or($vec::Y), $vec::Y);
-            assert_eq!(from_x_y(MAX, MAX).normalize_or($vec::Y), $vec::Y);
+            assert_eq!(from_x_y($t::MAX, 0.0).normalize_or($vec::Y), $vec::Y);
+            assert_eq!(from_x_y($t::MAX, $t::MAX).normalize_or($vec::Y), $vec::Y);
         });
 
         glam_test!(test_normalize_or_zero, {
@@ -166,21 +169,24 @@ macro_rules! impl_vec_float_normalize_tests {
                 from_x_y(-1.0, 0.0)
             );
             assert_eq!(
-                from_x_y(MAX.sqrt(), 0.0).normalize_or_zero(),
+                from_x_y($t::MAX.sqrt(), 0.0).normalize_or_zero(),
                 from_x_y(1.0, 0.0)
             );
 
             // We expect `normalize_or_zero` to return zero when inputs are very small:
             assert_eq!(from_x_y(0.0, 0.0).normalize_or_zero(), $vec::ZERO);
-            assert_eq!(from_x_y(MIN_POSITIVE, 0.0).normalize_or_zero(), $vec::ZERO);
+            assert_eq!(
+                from_x_y($t::MIN_POSITIVE, 0.0).normalize_or_zero(),
+                $vec::ZERO
+            );
 
             // We expect `normalize_or_zero` to return zero when inputs are non-finite:
-            assert_eq!(from_x_y(INFINITY, 0.0).normalize_or_zero(), $vec::ZERO);
-            assert_eq!(from_x_y(NAN, 0.0).normalize_or_zero(), $vec::ZERO);
+            assert_eq!(from_x_y($t::INFINITY, 0.0).normalize_or_zero(), $vec::ZERO);
+            assert_eq!(from_x_y($t::NAN, 0.0).normalize_or_zero(), $vec::ZERO);
 
             // We expect `normalize_or_zero` to return zero when inputs are very large:
-            assert_eq!(from_x_y(MAX, 0.0).normalize_or_zero(), $vec::ZERO);
-            assert_eq!(from_x_y(MAX, MAX).normalize_or_zero(), $vec::ZERO);
+            assert_eq!(from_x_y($t::MAX, 0.0).normalize_or_zero(), $vec::ZERO);
+            assert_eq!(from_x_y($t::MAX, $t::MAX).normalize_or_zero(), $vec::ZERO);
         });
     };
 }

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -653,10 +653,6 @@ macro_rules! impl_vec2_float_tests {
         impl_vec2_signed_tests!($t, $new, $vec2, $vec3, $mask);
         impl_vec_float_normalize_tests!($t, $vec2);
 
-        use core::$t::INFINITY;
-        use core::$t::NAN;
-        use core::$t::NEG_INFINITY;
-
         glam_test!(test_vec2_nan, {
             assert!($vec2::NAN.is_nan());
             assert!(!$vec2::NAN.is_finite());
@@ -763,19 +759,19 @@ macro_rules! impl_vec2_float_tests {
             assert_eq!($vec2::new(0.0, 11.123).round().y, 11.0);
             assert_eq!($vec2::new(0.0, 11.499).round().y, 11.0);
             assert_eq!(
-                $vec2::new(NEG_INFINITY, INFINITY).round(),
-                $vec2::new(NEG_INFINITY, INFINITY)
+                $vec2::new($t::NEG_INFINITY, $t::INFINITY).round(),
+                $vec2::new($t::NEG_INFINITY, $t::INFINITY)
             );
-            assert!($vec2::new(NAN, 0.0).round().x.is_nan());
+            assert!($vec2::new($t::NAN, 0.0).round().x.is_nan());
         });
 
         glam_test!(test_floor, {
             assert_eq!($vec2::new(1.35, -1.5).floor(), $vec2::new(1.0, -2.0));
             assert_eq!(
-                $vec2::new(INFINITY, NEG_INFINITY).floor(),
-                $vec2::new(INFINITY, NEG_INFINITY)
+                $vec2::new($t::INFINITY, $t::NEG_INFINITY).floor(),
+                $vec2::new($t::INFINITY, $t::NEG_INFINITY)
             );
-            assert!($vec2::new(NAN, 0.0).floor().x.is_nan());
+            assert!($vec2::new($t::NAN, 0.0).floor().x.is_nan());
             assert_eq!(
                 $vec2::new(-2000000.123, 10000000.123).floor(),
                 $vec2::new(-2000001.0, 10000000.0)
@@ -803,10 +799,10 @@ macro_rules! impl_vec2_float_tests {
         glam_test!(test_ceil, {
             assert_eq!($vec2::new(1.35, -1.5).ceil(), $vec2::new(2.0, -1.0));
             assert_eq!(
-                $vec2::new(INFINITY, NEG_INFINITY).ceil(),
-                $vec2::new(INFINITY, NEG_INFINITY)
+                $vec2::new($t::INFINITY, $t::NEG_INFINITY).ceil(),
+                $vec2::new($t::INFINITY, $t::NEG_INFINITY)
             );
-            assert!($vec2::new(NAN, 0.0).ceil().x.is_nan());
+            assert!($vec2::new($t::NAN, 0.0).ceil().x.is_nan());
             assert_eq!(
                 $vec2::new(-2000000.123, 1000000.123).ceil(),
                 $vec2::new(-2000000.0, 1000001.0)
@@ -816,10 +812,10 @@ macro_rules! impl_vec2_float_tests {
         glam_test!(test_trunc, {
             assert_eq!($vec2::new(1.35, -1.5).trunc(), $vec2::new(1.0, -1.0));
             assert_eq!(
-                $vec2::new(INFINITY, NEG_INFINITY).trunc(),
-                $vec2::new(INFINITY, NEG_INFINITY)
+                $vec2::new($t::INFINITY, $t::NEG_INFINITY).trunc(),
+                $vec2::new($t::INFINITY, $t::NEG_INFINITY)
             );
-            assert!($vec2::new(0.0, NAN).trunc().y.is_nan());
+            assert!($vec2::new(0.0, $t::NAN).trunc().y.is_nan());
             assert_eq!(
                 $vec2::new(-0.0, -2000000.123).trunc(),
                 $vec2::new(-0.0, -2000000.0)
@@ -853,10 +849,10 @@ macro_rules! impl_vec2_float_tests {
         glam_test!(test_is_finite, {
             assert!($vec2::new(0.0, 0.0).is_finite());
             assert!($vec2::new(-1e-10, 1e10).is_finite());
-            assert!(!$vec2::new(INFINITY, 0.0).is_finite());
-            assert!(!$vec2::new(0.0, NAN).is_finite());
-            assert!(!$vec2::new(0.0, NEG_INFINITY).is_finite());
-            assert!(!$vec2::new(INFINITY, NEG_INFINITY).is_finite());
+            assert!(!$vec2::new($t::INFINITY, 0.0).is_finite());
+            assert!(!$vec2::new(0.0, $t::NAN).is_finite());
+            assert!(!$vec2::new(0.0, $t::NEG_INFINITY).is_finite());
+            assert!(!$vec2::new($t::INFINITY, $t::NEG_INFINITY).is_finite());
             assert!(!$vec2::INFINITY.is_finite());
             assert!(!$vec2::NEG_INFINITY.is_finite());
         });

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -763,10 +763,6 @@ macro_rules! impl_vec3_float_tests {
         impl_vec3_signed_tests!($t, $new, $vec3, $mask);
         impl_vec_float_normalize_tests!($t, $vec3);
 
-        use core::$t::INFINITY;
-        use core::$t::NAN;
-        use core::$t::NEG_INFINITY;
-
         glam_test!(test_nan, {
             assert!($vec3::NAN.is_nan());
             assert!(!$vec3::NAN.is_finite());
@@ -887,10 +883,10 @@ macro_rules! impl_vec3_float_tests {
             assert_eq!($vec3::new(0.0, 11.123, 0.0).round().y, 11.0);
             assert_eq!($vec3::new(0.0, 11.499, 0.0).round().y, 11.0);
             assert_eq!(
-                $vec3::new(NEG_INFINITY, INFINITY, 0.0).round(),
-                $vec3::new(NEG_INFINITY, INFINITY, 0.0)
+                $vec3::new($t::NEG_INFINITY, $t::INFINITY, 0.0).round(),
+                $vec3::new($t::NEG_INFINITY, $t::INFINITY, 0.0)
             );
-            assert!($vec3::new(NAN, 0.0, 0.0).round().x.is_nan());
+            assert!($vec3::new($t::NAN, 0.0, 0.0).round().x.is_nan());
         });
 
         glam_test!(test_floor, {
@@ -899,10 +895,10 @@ macro_rules! impl_vec3_float_tests {
                 $vec3::new(1.0, 1.0, -2.0)
             );
             assert_eq!(
-                $vec3::new(INFINITY, NEG_INFINITY, 0.0).floor(),
-                $vec3::new(INFINITY, NEG_INFINITY, 0.0)
+                $vec3::new($t::INFINITY, $t::NEG_INFINITY, 0.0).floor(),
+                $vec3::new($t::INFINITY, $t::NEG_INFINITY, 0.0)
             );
-            assert!($vec3::new(NAN, 0.0, 0.0).floor().x.is_nan());
+            assert!($vec3::new($t::NAN, 0.0, 0.0).floor().x.is_nan());
             assert_eq!(
                 $vec3::new(-2000000.123, 10000000.123, 1000.9).floor(),
                 $vec3::new(-2000001.0, 10000000.0, 1000.0)
@@ -939,10 +935,10 @@ macro_rules! impl_vec3_float_tests {
                 $vec3::new(2.0, 2.0, -1.0)
             );
             assert_eq!(
-                $vec3::new(INFINITY, NEG_INFINITY, 0.0).ceil(),
-                $vec3::new(INFINITY, NEG_INFINITY, 0.0)
+                $vec3::new($t::INFINITY, $t::NEG_INFINITY, 0.0).ceil(),
+                $vec3::new($t::INFINITY, $t::NEG_INFINITY, 0.0)
             );
-            assert!($vec3::new(NAN, 0.0, 0.0).ceil().x.is_nan());
+            assert!($vec3::new($t::NAN, 0.0, 0.0).ceil().x.is_nan());
             assert_eq!(
                 $vec3::new(-2000000.123, 1000000.123, 1000.9).ceil(),
                 $vec3::new(-2000000.0, 1000001.0, 1001.0)
@@ -955,10 +951,10 @@ macro_rules! impl_vec3_float_tests {
                 $vec3::new(1.0, 1.0, -1.0)
             );
             assert_eq!(
-                $vec3::new(INFINITY, NEG_INFINITY, 0.0).trunc(),
-                $vec3::new(INFINITY, NEG_INFINITY, 0.0)
+                $vec3::new($t::INFINITY, $t::NEG_INFINITY, 0.0).trunc(),
+                $vec3::new($t::INFINITY, $t::NEG_INFINITY, 0.0)
             );
-            assert!($vec3::new(0.0, NAN, 0.0).trunc().y.is_nan());
+            assert!($vec3::new(0.0, $t::NAN, 0.0).trunc().y.is_nan());
             assert_eq!(
                 $vec3::new(-0.0, -2000000.123, 10000000.123).trunc(),
                 $vec3::new(-0.0, -2000000.0, 10000000.0)
@@ -992,9 +988,9 @@ macro_rules! impl_vec3_float_tests {
         glam_test!(test_is_finite, {
             assert!($vec3::new(0.0, 0.0, 0.0).is_finite());
             assert!($vec3::new(-1e-10, 1.0, 1e10).is_finite());
-            assert!(!$vec3::new(INFINITY, 0.0, 0.0).is_finite());
-            assert!(!$vec3::new(0.0, NAN, 0.0).is_finite());
-            assert!(!$vec3::new(0.0, 0.0, NEG_INFINITY).is_finite());
+            assert!(!$vec3::new($t::INFINITY, 0.0, 0.0).is_finite());
+            assert!(!$vec3::new(0.0, $t::NAN, 0.0).is_finite());
+            assert!(!$vec3::new(0.0, 0.0, $t::NEG_INFINITY).is_finite());
             assert!(!$vec3::NAN.is_finite());
             assert!(!$vec3::INFINITY.is_finite());
             assert!(!$vec3::NEG_INFINITY.is_finite());
@@ -1071,7 +1067,7 @@ macro_rules! impl_vec3_float_tests {
         });
 
         glam_test!(test_any_ortho, {
-            let eps = 2.0 * core::$t::EPSILON;
+            let eps = 2.0 * $t::EPSILON;
 
             for &v in &vec3_float_test_vectors!($vec3) {
                 let orthogonal = v.any_orthogonal_vector();

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -865,10 +865,6 @@ macro_rules! impl_vec4_float_tests {
         impl_vec4_signed_tests!($t, $new, $vec4, $vec3, $vec2, $mask);
         impl_vec_float_normalize_tests!($t, $vec4);
 
-        use core::$t::INFINITY;
-        use core::$t::NAN;
-        use core::$t::NEG_INFINITY;
-
         glam_test!(test_vec4_nan, {
             assert!($vec4::NAN.is_nan());
             assert!(!$vec4::NAN.is_finite());
@@ -1008,10 +1004,10 @@ macro_rules! impl_vec4_float_tests {
             assert_eq!($vec4::new(0.0, 0.0, 0.0, 11.123).round().w, 11.0);
             assert_eq!($vec4::new(0.0, 0.0, 11.501, 0.0).round().z, 12.0);
             assert_eq!(
-                $vec4::new(NEG_INFINITY, INFINITY, 1.0, -1.0).round(),
-                $vec4::new(NEG_INFINITY, INFINITY, 1.0, -1.0)
+                $vec4::new($t::NEG_INFINITY, $t::INFINITY, 1.0, -1.0).round(),
+                $vec4::new($t::NEG_INFINITY, $t::INFINITY, 1.0, -1.0)
             );
-            assert!($vec4::new(NAN, 0.0, 0.0, 1.0).round().x.is_nan());
+            assert!($vec4::new($t::NAN, 0.0, 0.0, 1.0).round().x.is_nan());
         });
 
         glam_test!(test_floor, {
@@ -1020,10 +1016,10 @@ macro_rules! impl_vec4_float_tests {
                 $vec4::new(1.0, 1.0, -2.0, 1.0)
             );
             assert_eq!(
-                $vec4::new(INFINITY, NEG_INFINITY, 0.0, 0.0).floor(),
-                $vec4::new(INFINITY, NEG_INFINITY, 0.0, 0.0)
+                $vec4::new($t::INFINITY, $t::NEG_INFINITY, 0.0, 0.0).floor(),
+                $vec4::new($t::INFINITY, $t::NEG_INFINITY, 0.0, 0.0)
             );
-            assert!($vec4::new(0.0, NAN, 0.0, 0.0).floor().y.is_nan());
+            assert!($vec4::new(0.0, $t::NAN, 0.0, 0.0).floor().y.is_nan());
             assert_eq!(
                 $vec4::new(-0.0, -2000000.123, 10000000.123, 1000.9).floor(),
                 $vec4::new(-0.0, -2000001.0, 10000000.0, 1000.0)
@@ -1060,10 +1056,10 @@ macro_rules! impl_vec4_float_tests {
                 $vec4::new(2.0, 2.0, -1.0, 1235.0)
             );
             assert_eq!(
-                $vec4::new(INFINITY, NEG_INFINITY, 0.0, 0.0).ceil(),
-                $vec4::new(INFINITY, NEG_INFINITY, 0.0, 0.0)
+                $vec4::new($t::INFINITY, $t::NEG_INFINITY, 0.0, 0.0).ceil(),
+                $vec4::new($t::INFINITY, $t::NEG_INFINITY, 0.0, 0.0)
             );
-            assert!($vec4::new(0.0, 0.0, NAN, 0.0).ceil().z.is_nan());
+            assert!($vec4::new(0.0, 0.0, $t::NAN, 0.0).ceil().z.is_nan());
             assert_eq!(
                 $vec4::new(-1234.1234, -2000000.123, 1000000.123, 1000.9).ceil(),
                 $vec4::new(-1234.0, -2000000.0, 1000001.0, 1001.0)
@@ -1076,10 +1072,10 @@ macro_rules! impl_vec4_float_tests {
                 $vec4::new(1.0, 1.0, -1.0, 1.0)
             );
             assert_eq!(
-                $vec4::new(INFINITY, NEG_INFINITY, 0.0, 0.0).trunc(),
-                $vec4::new(INFINITY, NEG_INFINITY, 0.0, 0.0)
+                $vec4::new($t::INFINITY, $t::NEG_INFINITY, 0.0, 0.0).trunc(),
+                $vec4::new($t::INFINITY, $t::NEG_INFINITY, 0.0, 0.0)
             );
-            assert!($vec4::new(0.0, NAN, 0.0, 0.0).trunc().y.is_nan());
+            assert!($vec4::new(0.0, $t::NAN, 0.0, 0.0).trunc().y.is_nan());
             assert_eq!(
                 $vec4::new(-0.0, -2000000.123, 10000000.123, 1000.9).trunc(),
                 $vec4::new(-0.0, -2000000.0, 10000000.0, 1000.0)
@@ -1113,10 +1109,10 @@ macro_rules! impl_vec4_float_tests {
         glam_test!(test_is_finite, {
             assert!($vec4::new(0.0, 0.0, 0.0, 0.0).is_finite());
             assert!($vec4::new(-1e-10, 1.0, 1e10, 42.0).is_finite());
-            assert!(!$vec4::new(INFINITY, 0.0, 0.0, 0.0).is_finite());
-            assert!(!$vec4::new(0.0, NAN, 0.0, 0.0).is_finite());
-            assert!(!$vec4::new(0.0, 0.0, NEG_INFINITY, 0.0).is_finite());
-            assert!(!$vec4::new(0.0, 0.0, 0.0, NAN).is_finite());
+            assert!(!$vec4::new($t::INFINITY, 0.0, 0.0, 0.0).is_finite());
+            assert!(!$vec4::new(0.0, $t::NAN, 0.0, 0.0).is_finite());
+            assert!(!$vec4::new(0.0, 0.0, $t::NEG_INFINITY, 0.0).is_finite());
+            assert!(!$vec4::new(0.0, 0.0, 0.0, $t::NAN).is_finite());
             assert!(!$vec4::INFINITY.is_finite());
             assert!(!$vec4::NEG_INFINITY.is_finite());
         });


### PR DESCRIPTION
The `std::f64::EPSILON` and similar constants are being deprecated and it is encouraged to use the associated constants on `f32` and `f64` instead.