### PR TITLE
Add wasm-bindgen feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,13 +43,14 @@ core-simd = []
 
 [dependencies]
 approx = { version = "0.5", optional = true, default-features = false }
+bytecheck = { version = "0.7", optional = true, default-features = false }
 bytemuck = { version = "1.9", optional = true, default-features = false }
+libm = { version = "0.2", optional = true, default-features = false}
 mint = { version = "0.5.8", optional = true, default-features = false }
 rand = { version = "0.8", optional = true, default-features = false }
-serde = { version = "1.0", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
-bytecheck = { version = "0.7", optional = true, default-features = false }
-libm = { version = "0.2", optional = true, default-features = false}
+serde = { version = "1.0", optional = true, default-features = false }
+wasm-bindgen = { version = "0.2", optional = true, default-features = false}
 
 [dev-dependencies]
 # rand_xoshiro is required for tests if rand is enabled

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ glam = { version = "0.29.0", default-features = false }
   without the `scalar-math` feature. It should work between all other builds of
   `glam`.  Endian conversion is currently not supported
 * [`bytecheck`] - to perform archive validation when using the `rkyv` feature
+* [`wasm-bindgen`] - adds `#[wasm_bindgen]` to types and constructors
 
 [`approx`]: https://docs.rs/approx
 [`bytemuck`]: https://docs.rs/bytemuck

--- a/codegen/templates/mat.rs.tera
+++ b/codegen/templates/mat.rs.tera
@@ -61,6 +61,11 @@
 {% set axes = ["x_axis", "y_axis", "z_axis", "w_axis"] | slice(end = dim) %}
 {% set dimension_in_full = ["zero", "one", "two", "three", "four"] | nth(n = dim) %}
 
+{%- if not is_sse2 %}
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+{%- endif %}
+
 use crate::{
 {% if scalar_t == "f32" %}
     DMat{{ dim }},
@@ -216,9 +221,15 @@ pub const fn {{ self_t | lower }}(
 {%- endif %}
 {%- if self_t == "Mat2" and not is_scalar %}
 #[repr(transparent)]
+{%- if not is_sse2 %}
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
+{%- endif %}
 pub struct {{ self_t }}(pub(crate) {{ simd_t }});
 {%- else %}
 #[repr(C)]
+{%- if not is_sse2 %}
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
+{%- endif %}
 pub struct {{ self_t }}
 {
     {% for axis in axes %}
@@ -226,6 +237,41 @@ pub struct {{ self_t }}
     {%- endfor %}
 }
 {% endif %}
+
+{%- if not is_sse2 %}
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl {{ self_t }} {
+  #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        {% for i in range(end = dim) %}
+            {%- for j in range(end = dim) %}
+                m{{ i }}{{ j }}: {{ scalar_t }},
+            {%- endfor %}
+        {%- endfor %}
+    ) -> Self {
+        {% if self_t == "Mat2" and is_sse2 %}
+            unsafe { UnionCast { a: [m00, m01, m10, m11] }.v }
+        {% elif self_t == "Mat2" and is_wasm32 %}
+            Self(f32x4(m00, m01, m10, m11))
+        {% elif self_t == "Mat2" and is_coresimd %}
+            Self(f32x4::from_array([m00, m01, m10, m11]))
+        {% elif self_t == "Mat2" and is_neon %}
+            unsafe { UnionCast { a: [m00, m01, m10, m11] }.v }
+        {% else %}
+        Self {
+            {% for i in range(end = dim) %}
+                {{ axes[i] }}: {{ col_t}}::new(
+                    {% for j in range(end = dim) %}
+                        m{{ i }}{{ j }},
+                    {% endfor %}
+                ),
+            {%- endfor %}
+        }
+        {% endif %}
+    }
+}
+{%- endif %}
 
 impl {{ self_t }} {
     /// A {{ nxn }} matrix with all elements set to `0.0`.

--- a/codegen/templates/quat.rs.tera
+++ b/codegen/templates/quat.rs.tera
@@ -31,6 +31,9 @@
     {% set mat4_t = "DMat4" %}
 {% endif %}
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     {{ scalar_t }}::math,
     euler::{EulerRot, FromEuler, ToEuler},
@@ -109,6 +112,7 @@ pub const fn {{ self_t | lower }}(x: {{ scalar_t }}, y: {{ scalar_t }}, z: {{ sc
 {%- endif %}
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct {{ self_t }}{
     pub x: {{ scalar_t }},
     pub y: {{ scalar_t }},
@@ -117,6 +121,7 @@ pub struct {{ self_t }}{
 }
 {%- else %}
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct {{ self_t }}(pub(crate) {{ simd_t }});
 {%- endif %}
 

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -134,6 +134,9 @@
     {% set zero = "0" %}
 {% endif %}
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 {% if bveca_from_type and bveca_from_type == "BVec4A" and is_scalar %}
     {% if scalar_t == "f32" %}
         #[cfg(feature = "scalar-math")]
@@ -273,6 +276,7 @@ pub const fn {{ self_t | lower }}(
 {%- if is_scalar %}
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct {{ self_t }}
 {
     {% for c in components %}
@@ -281,9 +285,63 @@ pub struct {{ self_t }}
 }
 {% else %}
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct {{ self_t }}(pub(crate) {{ simd_t }});
 {% endif %}
 
+{%- if not is_sse2 %}
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl {{ self_t }} {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        {% for c in components %}
+            {{ c }}: {{ scalar_t }},
+        {% endfor %}
+    ) -> Self {
+        {% if is_scalar %}
+            Self {
+                {% for c in components %}
+                    {{ c }},
+                {%- endfor %}
+            }
+        {% elif is_sse2 %}
+            unsafe {
+                UnionCast { a: [
+                    {% if dim == 3 %}
+                        x, y, z, z
+                    {% elif dim == 4 %}
+                        x, y, z, w
+                    {% endif %}
+                ] }.v
+            }
+        {% elif is_wasm32 %}
+            Self(f32x4(
+                {% if dim == 3 %}
+                    x, y, z, z
+                {% elif dim == 4 %}
+                    x, y, z, w
+                {% endif %}
+            ))
+        {% elif is_coresimd %}
+            Self(f32x4::from_array([
+                x, y, z,
+                {% if dim == 3 %}
+                    z
+                {% elif dim == 4 %}
+                    w
+                {% endif %}
+            ]))
+        {% elif is_neon %}
+            {% if dim == 3 %}
+                unsafe { UnionCast { a: [x, y, z, z] }.v }
+            {% elif dim == 4 %}
+                unsafe { UnionCast { a: [x, y, z, w] }.v }
+            {% endif %}
+        {% endif %}
+    }
+}
+{%- endif %}
 impl {{ self_t }} {
     /// All zeroes.
     pub const ZERO: Self = Self::splat({{ zero }});

--- a/src/f32/coresimd/mat2.rs
+++ b/src/f32/coresimd/mat2.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, swizzles::*, DMat2, Mat3, Mat3A, Vec2};
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
@@ -22,7 +25,16 @@ pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat2(pub(crate) f32x4);
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
+        Self(f32x4::from_array([m00, m01, m10, m11]))
+    }
+}
 
 impl Mat2 {
     /// A 2x2 matrix with all elements set to `0.0`.

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{FromEuler, ToEuler},
     f32::math,
@@ -46,10 +49,34 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// transform.
 #[derive(Clone, Copy)]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat3A {
     pub x_axis: Vec3A,
     pub y_axis: Vec3A,
     pub z_axis: Vec3A,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat3A {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        m00: f32,
+        m01: f32,
+        m02: f32,
+        m10: f32,
+        m11: f32,
+        m12: f32,
+        m20: f32,
+        m21: f32,
+        m22: f32,
+    ) -> Self {
+        Self {
+            x_axis: Vec3A::new(m00, m01, m02),
+            y_axis: Vec3A::new(m10, m11, m12),
+            z_axis: Vec3A::new(m20, m21, m22),
+        }
+    }
 }
 
 impl Mat3A {

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     coresimd::*,
     euler::{FromEuler, ToEuler},
@@ -52,11 +55,43 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// perspective correction using the [`Self::project_point3()`] convenience method.
 #[derive(Clone, Copy)]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat4 {
     pub x_axis: Vec4,
     pub y_axis: Vec4,
     pub z_axis: Vec4,
     pub w_axis: Vec4,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        m00: f32,
+        m01: f32,
+        m02: f32,
+        m03: f32,
+        m10: f32,
+        m11: f32,
+        m12: f32,
+        m13: f32,
+        m20: f32,
+        m21: f32,
+        m22: f32,
+        m23: f32,
+        m30: f32,
+        m31: f32,
+        m32: f32,
+        m33: f32,
+    ) -> Self {
+        Self {
+            x_axis: Vec4::new(m00, m01, m02, m03),
+            y_axis: Vec4::new(m10, m11, m12, m13),
+            z_axis: Vec4::new(m20, m21, m22, m23),
+            w_axis: Vec4::new(m30, m31, m32, m33),
+        }
+    }
 }
 
 impl Mat4 {

--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -1,5 +1,8 @@
 // Generated from quat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     coresimd::*,
     euler::{EulerRot, FromEuler, ToEuler},
@@ -35,6 +38,7 @@ pub const fn quat(x: f32, y: f32, z: f32, w: f32) -> Quat {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Quat(pub(crate) f32x4);
 
 impl Quat {

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{coresimd::*, f32::math, BVec3, BVec3A, Vec2, Vec3, Vec4};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -28,8 +31,17 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec3A(pub(crate) f32x4);
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Vec3A {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f32, y: f32, z: f32) -> Self {
+        Self(f32x4::from_array([x, y, z, z]))
+    }
+}
 impl Vec3A {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{coresimd::*, f32::math, BVec4, BVec4A, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -24,8 +27,17 @@ pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec4(pub(crate) f32x4);
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Vec4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f32, y: f32, z: f32, w: f32) -> Self {
+        Self(f32x4::from_array([x, y, z, w]))
+    }
+}
 impl Vec4 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{FromEuler, ToEuler},
     f32::math,
@@ -44,10 +47,34 @@ pub const fn mat3(x_axis: Vec3, y_axis: Vec3, z_axis: Vec3) -> Mat3 {
 /// transform.
 #[derive(Clone, Copy)]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat3 {
     pub x_axis: Vec3,
     pub y_axis: Vec3,
     pub z_axis: Vec3,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat3 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        m00: f32,
+        m01: f32,
+        m02: f32,
+        m10: f32,
+        m11: f32,
+        m12: f32,
+        m20: f32,
+        m21: f32,
+        m22: f32,
+    ) -> Self {
+        Self {
+            x_axis: Vec3::new(m00, m01, m02),
+            y_axis: Vec3::new(m10, m11, m12),
+            z_axis: Vec3::new(m20, m21, m22),
+        }
+    }
 }
 
 impl Mat3 {

--- a/src/f32/neon/mat2.rs
+++ b/src/f32/neon/mat2.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, swizzles::*, DMat2, Mat3, Mat3A, Vec2};
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
@@ -28,7 +31,21 @@ pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat2(pub(crate) float32x4_t);
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
+        unsafe {
+            UnionCast {
+                a: [m00, m01, m10, m11],
+            }
+            .v
+        }
+    }
+}
 
 impl Mat2 {
     /// A 2x2 matrix with all elements set to `0.0`.

--- a/src/f32/neon/mat3a.rs
+++ b/src/f32/neon/mat3a.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{FromEuler, ToEuler},
     f32::math,
@@ -46,10 +49,34 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// transform.
 #[derive(Clone, Copy)]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat3A {
     pub x_axis: Vec3A,
     pub y_axis: Vec3A,
     pub z_axis: Vec3A,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat3A {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        m00: f32,
+        m01: f32,
+        m02: f32,
+        m10: f32,
+        m11: f32,
+        m12: f32,
+        m20: f32,
+        m21: f32,
+        m22: f32,
+    ) -> Self {
+        Self {
+            x_axis: Vec3A::new(m00, m01, m02),
+            y_axis: Vec3A::new(m10, m11, m12),
+            z_axis: Vec3A::new(m20, m21, m22),
+        }
+    }
 }
 
 impl Mat3A {

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{FromEuler, ToEuler},
     f32::math,
@@ -52,11 +55,43 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// perspective correction using the [`Self::project_point3()`] convenience method.
 #[derive(Clone, Copy)]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat4 {
     pub x_axis: Vec4,
     pub y_axis: Vec4,
     pub z_axis: Vec4,
     pub w_axis: Vec4,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        m00: f32,
+        m01: f32,
+        m02: f32,
+        m03: f32,
+        m10: f32,
+        m11: f32,
+        m12: f32,
+        m13: f32,
+        m20: f32,
+        m21: f32,
+        m22: f32,
+        m23: f32,
+        m30: f32,
+        m31: f32,
+        m32: f32,
+        m33: f32,
+    ) -> Self {
+        Self {
+            x_axis: Vec4::new(m00, m01, m02, m03),
+            y_axis: Vec4::new(m10, m11, m12, m13),
+            z_axis: Vec4::new(m20, m21, m22, m23),
+            w_axis: Vec4::new(m30, m31, m32, m33),
+        }
+    }
 }
 
 impl Mat4 {

--- a/src/f32/neon/quat.rs
+++ b/src/f32/neon/quat.rs
@@ -1,5 +1,8 @@
 // Generated from quat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{EulerRot, FromEuler, ToEuler},
     f32::math,
@@ -41,6 +44,7 @@ pub const fn quat(x: f32, y: f32, z: f32, w: f32) -> Quat {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Quat(pub(crate) float32x4_t);
 
 impl Quat {

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, neon::*, BVec3, BVec3A, Vec2, Vec3, Vec4};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -33,8 +36,17 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec3A(pub(crate) float32x4_t);
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Vec3A {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f32, y: f32, z: f32) -> Self {
+        unsafe { UnionCast { a: [x, y, z, z] }.v }
+    }
+}
 impl Vec3A {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, neon::*, BVec4, BVec4A, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -29,8 +32,17 @@ pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec4(pub(crate) float32x4_t);
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Vec4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f32, y: f32, z: f32, w: f32) -> Self {
+        unsafe { UnionCast { a: [x, y, z, w] }.v }
+    }
+}
 impl Vec4 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f32/scalar/mat2.rs
+++ b/src/f32/scalar/mat2.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, swizzles::*, DMat2, Mat3, Mat3A, Vec2};
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
@@ -21,9 +24,22 @@ pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
 )]
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat2 {
     pub x_axis: Vec2,
     pub y_axis: Vec2,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
+        Self {
+            x_axis: Vec2::new(m00, m01),
+            y_axis: Vec2::new(m10, m11),
+        }
+    }
 }
 
 impl Mat2 {

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{FromEuler, ToEuler},
     f32::math,
@@ -44,10 +47,34 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// transform.
 #[derive(Clone, Copy)]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat3A {
     pub x_axis: Vec3A,
     pub y_axis: Vec3A,
     pub z_axis: Vec3A,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat3A {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        m00: f32,
+        m01: f32,
+        m02: f32,
+        m10: f32,
+        m11: f32,
+        m12: f32,
+        m20: f32,
+        m21: f32,
+        m22: f32,
+    ) -> Self {
+        Self {
+            x_axis: Vec3A::new(m00, m01, m02),
+            y_axis: Vec3A::new(m10, m11, m12),
+            z_axis: Vec3A::new(m20, m21, m22),
+        }
+    }
 }
 
 impl Mat3A {

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{FromEuler, ToEuler},
     f32::math,
@@ -56,11 +59,43 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
     repr(align(16))
 )]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat4 {
     pub x_axis: Vec4,
     pub y_axis: Vec4,
     pub z_axis: Vec4,
     pub w_axis: Vec4,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        m00: f32,
+        m01: f32,
+        m02: f32,
+        m03: f32,
+        m10: f32,
+        m11: f32,
+        m12: f32,
+        m13: f32,
+        m20: f32,
+        m21: f32,
+        m22: f32,
+        m23: f32,
+        m30: f32,
+        m31: f32,
+        m32: f32,
+        m33: f32,
+    ) -> Self {
+        Self {
+            x_axis: Vec4::new(m00, m01, m02, m03),
+            y_axis: Vec4::new(m10, m11, m12, m13),
+            z_axis: Vec4::new(m20, m21, m22, m23),
+            w_axis: Vec4::new(m30, m31, m32, m33),
+        }
+    }
 }
 
 impl Mat4 {

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -1,5 +1,8 @@
 // Generated from quat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{EulerRot, FromEuler, ToEuler},
     f32::math,
@@ -33,6 +36,7 @@ pub const fn quat(x: f32, y: f32, z: f32, w: f32) -> Quat {
 )]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Quat {
     pub x: f32,
     pub y: f32,

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, BVec3, BVec3A, Vec2, Vec3, Vec4};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -27,12 +30,21 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 #[cfg_attr(not(target_arch = "spirv"), repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec3A {
     pub x: f32,
     pub y: f32,
     pub z: f32,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Vec3A {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f32, y: f32, z: f32) -> Self {
+        Self { x, y, z }
+    }
+}
 impl Vec3A {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 #[cfg(feature = "scalar-math")]
 use crate::BVec4 as BVec4A;
 
@@ -30,6 +33,7 @@ pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {
 )]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec4 {
     pub x: f32,
     pub y: f32,
@@ -37,6 +41,14 @@ pub struct Vec4 {
     pub w: f32,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Vec4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f32, y: f32, z: f32, w: f32) -> Self {
+        Self { x, y, z, w }
+    }
+}
 impl Vec4 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -1,5 +1,8 @@
 // Generated from quat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{EulerRot, FromEuler, ToEuler},
     f32::math,
