### PR TITLE
div_ceil for UVec

### DIFF
--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -2584,6 +2584,19 @@ impl {{ self_t }} {
                 {%- endfor %}
             }
         }
+
+        /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+        ///
+        /// In other words this computes `[self.x.div_ceil(rhs), self.y.div_ceil(rhs), ..]`.
+        #[inline]
+        #[must_use]
+        pub const fn div_ceil_scalar(self, rhs: {{ scalar_t }}) -> Self {
+            Self {
+                {% for c in components %}
+                    {{ c }}: div_ceil_{{ scalar_t }}(self.{{ c }}, rhs),
+                {%- endfor %}
+            }
+        }
     {% endif %}
 {% endif %}
 }

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -191,6 +191,10 @@
     {% endif %}
 };
 
+{% if is_scalar and not is_signed %}
+use crate::{{ scalar_t }}::div_ceil_{{ scalar_t }};
+{% endif %}
+
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -2564,6 +2568,19 @@ impl {{ self_t }} {
             Self {
                 {% for c in components %}
                     {{ c }}: self.{{ c }}.saturating_add_signed(rhs.{{ c }}),
+                {%- endfor %}
+            }
+        }
+
+        /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+        ///
+        /// In other words this computes `[self.x.div_ceil(rhs.x), self.y.div_ceil(rhs.y), ..]`.
+        #[inline]
+        #[must_use]
+        pub const fn div_ceil(self, rhs: Self) -> Self {
+            Self {
+                {% for c in components %}
+                    {{ c }}: div_ceil_{{ scalar_t }}(self.{{ c }}, rhs.{{ c }}),
                 {%- endfor %}
             }
         }

--- a/src/u16.rs
+++ b/src/u16.rs
@@ -42,3 +42,17 @@ mod test {
         const_assert_eq!(8, core::mem::align_of::<super::U16Vec4>());
     }
 }
+
+/// rustc implementation from 1.73
+#[inline]
+#[track_caller]
+const fn div_ceil_u16(lhs: u16, rhs: u16) -> u16 {
+    let d = lhs / rhs;
+    let r = lhs % rhs;
+    if r > 0 {
+        d + 1
+    } else {
+        d
+    }
+}
+

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -478,6 +478,18 @@ impl U16Vec2 {
             y: div_ceil_u16(self.y, rhs.y),
         }
     }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs), self.y.div_ceil(rhs), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil_scalar(self, rhs: u16) -> Self {
+        Self {
+            x: div_ceil_u16(self.x, rhs),
+            y: div_ceil_u16(self.y, rhs),
+        }
+    }
 }
 
 impl Default for U16Vec2 {

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -2,6 +2,8 @@
 
 use crate::{BVec2, I16Vec2, I64Vec2, IVec2, U16Vec3, U64Vec2, UVec2};
 
+use crate::u16::div_ceil_u16;
+
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -462,6 +464,18 @@ impl U16Vec2 {
         Self {
             x: self.x.saturating_add_signed(rhs.x),
             y: self.y.saturating_add_signed(rhs.y),
+        }
+    }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs.x), self.y.div_ceil(rhs.y), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil(self, rhs: Self) -> Self {
+        Self {
+            x: div_ceil_u16(self.x, rhs.x),
+            y: div_ceil_u16(self.y, rhs.y),
         }
     }
 }

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -2,6 +2,8 @@
 
 use crate::{BVec3, BVec3A, I16Vec3, I64Vec3, IVec3, U16Vec2, U16Vec4, U64Vec3, UVec3};
 
