### PR TITLE
Make random quaternions uniformly random (via `Standard`)

### DIFF
--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -84,10 +84,11 @@ macro_rules! impl_float_types {
         impl Distribution<$quat> for Standard {
             #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $quat {
-                let yaw = -PI + rng.gen::<$t>() * 2.0 * PI;
-                let pitch = -PI + rng.gen::<$t>() * 2.0 * PI;
-                let roll = -PI + rng.gen::<$t>() * 2.0 * PI;
-                $quat::from_euler(crate::EulerRot::YXZ, yaw, pitch, roll)
+                let u = rng.gen_range::<$t, _>(0.0..=1.0);
+                let (u1, u2) = ($t::sqrt(1.0 - u), $t::sqrt(u));
+                let (sin1, cos1) = rng.gen_range::<$t, _>(0.0..=TAU).sin_cos();
+                let (sin2, cos2) = rng.gen_range::<$t, _>(0.0..=TAU).sin_cos();
+                $quat::from_xyzw(u1 * sin1, u1 * cos1, u2 * sin2, u2 * cos2)
             }
         }
 
@@ -140,7 +141,7 @@ macro_rules! impl_float_types {
 
 mod f32 {
     use crate::{Mat2, Mat3, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
-    use core::f32::consts::PI;
+    use core::f32::consts::TAU;
     use rand::{
         distributions::{Distribution, Standard},
         Rng,
@@ -169,7 +170,7 @@ mod f32 {
 
 mod f64 {
     use crate::{DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4};
-    use core::f64::consts::PI;
+    use core::f64::consts::TAU;
     use rand::{
         distributions::{Distribution, Standard},
         Rng,

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -84,11 +84,12 @@ macro_rules! impl_float_types {
         impl Distribution<$quat> for Standard {
             #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $quat {
-                let u = rng.gen_range::<$t, _>(0.0..=1.0);
-                let (u1, u2) = ($t::sqrt(1.0 - u), $t::sqrt(u));
-                let (sin1, cos1) = rng.gen_range::<$t, _>(0.0..=TAU).sin_cos();
-                let (sin2, cos2) = rng.gen_range::<$t, _>(0.0..=TAU).sin_cos();
-                $quat::from_xyzw(u1 * sin1, u1 * cos1, u2 * sin2, u2 * cos2)
+                let z = rng.gen_range::<$t, _>(-1.0..=1.0);
+                let (y, x) = math::sin_cos(rng.gen_range::<$t, _>(0.0..TAU));
+                let r = math::sqrt(1.0 - z * z);
+                let axis = $vec3::new(r * x, r * y, z);
+                let angle = rng.gen_range::<$t, _>(0.0..TAU);
+                $quat::from_axis_angle(axis, angle)
             }
         }
 
@@ -140,6 +141,7 @@ macro_rules! impl_float_types {
 }
 
 mod f32 {
+    use crate::f32::math;
     use crate::{Mat2, Mat3, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
     use core::f32::consts::TAU;
     use rand::{
@@ -169,6 +171,7 @@ mod f32 {
 }
 
 mod f64 {
+    use crate::f64::math;
     use crate::{DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4};
     use core::f64::consts::TAU;
     use rand::{


### PR DESCRIPTION
Previously, randomly sampled `Quat`s had bias because they were constructed using Euler rotation sequences. This PR makes them follow a uniform distribution. The algorithm used is the one described [here](https://web.archive.org/web/20180724074257/http://planning.cs.uiuc.edu/node198.html). 

This is essentially a follow-up from [this bevy_math PR](https://github.com/bevyengine/bevy/pull/12857), which affords users the ability to ergonomically obtain random directions and quaternions.

I believe that this implementation also conforms more closely with the philosophy of [Standard](https://docs.rs/rand/latest/rand/distributions/struct.Standard.html): since the space of quaternions is compact, it is quite natural for the "default" distribution over them to be uniform. 

Furthermore, if a user wants the old distribution, it is easily implemented using just `Rng::gen_range` and `Quat`'s constructors; the present implementation actually bundles relatively specialized knowledge into an interface, which abstracts difficulties away from users.