@@ -44,6 +47,7 @@ pub const fn quat(x: f32, y: f32, z: f32, w: f32) -> Quat {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Quat(pub(crate) __m128);
 
 impl Quat {

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, sse2::*, BVec3, BVec3A, Vec2, Vec3, Vec4};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -36,6 +39,7 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec3A(pub(crate) __m128);
 
 impl Vec3A {

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, sse2::*, BVec4, BVec4A, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -32,6 +35,7 @@ pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec4(pub(crate) __m128);
 
 impl Vec4 {

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, BVec2, Vec3};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -19,11 +22,20 @@ pub const fn vec2(x: f32, y: f32) -> Vec2 {
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec2 {
     pub x: f32,
     pub y: f32,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Vec2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f32, y: f32) -> Self {
+        Self { x, y }
+    }
+}
 impl Vec2 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, BVec3, BVec3A, Vec2, Vec4};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -18,12 +21,21 @@ pub const fn vec3(x: f32, y: f32, z: f32) -> Vec3 {
 #[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec3 {
     pub x: f32,
     pub y: f32,
     pub z: f32,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Vec3 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f32, y: f32, z: f32) -> Self {
+        Self { x, y, z }
+    }
+}
 impl Vec3 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f32/wasm32/mat2.rs
+++ b/src/f32/wasm32/mat2.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, swizzles::*, DMat2, Mat3, Mat3A, Vec2};
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
@@ -22,7 +25,16 @@ pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat2(pub(crate) v128);
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(m00: f32, m01: f32, m10: f32, m11: f32) -> Self {
+        Self(f32x4(m00, m01, m10, m11))
+    }
+}
 
 impl Mat2 {
     /// A 2x2 matrix with all elements set to `0.0`.

--- a/src/f32/wasm32/mat3a.rs
+++ b/src/f32/wasm32/mat3a.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{FromEuler, ToEuler},
     f32::math,
@@ -46,10 +49,34 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// transform.
 #[derive(Clone, Copy)]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat3A {
     pub x_axis: Vec3A,
     pub y_axis: Vec3A,
     pub z_axis: Vec3A,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat3A {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        m00: f32,
+        m01: f32,
+        m02: f32,
+        m10: f32,
+        m11: f32,
+        m12: f32,
+        m20: f32,
+        m21: f32,
+        m22: f32,
+    ) -> Self {
+        Self {
+            x_axis: Vec3A::new(m00, m01, m02),
+            y_axis: Vec3A::new(m10, m11, m12),
+            z_axis: Vec3A::new(m20, m21, m22),
+        }
+    }
 }
 
 impl Mat3A {

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{FromEuler, ToEuler},
     f32::math,
@@ -52,11 +55,43 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// perspective correction using the [`Self::project_point3()`] convenience method.
 #[derive(Clone, Copy)]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Mat4 {
     pub x_axis: Vec4,
     pub y_axis: Vec4,
     pub z_axis: Vec4,
     pub w_axis: Vec4,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Mat4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        m00: f32,
+        m01: f32,
+        m02: f32,
+        m03: f32,
+        m10: f32,
+        m11: f32,
+        m12: f32,
+        m13: f32,
+        m20: f32,
+        m21: f32,
+        m22: f32,
+        m23: f32,
+        m30: f32,
+        m31: f32,
+        m32: f32,
+        m33: f32,
+    ) -> Self {
+        Self {
+            x_axis: Vec4::new(m00, m01, m02, m03),
+            y_axis: Vec4::new(m10, m11, m12, m13),
+            z_axis: Vec4::new(m20, m21, m22, m23),
+            w_axis: Vec4::new(m30, m31, m32, m33),
+        }
+    }
 }
 
 impl Mat4 {

--- a/src/f32/wasm32/quat.rs
+++ b/src/f32/wasm32/quat.rs
@@ -1,5 +1,8 @@
 // Generated from quat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{EulerRot, FromEuler, ToEuler},
     f32::math,
@@ -35,6 +38,7 @@ pub const fn quat(x: f32, y: f32, z: f32, w: f32) -> Quat {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Quat(pub(crate) v128);
 
 impl Quat {

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, wasm32::*, BVec3, BVec3A, Vec2, Vec3, Vec4};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -27,8 +30,17 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec3A(pub(crate) v128);
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Vec3A {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f32, y: f32, z: f32) -> Self {
+        Self(f32x4(x, y, z, z))
+    }
+}
 impl Vec3A {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f32::math, wasm32::*, BVec4, BVec4A, Vec2, Vec3, Vec3A};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -23,8 +26,17 @@ pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[repr(transparent)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct Vec4(pub(crate) v128);
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl Vec4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f32, y: f32, z: f32, w: f32) -> Self {
+        Self(f32x4(x, y, z, w))
+    }
+}
 impl Vec4 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f64/dmat2.rs