+use crate::u16::div_ceil_u16;
+
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -527,6 +529,19 @@ impl U16Vec3 {
             x: self.x.saturating_add_signed(rhs.x),
             y: self.y.saturating_add_signed(rhs.y),
             z: self.z.saturating_add_signed(rhs.z),
+        }
+    }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs.x), self.y.div_ceil(rhs.y), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil(self, rhs: Self) -> Self {
+        Self {
+            x: div_ceil_u16(self.x, rhs.x),
+            y: div_ceil_u16(self.y, rhs.y),
+            z: div_ceil_u16(self.z, rhs.z),
         }
     }
 }

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -544,6 +544,19 @@ impl U16Vec3 {
             z: div_ceil_u16(self.z, rhs.z),
         }
     }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs), self.y.div_ceil(rhs), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil_scalar(self, rhs: u16) -> Self {
+        Self {
+            x: div_ceil_u16(self.x, rhs),
+            y: div_ceil_u16(self.y, rhs),
+            z: div_ceil_u16(self.z, rhs),
+        }
+    }
 }
 
 impl Default for U16Vec3 {

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -4,6 +4,8 @@
 use crate::BVec4A;
 use crate::{BVec4, I16Vec4, I64Vec4, IVec4, U16Vec2, U16Vec3, U64Vec4, UVec4};
 
+use crate::u16::div_ceil_u16;
+
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -557,6 +559,20 @@ impl U16Vec4 {
             y: self.y.saturating_add_signed(rhs.y),
             z: self.z.saturating_add_signed(rhs.z),
             w: self.w.saturating_add_signed(rhs.w),
+        }
+    }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs.x), self.y.div_ceil(rhs.y), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil(self, rhs: Self) -> Self {
+        Self {
+            x: div_ceil_u16(self.x, rhs.x),
+            y: div_ceil_u16(self.y, rhs.y),
+            z: div_ceil_u16(self.z, rhs.z),
+            w: div_ceil_u16(self.w, rhs.w),
         }
     }
 }

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -575,6 +575,20 @@ impl U16Vec4 {
             w: div_ceil_u16(self.w, rhs.w),
         }
     }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs), self.y.div_ceil(rhs), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil_scalar(self, rhs: u16) -> Self {
+        Self {
+            x: div_ceil_u16(self.x, rhs),
+            y: div_ceil_u16(self.y, rhs),
+            z: div_ceil_u16(self.z, rhs),
+            w: div_ceil_u16(self.w, rhs),
+        }
+    }
 }
 
 impl Default for U16Vec4 {

--- a/src/u32.rs
+++ b/src/u32.rs
@@ -42,3 +42,17 @@ mod test {
         const_assert_eq!(16, core::mem::align_of::<super::UVec4>());
     }
 }
+
+
+/// rustc implementation from 1.73
+#[inline]
+#[track_caller]
+const fn div_ceil_u32(lhs: u32, rhs: u32) -> u32 {
+    let d = lhs / rhs;
+    let r = lhs % rhs;
+    if r > 0 {
+        d + 1
+    } else {
+        d
+    }
+}

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -478,6 +478,18 @@ impl UVec2 {
             y: div_ceil_u32(self.y, rhs.y),
         }
     }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs), self.y.div_ceil(rhs), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil_scalar(self, rhs: u32) -> Self {
+        Self {
+            x: div_ceil_u32(self.x, rhs),
+            y: div_ceil_u32(self.y, rhs),
+        }
+    }
 }
 
 impl Default for UVec2 {

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -2,6 +2,8 @@
 
 use crate::{BVec2, I16Vec2, I64Vec2, IVec2, U16Vec2, U64Vec2, UVec3};
 
+use crate::u32::div_ceil_u32;
+
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -462,6 +464,18 @@ impl UVec2 {
         Self {
             x: self.x.saturating_add_signed(rhs.x),
             y: self.y.saturating_add_signed(rhs.y),
+        }
+    }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs.x), self.y.div_ceil(rhs.y), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil(self, rhs: Self) -> Self {
+        Self {
+            x: div_ceil_u32(self.x, rhs.x),
+            y: div_ceil_u32(self.y, rhs.y),
         }
     }
 }

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -2,6 +2,8 @@
 
 use crate::{BVec3, BVec3A, I16Vec3, I64Vec3, IVec3, U16Vec3, U64Vec3, UVec2, UVec4};
 
