### PR TITLE
Added bvec constructors

### DIFF
--- a/codegen/templates/vec_mask.rs.tera
+++ b/codegen/templates/vec_mask.rs.tera
@@ -51,7 +51,18 @@ union UnionCast {
 }
 {% endif %}
 
-{%- if is_scalar and is_bool %}
+/// Creates a {{ dim }}-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn {{ self_t | lower }}(
+    {% for c in components %}
+        {{ c }}: bool,
+    {% endfor %}
+) -> {{ self_t }} {
+    {{ self_t }}::new({{ components | join(sep=",") }})
+}
+
+{% if is_scalar and is_bool %}
 /// A {{ dim }}-dimensional `bool` vector mask.
 {%- elif is_scalar and is_u32 %}
 /// A {{ dim }}-dimensional `u32` vector mask.

--- a/src/bool.rs
+++ b/src/bool.rs
@@ -87,13 +87,15 @@ pub use coresimd::bvec4a::BVec4A;
 ))]
 pub use scalar::bvec3a::BVec3A;
 
-#[cfg(not(any(
-    feature = "scalar-math",
-    feature = "core-simd",
-    target_arch = "aarch64",
-    target_feature = "sse2",
-    target_feature = "simd128"
-),))]
+#[cfg(any(
+    not(any(
+        feature = "core-simd",
+        target_arch = "aarch64",
+        target_feature = "sse2",
+        target_feature = "simd128"
+    )),
+    feature = "scalar-math"
+))]
 pub use scalar::bvec4a::BVec4A;
 
 mod const_test_bvec2 {

--- a/src/bool.rs
+++ b/src/bool.rs
@@ -34,47 +34,47 @@ mod wasm32;
 ))]
 mod scalar;
 
-pub use bvec2::BVec2;
-pub use bvec3::BVec3;
-pub use bvec4::BVec4;
+pub use bvec2::{bvec2, BVec2};
+pub use bvec3::{bvec3, BVec3};
+pub use bvec4::{bvec4, BVec4};
 
 #[cfg(all(
     target_arch = "aarch64",
     not(any(feature = "core-simd", feature = "scalar-math"))
 ))]
-pub use neon::bvec3a::BVec3A;
+pub use neon::bvec3a::{bvec3a, BVec3A};
 #[cfg(all(
     target_arch = "aarch64",
     not(any(feature = "core-simd", feature = "scalar-math"))
 ))]
-pub use neon::bvec4a::BVec4A;
+pub use neon::bvec4a::{bvec4a, BVec4A};
 
 #[cfg(all(
     target_feature = "sse2",
     not(any(feature = "core-simd", feature = "scalar-math"))
 ))]
-pub use sse2::bvec3a::BVec3A;
+pub use sse2::bvec3a::{bvec3a, BVec3A};
 #[cfg(all(
     target_feature = "sse2",
     not(any(feature = "core-simd", feature = "scalar-math"))
 ))]
-pub use sse2::bvec4a::BVec4A;
+pub use sse2::bvec4a::{bvec4a, BVec4A};
 
 #[cfg(all(
     target_feature = "simd128",
     not(any(feature = "core-simd", feature = "scalar-math"))
 ))]
-pub use wasm32::bvec3a::BVec3A;
+pub use wasm32::bvec3a::{bvec3a, BVec3A};
 #[cfg(all(
     target_feature = "simd128",
     not(any(feature = "core-simd", feature = "scalar-math"))
 ))]
-pub use wasm32::bvec4a::BVec4A;
+pub use wasm32::bvec4a::{bvec4a, BVec4A};
 
 #[cfg(all(feature = "core-simd", not(feature = "scalar-math")))]
-pub use coresimd::bvec3a::BVec3A;
+pub use coresimd::bvec3a::{bvec3a, BVec3A};
 #[cfg(all(feature = "core-simd", not(feature = "scalar-math")))]
-pub use coresimd::bvec4a::BVec4A;
+pub use coresimd::bvec4a::{bvec4a, BVec4A};
 
 #[cfg(any(
     not(any(
@@ -85,7 +85,7 @@ pub use coresimd::bvec4a::BVec4A;
     )),
     feature = "scalar-math"
 ))]
-pub use scalar::bvec3a::BVec3A;
+pub use scalar::bvec3a::{bvec3a, BVec3A};
 
 #[cfg(any(
     not(any(
@@ -96,7 +96,7 @@ pub use scalar::bvec3a::BVec3A;
     )),
     feature = "scalar-math"
 ))]
-pub use scalar::bvec4a::BVec4A;
+pub use scalar::bvec4a::{bvec4a, BVec4A};
 
 mod const_test_bvec2 {
     const_assert_eq!(1, core::mem::align_of::<super::BVec2>());

--- a/src/bool/bvec2.rs
+++ b/src/bool/bvec2.rs
@@ -4,6 +4,13 @@
 use core::fmt;
 use core::ops::*;
 
+/// Creates a 2-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec2(x: bool, y: bool) -> BVec2 {
+    BVec2::new(x, y)
+}
+
 /// A 2-dimensional `bool` vector mask.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(C, align(1))]

--- a/src/bool/bvec3.rs
+++ b/src/bool/bvec3.rs
@@ -4,6 +4,13 @@
 use core::fmt;
 use core::ops::*;
 
+/// Creates a 3-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec3(x: bool, y: bool, z: bool) -> BVec3 {
+    BVec3::new(x, y, z)
+}
+
 /// A 3-dimensional `bool` vector mask.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(C, align(1))]