+++ b/src/f64/dmat2.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f64::math, swizzles::*, DMat3, DVec2, Mat2};
 #[cfg(not(target_arch = "spirv"))]
 use core::fmt;
@@ -17,9 +20,22 @@ pub const fn dmat2(x_axis: DVec2, y_axis: DVec2) -> DMat2 {
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct DMat2 {
     pub x_axis: DVec2,
     pub y_axis: DVec2,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl DMat2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(m00: f64, m01: f64, m10: f64, m11: f64) -> Self {
+        Self {
+            x_axis: DVec2::new(m00, m01),
+            y_axis: DVec2::new(m10, m11),
+        }
+    }
 }
 
 impl DMat2 {

--- a/src/f64/dmat3.rs
+++ b/src/f64/dmat3.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{FromEuler, ToEuler},
     f64::math,
@@ -44,10 +47,34 @@ pub const fn dmat3(x_axis: DVec3, y_axis: DVec3, z_axis: DVec3) -> DMat3 {
 /// transform.
 #[derive(Clone, Copy)]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct DMat3 {
     pub x_axis: DVec3,
     pub y_axis: DVec3,
     pub z_axis: DVec3,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl DMat3 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        m00: f64,
+        m01: f64,
+        m02: f64,
+        m10: f64,
+        m11: f64,
+        m12: f64,
+        m20: f64,
+        m21: f64,
+        m22: f64,
+    ) -> Self {
+        Self {
+            x_axis: DVec3::new(m00, m01, m02),
+            y_axis: DVec3::new(m10, m11, m12),
+            z_axis: DVec3::new(m20, m21, m22),
+        }
+    }
 }
 
 impl DMat3 {

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -1,5 +1,8 @@
 // Generated from mat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{FromEuler, ToEuler},
     f64::math,
@@ -50,11 +53,43 @@ pub const fn dmat4(x_axis: DVec4, y_axis: DVec4, z_axis: DVec4, w_axis: DVec4) -
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[repr(C)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct DMat4 {
     pub x_axis: DVec4,
     pub y_axis: DVec4,
     pub z_axis: DVec4,
     pub w_axis: DVec4,
+}
+
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl DMat4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(
+        m00: f64,
+        m01: f64,
+        m02: f64,
+        m03: f64,
+        m10: f64,
+        m11: f64,
+        m12: f64,
+        m13: f64,
+        m20: f64,
+        m21: f64,
+        m22: f64,
+        m23: f64,
+        m30: f64,
+        m31: f64,
+        m32: f64,
+        m33: f64,
+    ) -> Self {
+        Self {
+            x_axis: DVec4::new(m00, m01, m02, m03),
+            y_axis: DVec4::new(m10, m11, m12, m13),
+            z_axis: DVec4::new(m20, m21, m22, m23),
+            w_axis: DVec4::new(m30, m31, m32, m33),
+        }
+    }
 }
 
 impl DMat4 {

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -1,5 +1,8 @@
 // Generated from quat.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{
     euler::{EulerRot, FromEuler, ToEuler},
     f64::math,
@@ -29,6 +32,7 @@ pub const fn dquat(x: f64, y: f64, z: f64, w: f64) -> DQuat {
 #[derive(Clone, Copy)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct DQuat {
     pub x: f64,
     pub y: f64,

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f64::math, BVec2, DVec3, IVec2, UVec2, Vec2};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -19,11 +22,20 @@ pub const fn dvec2(x: f64, y: f64) -> DVec2 {
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct DVec2 {
     pub x: f64,
     pub y: f64,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl DVec2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f64, y: f64) -> Self {
+        Self { x, y }
+    }
+}
 impl DVec2 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{f64::math, BVec3, BVec3A, DVec2, DVec4, IVec3, UVec3, Vec3};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -18,12 +21,21 @@ pub const fn dvec3(x: f64, y: f64, z: f64) -> DVec3 {
 #[derive(Clone, Copy, PartialEq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct DVec3 {
     pub x: f64,
     pub y: f64,
     pub z: f64,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl DVec3 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f64, y: f64, z: f64) -> Self {
+        Self { x, y, z }
+    }
+}
 impl DVec3 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 #[cfg(not(feature = "scalar-math"))]
 use crate::BVec4A;
 use crate::{f64::math, BVec4, DVec2, DVec3, IVec4, UVec4, Vec4};
@@ -21,6 +24,7 @@ pub const fn dvec4(x: f64, y: f64, z: f64, w: f64) -> DVec4 {
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct DVec4 {
     pub x: f64,
     pub y: f64,
@@ -28,6 +32,14 @@ pub struct DVec4 {
     pub w: f64,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl DVec4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: f64, y: f64, z: f64, w: f64) -> Self {
+        Self { x, y, z, w }
+    }
+}
 impl DVec4 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0.0);

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec2, I16Vec3, I64Vec2, IVec2, U16Vec2, U64Vec2, UVec2};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -20,11 +23,20 @@ pub const fn i16vec2(x: i16, y: i16) -> I16Vec2 {
 #[cfg_attr(feature = "cuda", repr(align(4)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct I16Vec2 {
     pub x: i16,
     pub y: i16,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl I16Vec2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: i16, y: i16) -> Self {
+        Self { x, y }
+    }
+}
 impl I16Vec2 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec3, BVec3A, I16Vec2, I16Vec4, I64Vec3, IVec3, U16Vec3, U64Vec3, UVec3};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -19,12 +22,21 @@ pub const fn i16vec3(x: i16, y: i16, z: i16) -> I16Vec3 {
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct I16Vec3 {
     pub x: i16,
     pub y: i16,
     pub z: i16,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl I16Vec3 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: i16, y: i16, z: i16) -> Self {
+        Self { x, y, z }
+    }
+}
 impl I16Vec3 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 #[cfg(not(feature = "scalar-math"))]
 use crate::BVec4A;
 use crate::{BVec4, I16Vec2, I16Vec3, I64Vec4, IVec4, U16Vec4, U64Vec4, UVec4};
