### PR TITLE
Generic mapping function for vectors

### DIFF
--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -411,6 +411,20 @@ impl {{ self_t }} {
         {% endif %}
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn({{ scalar_t }}) -> {{ scalar_t }},
+    {
+        Self::new(
+            {% for c in components %}
+                f(self.{{ c }}),
+            {%- endfor %}
+        )
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -1842,20 +1856,6 @@ impl {{ self_t }} {
         {% else %}
             unimplemented!()
         {% endif %}
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn({{ scalar_t }}) -> {{ scalar_t }},
-    {
-        Self::new(
-            {% for c in components %}
-                f(self.{{ c }}),
-            {%- endfor %}
-        )
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -1844,6 +1844,20 @@ impl {{ self_t }} {
         {% endif %}
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn({{ scalar_t }}) -> {{ scalar_t }},
+    {
+        Self::new(
+            {% for c in components %}
+                {{ c }}: f(self.{{ c }}),
+            {%- endfor %}
+        )
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -1853,7 +1853,7 @@ impl {{ self_t }} {
     {
         Self::new(
             {% for c in components %}
-                {{ c }}: f(self.{{ c }}),
+                f(self.{{ c }}),
             {%- endfor %}
         )
     }

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -90,6 +90,16 @@ impl Vec3A {
         Self(Simd::from_array([v; 4]))
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -705,16 +715,6 @@ impl Vec3A {
     #[must_use]
     pub fn recip(self) -> Self {
         Self(self.0.recip())
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -707,6 +707,16 @@ impl Vec3A {
         Self(self.0.recip())
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -92,6 +92,16 @@ impl Vec4 {
         Self(Simd::from_array([v; 4]))
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -692,16 +702,6 @@ impl Vec4 {
     #[must_use]
     pub fn recip(self) -> Self {
         Self(self.0.recip())
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -694,6 +694,16 @@ impl Vec4 {
         Self(self.0.recip())
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -95,6 +95,16 @@ impl Vec3A {
         unsafe { UnionCast { a: [v; 4] }.v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -749,16 +759,6 @@ impl Vec3A {
     #[must_use]
     pub fn recip(self) -> Self {
         Self(unsafe { vdivq_f32(Self::ONE.0, self.0) })
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -751,6 +751,16 @@ impl Vec3A {
         Self(unsafe { vdivq_f32(Self::ONE.0, self.0) })
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -728,6 +728,16 @@ impl Vec4 {
         Self(unsafe { vdivq_f32(Self::ONE.0, self.0) })
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -97,6 +97,16 @@ impl Vec4 {
         unsafe { UnionCast { a: [v; 4] }.v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -726,16 +736,6 @@ impl Vec4 {
     #[must_use]
     pub fn recip(self) -> Self {
         Self(unsafe { vdivq_f32(Self::ONE.0, self.0) })
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -93,6 +93,16 @@ impl Vec3A {
         Self { x: v, y: v, z: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -748,16 +758,6 @@ impl Vec3A {
             y: 1.0 / self.y,
             z: 1.0 / self.z,
         }
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -750,6 +750,16 @@ impl Vec3A {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -111,6 +111,16 @@ impl Vec4 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -806,16 +816,6 @@ impl Vec4 {
             z: 1.0 / self.z,
             w: 1.0 / self.w,
         }
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -808,6 +808,16 @@ impl Vec4 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -98,6 +98,16 @@ impl Vec3A {
         unsafe { UnionCast { a: [v; 4] }.v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -748,16 +758,6 @@ impl Vec3A {
     #[must_use]
     pub fn recip(self) -> Self {
         Self(unsafe { _mm_div_ps(Self::ONE.0, self.0) })
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -750,6 +750,16 @@ impl Vec3A {
         Self(unsafe { _mm_div_ps(Self::ONE.0, self.0) })
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -736,6 +736,16 @@ impl Vec4 {
         Self(unsafe { _mm_div_ps(Self::ONE.0, self.0) })
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -100,6 +100,16 @@ impl Vec4 {
         unsafe { UnionCast { a: [v; 4] }.v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -734,16 +744,6 @@ impl Vec4 {
     #[must_use]
     pub fn recip(self) -> Self {
         Self(unsafe { _mm_div_ps(Self::ONE.0, self.0) })
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -673,6 +673,16 @@ impl Vec2 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -78,6 +78,16 @@ impl Vec2 {
         Self { x: v, y: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -671,16 +681,6 @@ impl Vec2 {
             x: 1.0 / self.x,
             y: 1.0 / self.y,
         }
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -84,6 +84,16 @@ impl Vec3 {
         Self { x: v, y: v, z: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -738,16 +748,6 @@ impl Vec3 {
             y: 1.0 / self.y,
             z: 1.0 / self.z,
         }
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -740,6 +740,16 @@ impl Vec3 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -89,6 +89,16 @@ impl Vec3A {
         Self(f32x4(v, v, v, v))
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -716,16 +726,6 @@ impl Vec3A {
     #[must_use]
     pub fn recip(self) -> Self {
         Self(f32x4_div(Self::ONE.0, self.0))
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -718,6 +718,16 @@ impl Vec3A {
         Self(f32x4_div(Self::ONE.0, self.0))
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -91,6 +91,16 @@ impl Vec4 {
         Self(f32x4(v, v, v, v))
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -709,16 +719,6 @@ impl Vec4 {
     #[must_use]
     pub fn recip(self) -> Self {
         Self(f32x4_div(Self::ONE.0, self.0))
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f32) -> f32,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -711,6 +711,16 @@ impl Vec4 {
         Self(f32x4_div(Self::ONE.0, self.0))
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f32) -> f32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -78,6 +78,16 @@ impl DVec2 {
         Self { x: v, y: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
+        Self::new(f(self.x), f(self.y))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -671,16 +681,6 @@ impl DVec2 {
             x: 1.0 / self.x,
             y: 1.0 / self.y,
         }
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f64) -> f64,
-    {
-        Self::new(f(self.x), f(self.y))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -673,6 +673,16 @@ impl DVec2 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
+        Self::new(f(self.x), f(self.y))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -84,6 +84,16 @@ impl DVec3 {
         Self { x: v, y: v, z: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -738,16 +748,6 @@ impl DVec3 {
             y: 1.0 / self.y,
             z: 1.0 / self.z,
         }
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f64) -> f64,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -740,6 +740,16 @@ impl DVec3 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -797,6 +797,16 @@ impl DVec4 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
     ///
     /// When `s` is `0.0`, the result will be equal to `self`.  When `s` is `1.0`, the result

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -102,6 +102,16 @@ impl DVec4 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(f64) -> f64,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///
@@ -795,16 +805,6 @@ impl DVec4 {
             z: 1.0 / self.z,
             w: 1.0 / self.w,
         }
-    }
-
-    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
-    #[inline]
-    #[must_use]
-    pub fn map<F>(self, f: F) -> Self
-    where
-        F: Fn(f64) -> f64,
-    {
-        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -70,6 +70,16 @@ impl I16Vec2 {
         Self { x: v, y: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(i16) -> i16,
+    {
+        Self::new(f(self.x), f(self.y))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -76,6 +76,16 @@ impl I16Vec3 {
         Self { x: v, y: v, z: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(i16) -> i16,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -94,6 +94,16 @@ impl I16Vec4 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(i16) -> i16,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -70,6 +70,16 @@ impl IVec2 {
         Self { x: v, y: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(i32) -> i32,
+    {
+        Self::new(f(self.x), f(self.y))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -76,6 +76,16 @@ impl IVec3 {
         Self { x: v, y: v, z: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(i32) -> i32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -94,6 +94,16 @@ impl IVec4 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(i32) -> i32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -70,6 +70,16 @@ impl I64Vec2 {
         Self { x: v, y: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(i64) -> i64,
+    {
+        Self::new(f(self.x), f(self.y))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -76,6 +76,16 @@ impl I64Vec3 {
         Self { x: v, y: v, z: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(i64) -> i64,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -94,6 +94,16 @@ impl I64Vec4 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(i64) -> i64,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -61,6 +61,16 @@ impl U16Vec2 {
         Self { x: v, y: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(u16) -> u16,
+    {
+        Self::new(f(self.x), f(self.y))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -64,6 +64,16 @@ impl U16Vec3 {
         Self { x: v, y: v, z: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(u16) -> u16,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -79,6 +79,16 @@ impl U16Vec4 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(u16) -> u16,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -61,6 +61,16 @@ impl UVec2 {
         Self { x: v, y: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(u32) -> u32,
+    {
+        Self::new(f(self.x), f(self.y))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -64,6 +64,16 @@ impl UVec3 {
         Self { x: v, y: v, z: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(u32) -> u32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -79,6 +79,16 @@ impl UVec4 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(u32) -> u32,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -61,6 +61,16 @@ impl U64Vec2 {
         Self { x: v, y: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(u64) -> u64,
+    {
+        Self::new(f(self.x), f(self.y))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -64,6 +64,16 @@ impl U64Vec3 {
         Self { x: v, y: v, z: v }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(u64) -> u64,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -79,6 +79,16 @@ impl U64Vec4 {
         }
     }
 
+    /// Returns a vector containing each element of `self` modified by a mapping function `f`.
+    #[inline]
+    #[must_use]
+    pub fn map<F>(self, f: F) -> Self
+    where
+        F: Fn(u64) -> u64,
+    {
+        Self::new(f(self.x), f(self.y), f(self.z), f(self.w))
+    }
+
     /// Creates a vector from the elements in `if_true` and `if_false`, selecting which to use
     /// for each element of `self`.
     ///

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -86,10 +86,7 @@ macro_rules! impl_vec2_tests {
 
         glam_test!(test_map, {
             let v = $vec2::new(1 as $t, 2 as $t);
-            assert_eq!(
-                v.map(|n| n + 3 as $t),
-                v + $vec2::splat(3 as $t)
-            );
+            assert_eq!(v.map(|n| n + 3 as $t), v + $vec2::splat(3 as $t));
             assert_eq!(v.map(|_| 0 as $t), $vec2::ZERO);
         });
 

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -904,6 +904,14 @@ macro_rules! impl_vec2_float_tests {
             );
         });
 
+        glam_test!(test_map, {
+            assert_approx_eq!(
+                $vec2::new(1.0, 2.0).map(|n| n + 3.0),
+                $vec2::new(1.0, 2.0) + $vec2::splat(3.0)
+            );
+            assert_approx_eq!($vec2::new(1.0, 2.0).map(|_| 0.0), $vec2::ZERO);
+        });
+
         glam_test!(test_angle_to, {
             let angle = $vec2::new(1.0, 0.0).angle_to($vec2::new(0.0, 1.0));
             assert_approx_eq!(core::$t::consts::FRAC_PI_2, angle, 1e-6);

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -84,6 +84,15 @@ macro_rules! impl_vec2_tests {
             assert_eq!($vec2::ONE, v);
         });
 
+        glam_test!(test_map, {
+            let v = $vec2::new(1 as $t, 2 as $t);
+            assert_eq!(
+                v.map(|n| n + 3 as $t),
+                v + $vec2::splat(3 as $t)
+            );
+            assert_eq!(v.map(|_| 0 as $t), $vec2::ZERO);
+        });
+
         glam_test!(test_with, {
             assert_eq!($vec2::X, $vec2::ZERO.with_x(1 as $t));
             assert_eq!($vec2::Y, $vec2::ZERO.with_y(1 as $t));
@@ -902,14 +911,6 @@ macro_rules! impl_vec2_float_tests {
                 $vec2::new(1.0, 2.0).exp(),
                 $vec2::new((1.0 as $t).exp(), (2.0 as $t).exp())
             );
-        });
-
-        glam_test!(test_map, {
-            assert_approx_eq!(
-                $vec2::new(1.0, 2.0).map(|n| n + 3.0),
-                $vec2::new(1.0, 2.0) + $vec2::splat(3.0)
-            );
-            assert_approx_eq!($vec2::new(1.0, 2.0).map(|_| 0.0), $vec2::ZERO);
         });
 
         glam_test!(test_angle_to, {

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -112,10 +112,7 @@ macro_rules! impl_vec3_tests {
 
         glam_test!(test_map, {
             let v = $vec3::new(1 as $t, 2 as $t, 3 as $t);
-            assert_eq!(
-                v.map(|n| n + 3 as $t),
-                v + $vec3::splat(3 as $t)
-            );
+            assert_eq!(v.map(|n| n + 3 as $t), v + $vec3::splat(3 as $t));
             assert_eq!(v.map(|_| 0 as $t), $vec3::ZERO);
         });
 

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -1027,7 +1027,7 @@ macro_rules! impl_vec3_float_tests {
                 $vec3::new(1.0, 2.0, 3.0).map(|n| n + 3.0),
                 $vec3::new(1.0, 2.0, 3.0) + $vec3::splat(3.0)
             );
-            assert_approx_eq!($vec3::new(1.0, 2.0, 3.0).map(|n| 1.0), $vec3::splat(1.0));
+            assert_approx_eq!($vec3::new(1.0, 2.0, 3.0).map(|_| 0.0), $vec3::ZERO);
         });
 
         glam_test!(test_angle_between, {

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -110,6 +110,15 @@ macro_rules! impl_vec3_tests {
             assert_eq!($vec3::ONE, v);
         });
 
+        glam_test!(test_map, {
+            let v = $vec3::new(1 as $t, 2 as $t, 3 as $t);
+            assert_eq!(
+                v.map(|n| n + 3 as $t),
+                v + $vec3::splat(3 as $t)
+            );
+            assert_eq!(v.map(|_| 0 as $t), $vec3::ZERO);
+        });
+
         glam_test!(test_with, {
             assert_eq!($vec3::X, $vec3::ZERO.with_x(1 as $t));
             assert_eq!($vec3::Y, $vec3::ZERO.with_y(1 as $t));
@@ -1020,14 +1029,6 @@ macro_rules! impl_vec3_float_tests {
                 $vec3::new(1.0, 2.0, 3.0).exp(),
                 $vec3::new((1.0 as $t).exp(), (2.0 as $t).exp(), (3.0 as $t).exp())
             );
-        });
-
-        glam_test!(test_map, {
-            assert_approx_eq!(
-                $vec3::new(1.0, 2.0, 3.0).map(|n| n + 3.0),
-                $vec3::new(1.0, 2.0, 3.0) + $vec3::splat(3.0)
-            );
-            assert_approx_eq!($vec3::new(1.0, 2.0, 3.0).map(|_| 0.0), $vec3::ZERO);
         });
 
         glam_test!(test_angle_between, {

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -1022,6 +1022,14 @@ macro_rules! impl_vec3_float_tests {
             );
         });
 
+        glam_test!(test_map, {
+            assert_approx_eq!(
+                $vec3::new(1.0, 2.0, 3.0).map(|n| n + 3.0),
+                $vec3::new(1.0, 2.0, 3.0) + $vec3::splat(3.0)
+            );
+            assert_approx_eq!($vec3::new(1.0, 2.0, 3.0).map(|n| 1.0), $vec3::splat(1.0));
+        });
+
         glam_test!(test_angle_between, {
             let angle = $vec3::new(1.0, 0.0, 1.0).angle_between($vec3::new(1.0, 1.0, 0.0));
             assert_approx_eq!(core::$t::consts::FRAC_PI_3, angle, 1e-6);

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1165,6 +1165,14 @@ macro_rules! impl_vec4_float_tests {
             );
         });
 
+        glam_test!(test_map, {
+            assert_approx_eq!(
+                $vec4::new(1.0, 2.0, 3.0, 4.0).map(|n| n + 3.0),
+                $vec4::new(1.0, 2.0, 3.0, 4.0) + $vec4::splat(3.0)
+            );
+            assert_approx_eq!($vec4::new(1.0, 2.0, 3.0, 4.0).map(|_| 0.0), $vec4::ZERO);
+        });
+
         glam_test!(test_clamp_length, {
             // Too long gets shortened
             assert_eq!(

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -154,10 +154,7 @@ macro_rules! impl_vec4_tests {
 
         glam_test!(test_map, {
             let v = $vec4::new(1 as $t, 2 as $t, 3 as $t, 4 as $t);
-            assert_eq!(
-                v.map(|n| n + 3 as $t),
-                v + $vec4::splat(3 as $t)
-            );
+            assert_eq!(v.map(|n| n + 3 as $t), v + $vec4::splat(3 as $t));
             assert_eq!(v.map(|_| 0 as $t), $vec4::ZERO);
         });
 

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -152,6 +152,15 @@ macro_rules! impl_vec4_tests {
             assert_eq!($vec4::ONE, v);
         });
 
+        glam_test!(test_map, {
+            let v = $vec4::new(1 as $t, 2 as $t, 3 as $t, 4 as $t);
+            assert_eq!(
+                v.map(|n| n + 3 as $t),
+                v + $vec4::splat(3 as $t)
+            );
+            assert_eq!(v.map(|_| 0 as $t), $vec4::ZERO);
+        });
+
         glam_test!(test_with, {
             assert_eq!($vec4::X, $vec4::ZERO.with_x(1 as $t));
             assert_eq!($vec4::Y, $vec4::ZERO.with_y(1 as $t));
@@ -1163,14 +1172,6 @@ macro_rules! impl_vec4_float_tests {
                 ),
                 1e-5
             );
-        });
-
-        glam_test!(test_map, {
-            assert_approx_eq!(
-                $vec4::new(1.0, 2.0, 3.0, 4.0).map(|n| n + 3.0),
-                $vec4::new(1.0, 2.0, 3.0, 4.0) + $vec4::splat(3.0)
-            );
-            assert_approx_eq!($vec4::new(1.0, 2.0, 3.0, 4.0).map(|_| 0.0), $vec4::ZERO);
         });
 
         glam_test!(test_clamp_length, {


### PR DESCRIPTION
Hi! Sorry I didn't make a discussion about this first, didn't read the guidelines until I already wrote this up, so figured I might as well post the PR.

This adds a generic mapping function that acts on all of the elements of a vector. Adding it to matrices as well might be useful, but my use cases for this has always just been vectors so far. I'm happy to add it to matrices if you think that'd be good for consistency's sake.

The use case, as an example, I had recently was taking any vector element in a normal below some `EPSILON` and setting it to 0.0, since the collision normal that was generated was a little bit finnicky. I don't see that use case alone as very useful in the library, but allowing per-element operations definitely is imo.