### PR TITLE
Add doc comment to `Quat::is_nan`

### DIFF
--- a/codegen/templates/quat.rs.tera
+++ b/codegen/templates/quat.rs.tera
@@ -660,6 +660,7 @@ impl {{ self_t }} {
         {{ vec4_t }}::from(self).is_finite()
     }
 
+    /// Returns `true` if any elements are `NAN`.
     #[inline]
     #[must_use]
     pub fn is_nan(self) -> bool {

--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -516,6 +516,7 @@ impl Quat {
         Vec4::from(self).is_finite()
     }
 
+    /// Returns `true` if any elements are `NAN`.
     #[inline]
     #[must_use]
     pub fn is_nan(self) -> bool {

--- a/src/f32/neon/quat.rs
+++ b/src/f32/neon/quat.rs
@@ -521,6 +521,7 @@ impl Quat {
         Vec4::from(self).is_finite()
     }
 
+    /// Returns `true` if any elements are `NAN`.
     #[inline]
     #[must_use]
     pub fn is_nan(self) -> bool {

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -528,6 +528,7 @@ impl Quat {
         Vec4::from(self).is_finite()
     }
 
+    /// Returns `true` if any elements are `NAN`.
     #[inline]
     #[must_use]
     pub fn is_nan(self) -> bool {

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -524,6 +524,7 @@ impl Quat {
         Vec4::from(self).is_finite()
     }
 
+    /// Returns `true` if any elements are `NAN`.
     #[inline]
     #[must_use]
     pub fn is_nan(self) -> bool {

--- a/src/f32/wasm32/quat.rs
+++ b/src/f32/wasm32/quat.rs
@@ -516,6 +516,7 @@ impl Quat {
         Vec4::from(self).is_finite()
     }
 
+    /// Returns `true` if any elements are `NAN`.
     #[inline]
     #[must_use]
     pub fn is_nan(self) -> bool {

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -510,6 +510,7 @@ impl DQuat {
         DVec4::from(self).is_finite()
     }
 
+    /// Returns `true` if any elements are `NAN`.
     #[inline]
     #[must_use]
     pub fn is_nan(self) -> bool {


### PR DESCRIPTION
Adds a doc comment to `Quat::is_nan`, similar to `VecT::is_nan`.