@@ -22,6 +25,7 @@ pub const fn i16vec4(x: i16, y: i16, z: i16, w: i16) -> I16Vec4 {
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct I16Vec4 {
     pub x: i16,
     pub y: i16,
@@ -29,6 +33,14 @@ pub struct I16Vec4 {
     pub w: i16,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl I16Vec4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: i16, y: i16, z: i16, w: i16) -> Self {
+        Self { x, y, z, w }
+    }
+}
 impl I16Vec4 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec2, I16Vec2, I64Vec2, IVec3, U16Vec2, U64Vec2, UVec2};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -20,11 +23,20 @@ pub const fn ivec2(x: i32, y: i32) -> IVec2 {
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct IVec2 {
     pub x: i32,
     pub y: i32,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl IVec2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: i32, y: i32) -> Self {
+        Self { x, y }
+    }
+}
 impl IVec2 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec3, BVec3A, I16Vec3, I64Vec3, IVec2, IVec4, U16Vec3, U64Vec3, UVec3};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -19,12 +22,21 @@ pub const fn ivec3(x: i32, y: i32, z: i32) -> IVec3 {
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct IVec3 {
     pub x: i32,
     pub y: i32,
     pub z: i32,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl IVec3 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: i32, y: i32, z: i32) -> Self {
+        Self { x, y, z }
+    }
+}
 impl IVec3 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 #[cfg(not(feature = "scalar-math"))]
 use crate::BVec4A;
 use crate::{BVec4, I16Vec4, I64Vec4, IVec2, IVec3, U16Vec4, U64Vec4, UVec4};