+use crate::u32::div_ceil_u32;
+
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -527,6 +529,19 @@ impl UVec3 {
             x: self.x.saturating_add_signed(rhs.x),
             y: self.y.saturating_add_signed(rhs.y),
             z: self.z.saturating_add_signed(rhs.z),
+        }
+    }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs.x), self.y.div_ceil(rhs.y), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil(self, rhs: Self) -> Self {
+        Self {
+            x: div_ceil_u32(self.x, rhs.x),
+            y: div_ceil_u32(self.y, rhs.y),
+            z: div_ceil_u32(self.z, rhs.z),
         }
     }
 }

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -544,6 +544,19 @@ impl UVec3 {
             z: div_ceil_u32(self.z, rhs.z),
         }
     }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs), self.y.div_ceil(rhs), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil_scalar(self, rhs: u32) -> Self {
+        Self {
+            x: div_ceil_u32(self.x, rhs),
+            y: div_ceil_u32(self.y, rhs),
+            z: div_ceil_u32(self.z, rhs),
+        }
+    }
 }
 
 impl Default for UVec3 {

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -4,6 +4,8 @@
 use crate::BVec4A;
 use crate::{BVec4, I16Vec4, I64Vec4, IVec4, U16Vec4, U64Vec4, UVec2, UVec3};
 
+use crate::u32::div_ceil_u32;
+
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -557,6 +559,20 @@ impl UVec4 {
             y: self.y.saturating_add_signed(rhs.y),
             z: self.z.saturating_add_signed(rhs.z),
             w: self.w.saturating_add_signed(rhs.w),
+        }
+    }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs.x), self.y.div_ceil(rhs.y), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil(self, rhs: Self) -> Self {
+        Self {
+            x: div_ceil_u32(self.x, rhs.x),
+            y: div_ceil_u32(self.y, rhs.y),
+            z: div_ceil_u32(self.z, rhs.z),
+            w: div_ceil_u32(self.w, rhs.w),
         }
     }
 }

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -575,6 +575,20 @@ impl UVec4 {
             w: div_ceil_u32(self.w, rhs.w),
         }
     }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs), self.y.div_ceil(rhs), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil_scalar(self, rhs: u32) -> Self {
+        Self {
+            x: div_ceil_u32(self.x, rhs),
+            y: div_ceil_u32(self.y, rhs),
+            z: div_ceil_u32(self.z, rhs),
+            w: div_ceil_u32(self.w, rhs),
+        }
+    }
 }
 
 impl Default for UVec4 {

--- a/src/u64.rs
+++ b/src/u64.rs
@@ -42,3 +42,16 @@ mod test {
         const_assert_eq!(16, core::mem::align_of::<super::U64Vec4>());
     }
 }
+
+/// rustc implementation from 1.73
+#[inline]
+#[track_caller]
+const fn div_ceil_u64(lhs: u64, rhs: u64) -> u64 {
+    let d = lhs / rhs;
+    let r = lhs % rhs;
+    if r > 0 {
+        d + 1
+    } else {
+        d
+    }
+}

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -478,6 +478,18 @@ impl U64Vec2 {
             y: div_ceil_u64(self.y, rhs.y),
         }
     }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs), self.y.div_ceil(rhs), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil_scalar(self, rhs: u64) -> Self {
+        Self {
+            x: div_ceil_u64(self.x, rhs),
+            y: div_ceil_u64(self.y, rhs),
+        }
+    }
 }
 
 impl Default for U64Vec2 {

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -2,6 +2,8 @@
 
 use crate::{BVec2, I16Vec2, I64Vec2, IVec2, U16Vec2, U64Vec3, UVec2};
 
+use crate::u64::div_ceil_u64;
+
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -462,6 +464,18 @@ impl U64Vec2 {
         Self {
             x: self.x.saturating_add_signed(rhs.x),
             y: self.y.saturating_add_signed(rhs.y),
+        }
+    }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs.x), self.y.div_ceil(rhs.y), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil(self, rhs: Self) -> Self {
+        Self {
+            x: div_ceil_u64(self.x, rhs.x),
+            y: div_ceil_u64(self.y, rhs.y),
         }
     }
 }

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -544,6 +544,19 @@ impl U64Vec3 {
             z: div_ceil_u64(self.z, rhs.z),
         }
     }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs), self.y.div_ceil(rhs), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil_scalar(self, rhs: u64) -> Self {
+        Self {
+            x: div_ceil_u64(self.x, rhs),
+            y: div_ceil_u64(self.y, rhs),
+            z: div_ceil_u64(self.z, rhs),
+        }
+    }
 }
 
 impl Default for U64Vec3 {

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -2,6 +2,8 @@
 
 use crate::{BVec3, BVec3A, I16Vec3, I64Vec3, IVec3, U16Vec3, U64Vec2, U64Vec4, UVec3};
 
+use crate::u64::div_ceil_u64;
+
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -527,6 +529,19 @@ impl U64Vec3 {
             x: self.x.saturating_add_signed(rhs.x),
             y: self.y.saturating_add_signed(rhs.y),
             z: self.z.saturating_add_signed(rhs.z),
+        }
+    }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs.x), self.y.div_ceil(rhs.y), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil(self, rhs: Self) -> Self {
+        Self {
+            x: div_ceil_u64(self.x, rhs.x),
+            y: div_ceil_u64(self.y, rhs.y),
+            z: div_ceil_u64(self.z, rhs.z),
         }
     }
 }

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -575,6 +575,20 @@ impl U64Vec4 {
             w: div_ceil_u64(self.w, rhs.w),
         }
     }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs), self.y.div_ceil(rhs), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil_scalar(self, rhs: u64) -> Self {
+        Self {
+            x: div_ceil_u64(self.x, rhs),
+            y: div_ceil_u64(self.y, rhs),
+            z: div_ceil_u64(self.z, rhs),
+            w: div_ceil_u64(self.w, rhs),
+        }
+    }
 }
 
 impl Default for U64Vec4 {

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -4,6 +4,8 @@
 use crate::BVec4A;
 use crate::{BVec4, I16Vec4, I64Vec4, IVec4, U16Vec4, U64Vec2, U64Vec3, UVec4};
 
+use crate::u64::div_ceil_u64;
+
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -557,6 +559,20 @@ impl U64Vec4 {
             y: self.y.saturating_add_signed(rhs.y),
             z: self.z.saturating_add_signed(rhs.z),
             w: self.w.saturating_add_signed(rhs.w),
+        }
+    }
+
+    /// Returns a vector containing quotient of `self` and `rhs`, rounding the result towards positive infinity.
+    ///
+    /// In other words this computes `[self.x.div_ceil(rhs.x), self.y.div_ceil(rhs.y), ..]`.
+    #[inline]
+    #[must_use]
+    pub const fn div_ceil(self, rhs: Self) -> Self {
+        Self {
+            x: div_ceil_u64(self.x, rhs.x),
+            y: div_ceil_u64(self.y, rhs.y),
+            z: div_ceil_u64(self.z, rhs.z),
+            w: div_ceil_u64(self.w, rhs.w),
         }
     }
 }

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -1799,6 +1799,13 @@ mod uvec2 {
         );
     });
 