--- a/src/bool/bvec4.rs
+++ b/src/bool/bvec4.rs
@@ -4,6 +4,13 @@
 use core::fmt;
 use core::ops::*;
 
+/// Creates a 4-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec4(x: bool, y: bool, z: bool, w: bool) -> BVec4 {
+    BVec4::new(x, y, z, w)
+}
+
 /// A 4-dimensional `bool` vector mask.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(C, align(1))]

--- a/src/bool/coresimd/bvec3a.rs
+++ b/src/bool/coresimd/bvec3a.rs
@@ -12,6 +12,13 @@ union UnionCast {
     v: BVec3A,
 }
 
+/// Creates a 3-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec3a(x: bool, y: bool, z: bool) -> BVec3A {
+    BVec3A::new(x, y, z)
+}
+
 /// A 3-dimensional SIMD vector mask.
 ///
 /// This type is 16 byte aligned.

--- a/src/bool/coresimd/bvec4a.rs
+++ b/src/bool/coresimd/bvec4a.rs
@@ -12,6 +12,13 @@ union UnionCast {
     v: BVec4A,
 }
 
+/// Creates a 4-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec4a(x: bool, y: bool, z: bool, w: bool) -> BVec4A {
+    BVec4A::new(x, y, z, w)
+}
+
 /// A 4-dimensional SIMD vector mask.
 ///
 /// This type is 16 byte aligned.

--- a/src/bool/neon/bvec3a.rs
+++ b/src/bool/neon/bvec3a.rs
@@ -12,6 +12,13 @@ union UnionCast {
     v: BVec3A,
 }
 
+/// Creates a 3-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec3a(x: bool, y: bool, z: bool) -> BVec3A {
+    BVec3A::new(x, y, z)
+}
+
 /// A 3-dimensional SIMD vector mask.
 ///
 /// This type is 16 byte aligned.

--- a/src/bool/neon/bvec4a.rs
+++ b/src/bool/neon/bvec4a.rs
@@ -12,6 +12,13 @@ union UnionCast {
     v: BVec4A,
 }
 
+/// Creates a 4-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec4a(x: bool, y: bool, z: bool, w: bool) -> BVec4A {
+    BVec4A::new(x, y, z, w)
+}
+
 /// A 4-dimensional SIMD vector mask.
 ///
 /// This type is 16 byte aligned.

--- a/src/bool/scalar/bvec3a.rs
+++ b/src/bool/scalar/bvec3a.rs
@@ -4,6 +4,13 @@
 use core::fmt;
 use core::ops::*;
 
+/// Creates a 3-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec3a(x: bool, y: bool, z: bool) -> BVec3A {
+    BVec3A::new(x, y, z)
+}
+
 /// A 3-dimensional `u32` vector mask.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(C, align(16))]

--- a/src/bool/scalar/bvec4a.rs
+++ b/src/bool/scalar/bvec4a.rs
@@ -4,6 +4,13 @@
 use core::fmt;
 use core::ops::*;
 
+/// Creates a 4-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec4a(x: bool, y: bool, z: bool, w: bool) -> BVec4A {
+    BVec4A::new(x, y, z, w)
+}
+
 /// A 4-dimensional `u32` vector mask.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(C, align(16))]

--- a/src/bool/sse2/bvec3a.rs
+++ b/src/bool/sse2/bvec3a.rs
@@ -15,6 +15,13 @@ union UnionCast {
     v: BVec3A,
 }
 
+/// Creates a 3-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec3a(x: bool, y: bool, z: bool) -> BVec3A {
+    BVec3A::new(x, y, z)
+}
+
 /// A 3-dimensional SIMD vector mask.
 ///
 /// This type is 16 byte aligned.

--- a/src/bool/sse2/bvec4a.rs
+++ b/src/bool/sse2/bvec4a.rs
@@ -15,6 +15,13 @@ union UnionCast {
     v: BVec4A,
 }
 
+/// Creates a 4-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec4a(x: bool, y: bool, z: bool, w: bool) -> BVec4A {
+    BVec4A::new(x, y, z, w)
+}
+
 /// A 4-dimensional SIMD vector mask.
 ///
 /// This type is 16 byte aligned.

--- a/src/bool/wasm32/bvec3a.rs
+++ b/src/bool/wasm32/bvec3a.rs
@@ -6,6 +6,13 @@ use core::ops::*;
 
 use core::arch::wasm32::*;
 
+/// Creates a 3-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec3a(x: bool, y: bool, z: bool) -> BVec3A {
+    BVec3A::new(x, y, z)
+}
+
 /// A 3-dimensional SIMD vector mask.
 ///
 /// This type is 16 byte aligned.

--- a/src/bool/wasm32/bvec4a.rs
+++ b/src/bool/wasm32/bvec4a.rs
@@ -6,6 +6,13 @@ use core::ops::*;
 
 use core::arch::wasm32::*;
 
+/// Creates a 4-dimensional `bool` vector mask.
+#[inline(always)]
+#[must_use]
+pub const fn bvec4a(x: bool, y: bool, z: bool, w: bool) -> BVec4A {
+    BVec4A::new(x, y, z, w)
+}
+
 /// A 4-dimensional SIMD vector mask.
 ///
 /// This type is 16 byte aligned.


### PR DESCRIPTION
I noticed that all `BVec*`s are missing the freestanding `fn *vec*()` constructors.