@@ -22,6 +25,7 @@ pub const fn ivec4(x: i32, y: i32, z: i32, w: i32) -> IVec4 {
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct IVec4 {
     pub x: i32,
     pub y: i32,
@@ -29,6 +33,14 @@ pub struct IVec4 {
     pub w: i32,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl IVec4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: i32, y: i32, z: i32, w: i32) -> Self {
+        Self { x, y, z, w }
+    }
+}
 impl IVec4 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec2, I16Vec2, I64Vec3, IVec2, U16Vec2, U64Vec2, UVec2};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -20,11 +23,20 @@ pub const fn i64vec2(x: i64, y: i64) -> I64Vec2 {
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct I64Vec2 {
     pub x: i64,
     pub y: i64,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl I64Vec2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: i64, y: i64) -> Self {
+        Self { x, y }
+    }
+}
 impl I64Vec2 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec3, BVec3A, I16Vec3, I64Vec2, I64Vec4, IVec3, U16Vec3, U64Vec3, UVec3};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -19,12 +22,21 @@ pub const fn i64vec3(x: i64, y: i64, z: i64) -> I64Vec3 {
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct I64Vec3 {
     pub x: i64,
     pub y: i64,
     pub z: i64,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl I64Vec3 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: i64, y: i64, z: i64) -> Self {
+        Self { x, y, z }
+    }
+}
 impl I64Vec3 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 #[cfg(not(feature = "scalar-math"))]
 use crate::BVec4A;
 use crate::{BVec4, I16Vec4, I64Vec2, I64Vec3, IVec4, U16Vec4, U64Vec4, UVec4};