+    glam_test!(test_div_ceil_scalar, {
+        assert_eq!(
+            UVec2::new(11, 12).div_ceil_scalar(4),
+            UVec2::new(3, 3)
+        );
+    });
+
     impl_vec2_tests!(u32, uvec2, UVec2, UVec3, BVec2, bvec2);
     impl_vec2_eq_hash_tests!(u32, uvec2);
 

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -1792,6 +1792,13 @@ mod uvec2 {
         );
     });
 
+    glam_test!(test_div_ceil, {
+        assert_eq!(
+            UVec2::new(11, 12).div_ceil(UVec2::new(2, 3)),
+            UVec2::new(6, 4)
+        );
+    });
+
     impl_vec2_tests!(u32, uvec2, UVec2, UVec3, BVec2, bvec2);
     impl_vec2_eq_hash_tests!(u32, uvec2);
 

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -1843,6 +1843,13 @@ mod u16vec3 {
         );
     });
 
+    glam_test!(test_div_ceil, {
+        assert_eq!(
+            U16Vec3::new(11, 12, 0).div_ceil(U16Vec3::new(2, 3, 1)),
+            U16Vec3::new(6, 4, 0)
+        );
+    });
+
     impl_vec3_tests!(u16, u16vec3, U16Vec3, BVec3, bvec3);
     impl_vec3_eq_hash_tests!(u16, u16vec3);
 

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -1850,6 +1850,13 @@ mod u16vec3 {
         );
     });
 
+    glam_test!(test_div_ceil_scalar, {
+        assert_eq!(
+            U16Vec3::new(11, 12, 0).div_ceil_scalar(5),
+            U16Vec3::new(3, 3, 0)
+        );
+    });
+
     impl_vec3_tests!(u16, u16vec3, U16Vec3, BVec3, bvec3);
     impl_vec3_eq_hash_tests!(u16, u16vec3);
 

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -2517,6 +2517,13 @@ mod u64vec4 {
         );
     });
 
+    glam_test!(test_div_ceil, {
+        assert_eq!(
+            U64Vec4::new(11, 12, 0, 12345).div_ceil(U64Vec4::new(2, 3, 1, u64::MAX)),
+            U64Vec4::new(6, 4, 0, 1)
+        );
+    });
+
     impl_vec4_tests!(u64, u64vec4, U64Vec4, U64Vec3, U64Vec2, BVec4, bvec4);
     impl_vec4_eq_hash_tests!(u64, u64vec4);
 

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -2524,6 +2524,13 @@ mod u64vec4 {
         );
     });
 
+    glam_test!(test_div_ceil_scalar, {
+        assert_eq!(
+            U64Vec4::new(11, 12, 0, 12345).div_ceil_scalar(1000),
+            U64Vec4::new(1, 1, 0, 13)
+        );
+    });
+
     impl_vec4_tests!(u64, u64vec4, U64Vec4, U64Vec3, U64Vec2, BVec4, bvec4);
     impl_vec4_eq_hash_tests!(u64, u64vec4);
 


### PR DESCRIPTION
Convenience function for divison with rounding up. It's handy for things like `let num_tiles = world_size.div_ceil(tile_size);`

It's only for unsigned scalars, because Rust hasn't stabilized `div_ceil` for other types yet. I've copied `div_ceil` implementation to keep MSRV under 1.73. 