### PR TITLE
Unreal ABI Compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glam"
-version = "0.27.0" # remember to update html_root_url
+version = "0.27.0"                                                       # remember to update html_root_url
 edition = "2021"
 authors = ["Cameron Hart <cameron.hart@gmail.com>"]
 description = "A simple and fast 3D math library for games and graphics"
@@ -41,6 +41,9 @@ fast-math = []
 # experimental nightly portable-simd support
 core-simd = []
 
+# Unreal Engine ABI Compatibility, for interoperating with Rust
+unreal-abi-compat = []
+
 [dependencies]
 approx = { version = "0.5", optional = true, default-features = false }
 bytemuck = { version = "1.9", optional = true, default-features = false }
@@ -49,7 +52,7 @@ rand = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.7", optional = true, default-features = false }
-libm = { version = "0.2", optional = true, default-features = false}
+libm = { version = "0.2", optional = true, default-features = false }
 
 [dev-dependencies]
 # rand_xoshiro is required for tests if rand is enabled
@@ -123,7 +126,4 @@ name = "iai"
 harness = false
 
 [workspace]
-members = [
-    "codegen",
-    "test_no_std",
-]
+members = ["codegen", "test_no_std"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glam"
-version = "0.27.0"                                                       # remember to update html_root_url
+version = "0.27.0" # remember to update html_root_url
 edition = "2021"
 authors = ["Cameron Hart <cameron.hart@gmail.com>"]
 description = "A simple and fast 3D math library for games and graphics"
@@ -52,7 +52,7 @@ rand = { version = "0.8", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.7", optional = true, default-features = false }
-libm = { version = "0.2", optional = true, default-features = false }
+libm = { version = "0.2", optional = true, default-features = false}
 
 [dev-dependencies]
 # rand_xoshiro is required for tests if rand is enabled
@@ -126,4 +126,7 @@ name = "iai"
 harness = false
 
 [workspace]
-members = ["codegen", "test_no_std"]
+members = [
+    "codegen",
+    "test_no_std",
+]

--- a/codegen/templates/quat.rs.tera
+++ b/codegen/templates/quat.rs.tera
@@ -103,6 +103,9 @@ pub const fn {{ self_t | lower }}(x: {{ scalar_t }}, y: {{ scalar_t }}, z: {{ sc
 {%- endif %}
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+{%- if scalar_t == "f64" %}
+#[cfg_attr(feature == "unreal-api-compat", repr(align(16)))]
+{%- endif %}
 pub struct {{ self_t }}{
     pub x: {{ scalar_t }},
     pub y: {{ scalar_t }},

--- a/codegen/templates/quat.rs.tera
+++ b/codegen/templates/quat.rs.tera
@@ -104,7 +104,7 @@ pub const fn {{ self_t | lower }}(x: {{ scalar_t }}, y: {{ scalar_t }}, z: {{ sc
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 {%- if scalar_t == "f64" %}
-#[cfg_attr(feature = "unreal-api-compat", repr(align(16)))]
+#[cfg_attr(feature = "unreal-abi-compat", repr(align(16)))]
 {%- endif %}
 pub struct {{ self_t }}{
     pub x: {{ scalar_t }},

--- a/codegen/templates/quat.rs.tera
+++ b/codegen/templates/quat.rs.tera
@@ -104,7 +104,7 @@ pub const fn {{ self_t | lower }}(x: {{ scalar_t }}, y: {{ scalar_t }}, z: {{ sc
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 {%- if scalar_t == "f64" %}
-#[cfg_attr(feature == "unreal-api-compat", repr(align(16)))]
+#[cfg_attr(feature = "unreal-api-compat", repr(align(16)))]
 {%- endif %}
 pub struct {{ self_t }}{
     pub x: {{ scalar_t }},

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -263,9 +263,9 @@ pub const fn {{ self_t | lower }}(
 )]
 {%- elif dim != 3 and is_scalar %}
 #[cfg_attr(feature = "cuda", repr(align({{ cuda_align }})))]
-    {% if dim == 4 and scalar_t == "f64" %}
+{% if dim == 4 and scalar_t == "f64" %}
 #[cfg_attr(feature = "unreal-abi-compat", repr(align(16)))]
-    {% endif %}
+{% endif %}
 {%- endif %}
 {%- if is_scalar %}
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -263,6 +263,9 @@ pub const fn {{ self_t | lower }}(
 )]
 {%- elif dim != 3 and is_scalar %}
 #[cfg_attr(feature = "cuda", repr(align({{ cuda_align }})))]
+    {% if dim == 4 and scalar_t == "f64" %}
+#[cfg_attr(feature = "unreal-abi-compat", repr(align(16)))]
+    {% endif %}
 {%- endif %}
 {%- if is_scalar %}
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]

--- a/src/euler.rs
+++ b/src/euler.rs
@@ -28,6 +28,9 @@ pub enum EulerRot {
     XZY,
 }
 
+#[cfg(feature = "unreal-abi-compat")]
+pub const UNREAL_EULER_ROT: EulerRot = EulerRot::XYZ;
+
 impl Default for EulerRot {
     /// Default `YXZ` as yaw (y-axis), pitch (x-axis), roll (z-axis).
     fn default() -> Self {

--- a/src/f32.rs
+++ b/src/f32.rs
@@ -3,6 +3,7 @@ mod affine3a;
 mod float;
 mod mat3;
 pub(crate) mod math;
+mod rotator;
 mod vec2;
 mod vec3;
 
@@ -63,6 +64,8 @@ pub use mat3::{mat3, Mat3};
 pub use mat3a::{mat3a, Mat3A};
 pub use mat4::{mat4, Mat4};
 pub use quat::{quat, Quat};
+#[cfg(feature = "unreal-abi-compat")]
+pub use rotator::{rotator, Rotator};
 pub use vec2::{vec2, Vec2};
 pub use vec3::{vec3, Vec3};
 pub use vec3a::{vec3a, Vec3A};

--- a/src/f32/rotator.rs
+++ b/src/f32/rotator.rs
@@ -3,7 +3,7 @@
 use crate::{Quat, UNREAL_EULER_ROT};
 
 #[repr(C)]
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct Rotator {
     pub pitch: f32,
     pub yaw: f32,
@@ -21,12 +21,16 @@ impl Rotator {
         rotator(pitch, yaw, roll)
     }
 
-    pub const fn from_euler(a: f32, b: f32, c: f32) -> Self {
-        Self::new(b, c, a)
+    pub fn from_euler(a: f32, b: f32, c: f32) -> Self {
+        Self::new(f32::to_degrees(b), f32::to_degrees(c), f32::to_degrees(a))
     }
 
-    pub const fn to_euler(&self) -> (f32, f32, f32) {
-        (self.roll, self.pitch, self.yaw)
+    pub fn to_euler(&self) -> (f32, f32, f32) {
+        (
+            f32::to_radians(self.roll),
+            f32::to_radians(self.pitch),
+            f32::to_radians(self.yaw),
+        )
     }
 }
 

--- a/src/f32/rotator.rs
+++ b/src/f32/rotator.rs
@@ -25,6 +25,11 @@ impl Rotator {
         Self::new(f32::to_degrees(b), f32::to_degrees(c), f32::to_degrees(a))
     }
 
+    pub fn from_quat(q: Quat) -> Self {
+        let (a, b, c) = q.to_euler(UNREAL_EULER_ROT);
+        Self::new(a, b, c)
+    }
+
     pub fn to_euler(&self) -> (f32, f32, f32) {
         (
             f32::to_radians(self.roll),
@@ -32,18 +37,31 @@ impl Rotator {
             f32::to_radians(self.yaw),
         )
     }
+
+    pub fn to_quat(&self) -> Quat {
+        let (a, b, c) = self.to_euler();
+        Quat::from_euler(UNREAL_EULER_ROT, a, b, c)
+    }
 }
 
 impl From<Rotator> for Quat {
     fn from(r: Rotator) -> Self {
-        let (a, b, c) = r.to_euler();
-        Quat::from_euler(UNREAL_EULER_ROT, a, b, c)
+        r.to_quat()
     }
 }
 
 impl From<Quat> for Rotator {
     fn from(q: Quat) -> Self {
-        let euler = q.to_euler(UNREAL_EULER_ROT);
-        Rotator::from_euler(euler.0, euler.1, euler.2)
+        Self::from_quat(q)
+    }
+}
+
+impl Quat {
+    pub fn from_rotator(rot: Rotator) -> Self {
+        rot.to_quat()
+    }
+
+    pub fn to_rotator(&self) -> Rotator {
+        Rotator::from_quat(*self)
     }
 }

--- a/src/f32/rotator.rs
+++ b/src/f32/rotator.rs
@@ -1,0 +1,45 @@
+#![cfg(feature = "unreal-abi-compat")]
+
+use crate::{Quat, UNREAL_EULER_ROT};
+
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy)]
+pub struct Rotator {
+    pub pitch: f32,
+    pub yaw: f32,
+    pub roll: f32,
+}
+
+#[inline]
+#[must_use]
+pub const fn rotator(pitch: f32, yaw: f32, roll: f32) -> Rotator {
+    Rotator { pitch, yaw, roll }
+}
+
+impl Rotator {
+    pub const fn new(pitch: f32, yaw: f32, roll: f32) -> Self {
+        rotator(pitch, yaw, roll)
+    }
+
+    pub const fn from_euler(a: f32, b: f32, c: f32) -> Self {
+        Self::new(b, c, a)
+    }
+
+    pub const fn to_euler(&self) -> (f32, f32, f32) {
+        (self.roll, self.pitch, self.yaw)
+    }
+}
+
+impl From<Rotator> for Quat {
+    fn from(r: Rotator) -> Self {
+        let (a, b, c) = r.to_euler();
+        Quat::from_euler(UNREAL_EULER_ROT, a, b, c)
+    }
+}
+
+impl From<Quat> for Rotator {
+    fn from(q: Quat) -> Self {
+        let euler = q.to_euler(UNREAL_EULER_ROT);
+        Rotator::from_euler(euler.0, euler.1, euler.2)
+    }
+}

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -4,6 +4,7 @@ mod dmat2;
 mod dmat3;
 mod dmat4;
 mod dquat;
+mod drotator;
 mod dvec2;
 mod dvec3;
 mod dvec4;
@@ -16,6 +17,8 @@ pub use dmat2::{dmat2, DMat2};
 pub use dmat3::{dmat3, DMat3};
 pub use dmat4::{dmat4, DMat4};
 pub use dquat::{dquat, DQuat};
+#[cfg(feature = "unreal-abi-compat")]
+pub use drotator::{drotator, DRotator};
 pub use dvec2::{dvec2, DVec2};
 pub use dvec3::{dvec3, DVec3};
 pub use dvec4::{dvec4, DVec4};

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -96,9 +96,7 @@ mod test {
             core::mem::align_of::<f64>(),
             core::mem::align_of::<super::DVec4>()
         );
-        #[cfg(any(feature = "cuda", target_arch = "spirv"))]
-        const_assert_eq!(16, core::mem::align_of::<super::DVec4>());
-        #[cfg(feature = "unreal-abi-compat")]
+        #[cfg(any(feature = "cuda", target_arch = "spirv", feature = "unreal-abi-compat"))]
         const_assert_eq!(16, core::mem::align_of::<super::DVec4>());
         const_assert_eq!(32, core::mem::size_of::<super::DVec4>());
     }

--- a/src/f64.rs
+++ b/src/f64.rs
@@ -56,13 +56,15 @@ mod test {
     }
 
     mod const_test_dquat {
-        #[cfg(not(target_arch = "spirv"))]
+        #[cfg(all(not(target_arch = "spirv"), not(feature = "unreal-abi-compat")))]
         const_assert_eq!(
             core::mem::align_of::<f64>(),
             core::mem::align_of::<super::DQuat>()
         );
         #[cfg(target_arch = "spirv")]
         const_assert_eq!(32, core::mem::align_of::<super::DQuat>());
+        #[cfg(feature = "unreal-abi-compat")]
+        const_assert_eq!(16, core::mem::align_of::<super::DQuat>());
         const_assert_eq!(32, core::mem::size_of::<super::DQuat>());
     }
 
@@ -89,12 +91,14 @@ mod test {
     }
 
     mod const_test_dvec4 {
-        #[cfg(not(any(feature = "cuda", target_arch = "spirv")))]
+        #[cfg(not(any(feature = "cuda", target_arch = "spirv", feature = "unreal-abi-compat")))]
         const_assert_eq!(
             core::mem::align_of::<f64>(),
             core::mem::align_of::<super::DVec4>()
         );
         #[cfg(any(feature = "cuda", target_arch = "spirv"))]
+        const_assert_eq!(16, core::mem::align_of::<super::DVec4>());
+        #[cfg(feature = "unreal-abi-compat")]
         const_assert_eq!(16, core::mem::align_of::<super::DVec4>());
         const_assert_eq!(32, core::mem::size_of::<super::DVec4>());
     }

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -29,10 +29,7 @@ pub const fn dquat(x: f64, y: f64, z: f64, w: f64) -> DQuat {
 #[derive(Clone, Copy)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
-#[cfg_attr(
-    all(not(target_arch = "spirv"), feature = "unreal-abi-compat"),
-    repr(align(16))
-)]
+#[cfg_attr(feature == "unreal-api-compat", repr(align(16)))]
 pub struct DQuat {
     pub x: f64,
     pub y: f64,

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -29,7 +29,7 @@ pub const fn dquat(x: f64, y: f64, z: f64, w: f64) -> DQuat {
 #[derive(Clone, Copy)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
-#[cfg_attr(feature = "unreal-api-compat", repr(align(16)))]
+#[cfg_attr(feature = "unreal-abi-compat", repr(align(16)))]
 pub struct DQuat {
     pub x: f64,
     pub y: f64,

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -29,7 +29,7 @@ pub const fn dquat(x: f64, y: f64, z: f64, w: f64) -> DQuat {
 #[derive(Clone, Copy)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
-#[cfg_attr(feature == "unreal-api-compat", repr(align(16)))]
+#[cfg_attr(feature = "unreal-api-compat", repr(align(16)))]
 pub struct DQuat {
     pub x: f64,
     pub y: f64,

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -29,6 +29,10 @@ pub const fn dquat(x: f64, y: f64, z: f64, w: f64) -> DQuat {
 #[derive(Clone, Copy)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(
+    all(not(target_arch = "spirv"), feature = "unreal-abi-compat"),
+    repr(align(16))
+)]
 pub struct DQuat {
     pub x: f64,
     pub y: f64,

--- a/src/f64/drotator.rs
+++ b/src/f64/drotator.rs
@@ -3,7 +3,7 @@
 use crate::{DQuat, UNREAL_EULER_ROT};
 
 #[repr(C)]
-#[derive(Default, Debug, Clone, Copy)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct DRotator {
     pub pitch: f64,
     pub yaw: f64,
@@ -21,12 +21,16 @@ impl DRotator {
         drotator(pitch, yaw, roll)
     }
 
-    pub const fn from_euler(a: f64, b: f64, c: f64) -> Self {
-        Self::new(b, c, a)
+    pub fn from_euler(a: f64, b: f64, c: f64) -> Self {
+        Self::new(f64::to_degrees(b), f64::to_degrees(c), f64::to_degrees(a))
     }
 
-    pub const fn to_euler(&self) -> (f64, f64, f64) {
-        (self.roll, self.pitch, self.yaw)
+    pub fn to_euler(&self) -> (f64, f64, f64) {
+        (
+            f64::to_radians(self.roll),
+            f64::to_radians(self.pitch),
+            f64::to_radians(self.yaw),
+        )
     }
 }
 

--- a/src/f64/drotator.rs
+++ b/src/f64/drotator.rs
@@ -25,6 +25,11 @@ impl DRotator {
         Self::new(f64::to_degrees(b), f64::to_degrees(c), f64::to_degrees(a))
     }
 
+    pub fn from_quat(q: DQuat) -> Self {
+        let (a, b, c) = q.to_euler(UNREAL_EULER_ROT);
+        Self::new(a, b, c)
+    }
+
     pub fn to_euler(&self) -> (f64, f64, f64) {
         (
             f64::to_radians(self.roll),
@@ -32,18 +37,31 @@ impl DRotator {
             f64::to_radians(self.yaw),
         )
     }
+
+    pub fn to_quat(&self) -> DQuat {
+        let (a, b, c) = self.to_euler();
+        DQuat::from_euler(UNREAL_EULER_ROT, a, b, c)
+    }
 }
 
 impl From<DRotator> for DQuat {
     fn from(r: DRotator) -> Self {
-        let (a, b, c) = r.to_euler();
-        DQuat::from_euler(UNREAL_EULER_ROT, a, b, c)
+        r.to_quat()
     }
 }
 
 impl From<DQuat> for DRotator {
     fn from(q: DQuat) -> Self {
-        let euler = q.to_euler(UNREAL_EULER_ROT);
-        DRotator::from_euler(euler.0, euler.1, euler.2)
+        Self::from_quat(q)
+    }
+}
+
+impl DQuat {
+    pub fn from_rotator(rot: DRotator) -> Self {
+        rot.to_quat()
+    }
+
+    pub fn to_rotator(&self) -> DRotator {
+        DRotator::from_quat(*self)
     }
 }

--- a/src/f64/drotator.rs
+++ b/src/f64/drotator.rs
@@ -1,0 +1,45 @@
+#![cfg(feature = "unreal-abi-compat")]
+
+use crate::{DQuat, UNREAL_EULER_ROT};
+
+#[repr(C)]
+#[derive(Default, Debug, Clone, Copy)]
+pub struct DRotator {
+    pub pitch: f64,
+    pub yaw: f64,
+    pub roll: f64,
+}
+
+#[inline]
+#[must_use]
+pub const fn drotator(pitch: f64, yaw: f64, roll: f64) -> DRotator {
+    DRotator { pitch, yaw, roll }
+}
+
+impl DRotator {
+    pub const fn new(pitch: f64, yaw: f64, roll: f64) -> Self {
+        drotator(pitch, yaw, roll)
+    }
+
+    pub const fn from_euler(a: f64, b: f64, c: f64) -> Self {
+        Self::new(b, c, a)
+    }
+
+    pub const fn to_euler(&self) -> (f64, f64, f64) {
+        (self.roll, self.pitch, self.yaw)
+    }
+}
+
+impl From<DRotator> for DQuat {
+    fn from(r: DRotator) -> Self {
+        let (a, b, c) = r.to_euler();
+        DQuat::from_euler(UNREAL_EULER_ROT, a, b, c)
+    }
+}
+
+impl From<DQuat> for DRotator {
+    fn from(q: DQuat) -> Self {
+        let euler = q.to_euler(UNREAL_EULER_ROT);
+        DRotator::from_euler(euler.0, euler.1, euler.2)
+    }
+}

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -18,7 +18,8 @@ pub const fn dvec4(x: f64, y: f64, z: f64, w: f64) -> DVec4 {
 
 /// A 4-dimensional vector.
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(any(feature = "cuda", feature = "unreal-abi-compat"), repr(align(16)))]
+#[cfg_attr(feature = "cuda", repr(align(16)))]
+#[cfg_attr(feature = "unreal-abi-compat", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct DVec4 {

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -18,7 +18,7 @@ pub const fn dvec4(x: f64, y: f64, z: f64, w: f64) -> DVec4 {
 
 /// A 4-dimensional vector.
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "cuda", repr(align(16)))]
+#[cfg_attr(any(feature = "cuda", feature = "unreal-abi-compat"), repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct DVec4 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,6 +342,9 @@ pub use self::swizzles::{Vec2Swizzles, Vec3Swizzles, Vec4Swizzles};
 /** Rotation Helper */
 pub use euler::EulerRot;
 
+#[cfg(feature = "unreal-abi-compat")]
+pub use euler::UNREAL_EULER_ROT;
+
 /** A trait for extending [`prim@f32`] and [`prim@f64`] with extra methods. */
 mod float;
 pub use float::FloatExt;


### PR DESCRIPTION
Updates:
- Added feature `unreal-abi-compat`.
  - Corrects the alignments for `DQuat` and `DVec4`.
- Added const `UNREAL_EULER_ROT`.
  - Exposes the default Unreal Engine rotation order.
- Added `Rotator` and `DRotator`.
  - These correspond to `FRotator3f`/`FRotator3d`.
  - Provide degree-based euler-angle proxy.
  - Contains euler/quaternion cast operators.
  - Wrapped in feature.

Minor changes only.