@@ -22,6 +25,7 @@ pub const fn i64vec4(x: i64, y: i64, z: i64, w: i64) -> I64Vec4 {
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct I64Vec4 {
     pub x: i64,
     pub y: i64,
@@ -29,6 +33,14 @@ pub struct I64Vec4 {
     pub w: i64,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl I64Vec4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: i64, y: i64, z: i64, w: i64) -> Self {
+        Self { x, y, z, w }
+    }
+}
 impl I64Vec4 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec2, I16Vec2, I64Vec2, IVec2, U16Vec3, U64Vec2, UVec2};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -20,11 +23,20 @@ pub const fn u16vec2(x: u16, y: u16) -> U16Vec2 {
 #[cfg_attr(feature = "cuda", repr(align(4)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct U16Vec2 {
     pub x: u16,
     pub y: u16,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl U16Vec2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: u16, y: u16) -> Self {
+        Self { x, y }
+    }
+}
 impl U16Vec2 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec3, BVec3A, I16Vec3, I64Vec3, IVec3, U16Vec2, U16Vec4, U64Vec3, UVec3};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -19,12 +22,21 @@ pub const fn u16vec3(x: u16, y: u16, z: u16) -> U16Vec3 {
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct U16Vec3 {
     pub x: u16,
     pub y: u16,
     pub z: u16,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl U16Vec3 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: u16, y: u16, z: u16) -> Self {
+        Self { x, y, z }
+    }
+}
 impl U16Vec3 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 #[cfg(not(feature = "scalar-math"))]
 use crate::BVec4A;
 use crate::{BVec4, I16Vec4, I64Vec4, IVec4, U16Vec2, U16Vec3, U64Vec4, UVec4};
@@ -22,6 +25,7 @@ pub const fn u16vec4(x: u16, y: u16, z: u16, w: u16) -> U16Vec4 {
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct U16Vec4 {
     pub x: u16,
     pub y: u16,
@@ -29,6 +33,14 @@ pub struct U16Vec4 {
     pub w: u16,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl U16Vec4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: u16, y: u16, z: u16, w: u16) -> Self {
+        Self { x, y, z, w }
+    }
+}
 impl U16Vec4 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec2, I16Vec2, I64Vec2, IVec2, U16Vec2, U64Vec2, UVec3};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -20,11 +23,20 @@ pub const fn uvec2(x: u32, y: u32) -> UVec2 {
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct UVec2 {
     pub x: u32,
     pub y: u32,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl UVec2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: u32, y: u32) -> Self {
+        Self { x, y }
+    }
+}
 impl UVec2 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec3, BVec3A, I16Vec3, I64Vec3, IVec3, U16Vec3, U64Vec3, UVec2, UVec4};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -19,12 +22,21 @@ pub const fn uvec3(x: u32, y: u32, z: u32) -> UVec3 {
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct UVec3 {
     pub x: u32,
     pub y: u32,
     pub z: u32,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl UVec3 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: u32, y: u32, z: u32) -> Self {
+        Self { x, y, z }
+    }
+}
 impl UVec3 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 #[cfg(not(feature = "scalar-math"))]
 use crate::BVec4A;
 use crate::{BVec4, I16Vec4, I64Vec4, IVec4, U16Vec4, U64Vec4, UVec2, UVec3};
@@ -22,6 +25,7 @@ pub const fn uvec4(x: u32, y: u32, z: u32, w: u32) -> UVec4 {
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct UVec4 {
     pub x: u32,
     pub y: u32,
@@ -29,6 +33,14 @@ pub struct UVec4 {
     pub w: u32,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl UVec4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: u32, y: u32, z: u32, w: u32) -> Self {
+        Self { x, y, z, w }
+    }
+}
 impl UVec4 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec2, I16Vec2, I64Vec2, IVec2, U16Vec2, U64Vec3, UVec2};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -20,11 +23,20 @@ pub const fn u64vec2(x: u64, y: u64) -> U64Vec2 {
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct U64Vec2 {
     pub x: u64,
     pub y: u64,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl U64Vec2 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: u64, y: u64) -> Self {
+        Self { x, y }
+    }
+}
 impl U64Vec2 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 use crate::{BVec3, BVec3A, I16Vec3, I64Vec3, IVec3, U16Vec3, U64Vec2, U64Vec4, UVec3};
 
 #[cfg(not(target_arch = "spirv"))]
@@ -19,12 +22,21 @@ pub const fn u64vec3(x: u64, y: u64, z: u64) -> U64Vec3 {
 #[derive(Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct U64Vec3 {
     pub x: u64,
     pub y: u64,
     pub z: u64,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl U64Vec3 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: u64, y: u64, z: u64) -> Self {
+        Self { x, y, z }
+    }
+}
 impl U64Vec3 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -1,5 +1,8 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
+#[cfg(feature = "wasm-bindgen")]
+use wasm_bindgen::prelude::*;
+
 #[cfg(not(feature = "scalar-math"))]
 use crate::BVec4A;
 use crate::{BVec4, I16Vec4, I64Vec4, IVec4, U16Vec4, U64Vec2, U64Vec3, UVec4};
@@ -22,6 +25,7 @@ pub const fn u64vec4(x: u64, y: u64, z: u64, w: u64) -> U64Vec4 {
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 pub struct U64Vec4 {
     pub x: u64,
     pub y: u64,
@@ -29,6 +33,14 @@ pub struct U64Vec4 {
     pub w: u64,
 }
 
+#[cfg(feature = "wasm-bindgen")]
+#[wasm_bindgen]
+impl U64Vec4 {
+    #[cfg_attr(feature = "wasm-bindgen", wasm_bindgen(constructor))]
+    pub fn wasm_bindgen_ctor(x: u64, y: u64, z: u64, w: u64) -> Self {
+        Self { x, y, z, w }
+    }
+}
 impl U64Vec4 {
     /// All zeroes.
     pub const ZERO: Self = Self::splat(0);


### PR DESCRIPTION
See issue #292  and discussion #277 

This adds a `wasm-bindgen` feature that decorates structs for wasm/JS bindings, and adds a wasm-only constructor. 

There are a couple points worth discussing/considering before merging this:
- It's a feature, instead of `target_arch = "wasm32"` because not everyone compiling for WASM needs to access the types from JS
- `const fn` cannot be bound in `wasm_bindgen`, so I crated a separate `new` (called `wasm_bindgen_ctor`) function just for the wasm constructor
  - Additionally, we can't (probably shouldn't) just make the existing `new` non-const, as other const factory functions use it transitively
  - The function is only added when the `wasm-bindgen` feature is active, it won't pollute auto-complete et. al
- I chose not to bind all the methods on types, though many *could* be bound
  - This decision was mostly out of laziness; I didn't want to bind them all if there isn't interest in this PR anyway
  - This will however add a lot of extra `#[wasm_bindgen(skip)]` decorators
- SSE2 is exclusive with `wasm_bindgen`
- I couldn't figure out why it was still mad when binding an affine, so I skipped it

I need this for [my project](https://github.com/AThilenius/logic-paint-rs), but I can use my own fork if this PR doesn't fit well with your direction. No worries.