### PR TITLE
Improve documentation for the `Mat4` projection functions

### DIFF
--- a/codegen/templates/mat.rs.tera
+++ b/codegen/templates/mat.rs.tera
@@ -1716,7 +1716,22 @@ impl {{ self_t }} {
         Self::look_to_rh(eye, center.sub(eye), up)
     }
 
-    /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
+    /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that OpenGL expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
     #[inline]
@@ -1740,7 +1755,47 @@ impl {{ self_t }} {
         )
     }
 
+    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that Vulkan expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points *down*, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    #[inline]
+    #[must_use]
+    pub fn perspective_rh_vk(
+        fov_y_radians: {{ scalar_t }},
+        aspect_ratio: {{ scalar_t }},
+        z_near: {{ scalar_t }},
+        z_far: {{ scalar_t }},
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
     ///
     /// # Panics
     ///
@@ -1764,6 +1819,20 @@ impl {{ self_t }} {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
     /// # Panics
     ///
     /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
@@ -1786,9 +1855,27 @@ impl {{ self_t }} {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
     /// # Panics
     ///
-    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_lh(fov_y_radians: {{ scalar_t }}, aspect_ratio: {{ scalar_t }}, z_near: {{ scalar_t }}) -> Self {
@@ -1804,7 +1891,11 @@ impl {{ self_t }} {
         )
     }
 
-    /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
+    /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
     /// # Panics
     ///
@@ -1828,8 +1919,29 @@ impl {{ self_t }} {
         )
     }
 
-    /// Creates an infinite right-handed perspective projection matrix with
-    /// `[0,1]` depth range.
+    /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_rh(fov_y_radians: {{ scalar_t }}, aspect_ratio: {{ scalar_t }}, z_near: {{ scalar_t }}) -> Self {
@@ -1843,8 +1955,15 @@ impl {{ self_t }} {
         )
     }
 
-    /// Creates an infinite reverse right-handed perspective projection matrix
-    /// with `[0,1]` depth range.
+    /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_reverse_rh(
@@ -1866,6 +1985,8 @@ impl {{ self_t }} {
     /// range.  This is the same as the OpenGL `glOrtho` function in OpenGL.
     /// See
     /// <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glOrtho.xml>
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that OpenGL expects.
     #[inline]
     #[must_use]
     pub fn orthographic_rh_gl(
@@ -1891,7 +2012,26 @@ impl {{ self_t }} {
         )
     }
 
+    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
+    /// range and Y axis pointing down.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
+    #[inline]
+    #[must_use]
+    pub fn orthographic_rh_vk(
+        left: {{ scalar_t }},
+        right: {{ scalar_t }},
+        bottom: {{ scalar_t }},
+        top: {{ scalar_t }},
+        near: {{ scalar_t }},
+        far: {{ scalar_t }},
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a left-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_lh(
@@ -1919,6 +2059,8 @@ impl {{ self_t }} {
     }
 
     /// Creates a right-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_rh(

--- a/codegen/templates/mat.rs.tera
+++ b/codegen/templates/mat.rs.tera
@@ -1743,20 +1743,6 @@ impl {{ self_t }} {
         )
     }
 
-    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
-    ///
-    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn perspective_rh_vk(
-        fov_y_radians: {{ scalar_t }},
-        aspect_ratio: {{ scalar_t }},
-        z_near: {{ scalar_t }},
-        z_far: {{ scalar_t }},
-    ) -> Self {
-        todo!()
-    }
-
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
     /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
@@ -1930,23 +1916,6 @@ impl {{ self_t }} {
             {{ col_t }}::new(0.0, 0.0, c, 0.0),
             {{ col_t }}::new(tx, ty, tz, 1.0),
         )
-    }
-
-    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
-    /// range and Y axis pointing down.
-    ///
-    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn orthographic_rh_vk(
-        left: {{ scalar_t }},
-        right: {{ scalar_t }},
-        bottom: {{ scalar_t }},
-        top: {{ scalar_t }},
-        near: {{ scalar_t }},
-        far: {{ scalar_t }},
-    ) -> Self {
-        todo!()
     }
 
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.

--- a/codegen/templates/mat.rs.tera
+++ b/codegen/templates/mat.rs.tera
@@ -1718,19 +1718,7 @@ impl {{ self_t }} {
 
     /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that OpenGL expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    /// Useful to map the standard right-handed coordinate system into what OpenGL expects.
     ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
@@ -1757,19 +1745,7 @@ impl {{ self_t }} {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that Vulkan expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points *down*, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
     #[inline]
     #[must_use]
     pub fn perspective_rh_vk(
@@ -1783,19 +1759,7 @@ impl {{ self_t }} {
 
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -1819,19 +1783,7 @@ impl {{ self_t }} {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -1855,22 +1807,8 @@ impl {{ self_t }} {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_lh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -1892,8 +1830,6 @@ impl {{ self_t }} {
     }
 
     /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
@@ -1921,22 +1857,8 @@ impl {{ self_t }} {
 
     /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_rh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -1956,8 +1878,6 @@ impl {{ self_t }} {
     }
 
     /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -848,7 +848,22 @@ impl Mat4 {
         Self::look_to_rh(eye, center.sub(eye), up)
     }
 
-    /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
+    /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that OpenGL expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
     #[inline]
@@ -872,7 +887,47 @@ impl Mat4 {
         )
     }
 
+    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that Vulkan expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points *down*, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    #[inline]
+    #[must_use]
+    pub fn perspective_rh_vk(
+        fov_y_radians: f32,
+        aspect_ratio: f32,
+        z_near: f32,
+        z_far: f32,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
     ///
     /// # Panics
     ///
@@ -896,6 +951,20 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
     /// # Panics
     ///
     /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
@@ -918,9 +987,27 @@ impl Mat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
     /// # Panics
     ///
-    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_lh(fov_y_radians: f32, aspect_ratio: f32, z_near: f32) -> Self {
@@ -936,7 +1023,11 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
+    /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
     /// # Panics
     ///
@@ -960,8 +1051,29 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite right-handed perspective projection matrix with
-    /// `[0,1]` depth range.
+    /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_rh(fov_y_radians: f32, aspect_ratio: f32, z_near: f32) -> Self {
@@ -975,8 +1087,15 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite reverse right-handed perspective projection matrix
-    /// with `[0,1]` depth range.
+    /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_reverse_rh(
@@ -998,6 +1117,8 @@ impl Mat4 {
     /// range.  This is the same as the OpenGL `glOrtho` function in OpenGL.
     /// See
     /// <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glOrtho.xml>
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that OpenGL expects.
     #[inline]
     #[must_use]
     pub fn orthographic_rh_gl(
@@ -1023,7 +1144,26 @@ impl Mat4 {
         )
     }
 
+    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
+    /// range and Y axis pointing down.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
+    #[inline]
+    #[must_use]
+    pub fn orthographic_rh_vk(
+        left: f32,
+        right: f32,
+        bottom: f32,
+        top: f32,
+        near: f32,
+        far: f32,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a left-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_lh(
@@ -1051,6 +1191,8 @@ impl Mat4 {
     }
 
     /// Creates a right-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_rh(

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -875,20 +875,6 @@ impl Mat4 {
         )
     }
 
-    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
-    ///
-    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn perspective_rh_vk(
-        fov_y_radians: f32,
-        aspect_ratio: f32,
-        z_near: f32,
-        z_far: f32,
-    ) -> Self {
-        todo!()
-    }
-
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
     /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
@@ -1062,23 +1048,6 @@ impl Mat4 {
             Vec4::new(0.0, 0.0, c, 0.0),
             Vec4::new(tx, ty, tz, 1.0),
         )
-    }
-
-    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
-    /// range and Y axis pointing down.
-    ///
-    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn orthographic_rh_vk(
-        left: f32,
-        right: f32,
-        bottom: f32,
-        top: f32,
-        near: f32,
-        far: f32,
-    ) -> Self {
-        todo!()
     }
 
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -850,19 +850,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that OpenGL expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    /// Useful to map the standard right-handed coordinate system into what OpenGL expects.
     ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
@@ -889,19 +877,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that Vulkan expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points *down*, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
     #[inline]
     #[must_use]
     pub fn perspective_rh_vk(
@@ -915,19 +891,7 @@ impl Mat4 {
 
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -951,19 +915,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -987,22 +939,8 @@ impl Mat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_lh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -1024,8 +962,6 @@ impl Mat4 {
     }
 
     /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
@@ -1053,22 +989,8 @@ impl Mat4 {
 
     /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_rh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -1088,8 +1010,6 @@ impl Mat4 {
     }
 
     /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -855,19 +855,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that OpenGL expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    /// Useful to map the standard right-handed coordinate system into what OpenGL expects.
     ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
@@ -894,19 +882,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that Vulkan expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points *down*, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
     #[inline]
     #[must_use]
     pub fn perspective_rh_vk(
@@ -920,19 +896,7 @@ impl Mat4 {
 
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -956,19 +920,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -992,22 +944,8 @@ impl Mat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_lh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -1029,8 +967,6 @@ impl Mat4 {
     }
 
     /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
@@ -1058,22 +994,8 @@ impl Mat4 {
 
     /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_rh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -1093,8 +1015,6 @@ impl Mat4 {
     }
 
     /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -853,7 +853,22 @@ impl Mat4 {
         Self::look_to_rh(eye, center.sub(eye), up)
     }
 
-    /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
+    /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that OpenGL expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
     #[inline]
@@ -877,7 +892,47 @@ impl Mat4 {
         )
     }
 
+    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that Vulkan expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points *down*, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    #[inline]
+    #[must_use]
+    pub fn perspective_rh_vk(
+        fov_y_radians: f32,
+        aspect_ratio: f32,
+        z_near: f32,
+        z_far: f32,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
     ///
     /// # Panics
     ///
@@ -901,6 +956,20 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
     /// # Panics
     ///
     /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
@@ -923,9 +992,27 @@ impl Mat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
     /// # Panics
     ///
-    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_lh(fov_y_radians: f32, aspect_ratio: f32, z_near: f32) -> Self {
@@ -941,7 +1028,11 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
+    /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
     /// # Panics
     ///
@@ -965,8 +1056,29 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite right-handed perspective projection matrix with
-    /// `[0,1]` depth range.
+    /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_rh(fov_y_radians: f32, aspect_ratio: f32, z_near: f32) -> Self {
@@ -980,8 +1092,15 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite reverse right-handed perspective projection matrix
-    /// with `[0,1]` depth range.
+    /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_reverse_rh(
@@ -1003,6 +1122,8 @@ impl Mat4 {
     /// range.  This is the same as the OpenGL `glOrtho` function in OpenGL.
     /// See
     /// <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glOrtho.xml>
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that OpenGL expects.
     #[inline]
     #[must_use]
     pub fn orthographic_rh_gl(
@@ -1028,7 +1149,26 @@ impl Mat4 {
         )
     }
 
+    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
+    /// range and Y axis pointing down.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
+    #[inline]
+    #[must_use]
+    pub fn orthographic_rh_vk(
+        left: f32,
+        right: f32,
+        bottom: f32,
+        top: f32,
+        near: f32,
+        far: f32,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a left-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_lh(
@@ -1056,6 +1196,8 @@ impl Mat4 {
     }
 
     /// Creates a right-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_rh(

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -880,20 +880,6 @@ impl Mat4 {
         )
     }
 
-    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
-    ///
-    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn perspective_rh_vk(
-        fov_y_radians: f32,
-        aspect_ratio: f32,
-        z_near: f32,
-        z_far: f32,
-    ) -> Self {
-        todo!()
-    }
-
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
     /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
@@ -1067,23 +1053,6 @@ impl Mat4 {
             Vec4::new(0.0, 0.0, c, 0.0),
             Vec4::new(tx, ty, tz, 1.0),
         )
-    }
-
-    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
-    /// range and Y axis pointing down.
-    ///
-    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn orthographic_rh_vk(
-        left: f32,
-        right: f32,
-        bottom: f32,
-        top: f32,
-        near: f32,
-        far: f32,
-    ) -> Self {
-        todo!()
     }
 
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -770,7 +770,22 @@ impl Mat4 {
         Self::look_to_rh(eye, center.sub(eye), up)
     }
 
-    /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
+    /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that OpenGL expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
     #[inline]
@@ -794,7 +809,47 @@ impl Mat4 {
         )
     }
 
+    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that Vulkan expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points *down*, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    #[inline]
+    #[must_use]
+    pub fn perspective_rh_vk(
+        fov_y_radians: f32,
+        aspect_ratio: f32,
+        z_near: f32,
+        z_far: f32,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
     ///
     /// # Panics
     ///
@@ -818,6 +873,20 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
     /// # Panics
     ///
     /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
@@ -840,9 +909,27 @@ impl Mat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
     /// # Panics
     ///
-    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_lh(fov_y_radians: f32, aspect_ratio: f32, z_near: f32) -> Self {
@@ -858,7 +945,11 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
+    /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
     /// # Panics
     ///
@@ -882,8 +973,29 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite right-handed perspective projection matrix with
-    /// `[0,1]` depth range.
+    /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_rh(fov_y_radians: f32, aspect_ratio: f32, z_near: f32) -> Self {
@@ -897,8 +1009,15 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite reverse right-handed perspective projection matrix
-    /// with `[0,1]` depth range.
+    /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_reverse_rh(
@@ -920,6 +1039,8 @@ impl Mat4 {
     /// range.  This is the same as the OpenGL `glOrtho` function in OpenGL.
     /// See
     /// <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glOrtho.xml>
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that OpenGL expects.
     #[inline]
     #[must_use]
     pub fn orthographic_rh_gl(
@@ -945,7 +1066,26 @@ impl Mat4 {
         )
     }
 
+    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
+    /// range and Y axis pointing down.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
+    #[inline]
+    #[must_use]
+    pub fn orthographic_rh_vk(
+        left: f32,
+        right: f32,
+        bottom: f32,
+        top: f32,
+        near: f32,
+        far: f32,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a left-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_lh(
@@ -973,6 +1113,8 @@ impl Mat4 {
     }
 
     /// Creates a right-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_rh(

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -797,20 +797,6 @@ impl Mat4 {
         )
     }
 
-    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
-    ///
-    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn perspective_rh_vk(
-        fov_y_radians: f32,
-        aspect_ratio: f32,
-        z_near: f32,
-        z_far: f32,
-    ) -> Self {
-        todo!()
-    }
-
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
     /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
@@ -984,23 +970,6 @@ impl Mat4 {
             Vec4::new(0.0, 0.0, c, 0.0),
             Vec4::new(tx, ty, tz, 1.0),
         )
-    }
-
-    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
-    /// range and Y axis pointing down.
-    ///
-    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn orthographic_rh_vk(
-        left: f32,
-        right: f32,
-        bottom: f32,
-        top: f32,
-        near: f32,
-        far: f32,
-    ) -> Self {
-        todo!()
     }
 
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -772,19 +772,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that OpenGL expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    /// Useful to map the standard right-handed coordinate system into what OpenGL expects.
     ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
@@ -811,19 +799,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that Vulkan expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points *down*, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
     #[inline]
     #[must_use]
     pub fn perspective_rh_vk(
@@ -837,19 +813,7 @@ impl Mat4 {
 
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -873,19 +837,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -909,22 +861,8 @@ impl Mat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_lh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -946,8 +884,6 @@ impl Mat4 {
     }
 
     /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
@@ -975,22 +911,8 @@ impl Mat4 {
 
     /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_rh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -1010,8 +932,6 @@ impl Mat4 {
     }
 
     /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -857,7 +857,22 @@ impl Mat4 {
         Self::look_to_rh(eye, center.sub(eye), up)
     }
 
-    /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
+    /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that OpenGL expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
     #[inline]
@@ -881,7 +896,47 @@ impl Mat4 {
         )
     }
 
+    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that Vulkan expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points *down*, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    #[inline]
+    #[must_use]
+    pub fn perspective_rh_vk(
+        fov_y_radians: f32,
+        aspect_ratio: f32,
+        z_near: f32,
+        z_far: f32,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
     ///
     /// # Panics
     ///
@@ -905,6 +960,20 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
     /// # Panics
     ///
     /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
@@ -927,9 +996,27 @@ impl Mat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
     /// # Panics
     ///
-    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_lh(fov_y_radians: f32, aspect_ratio: f32, z_near: f32) -> Self {
@@ -945,7 +1032,11 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
+    /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
     /// # Panics
     ///
@@ -969,8 +1060,29 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite right-handed perspective projection matrix with
-    /// `[0,1]` depth range.
+    /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_rh(fov_y_radians: f32, aspect_ratio: f32, z_near: f32) -> Self {
@@ -984,8 +1096,15 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite reverse right-handed perspective projection matrix
-    /// with `[0,1]` depth range.
+    /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_reverse_rh(
@@ -1007,6 +1126,8 @@ impl Mat4 {
     /// range.  This is the same as the OpenGL `glOrtho` function in OpenGL.
     /// See
     /// <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glOrtho.xml>
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that OpenGL expects.
     #[inline]
     #[must_use]
     pub fn orthographic_rh_gl(
@@ -1032,7 +1153,26 @@ impl Mat4 {
         )
     }
 
+    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
+    /// range and Y axis pointing down.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
+    #[inline]
+    #[must_use]
+    pub fn orthographic_rh_vk(
+        left: f32,
+        right: f32,
+        bottom: f32,
+        top: f32,
+        near: f32,
+        far: f32,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a left-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_lh(
@@ -1060,6 +1200,8 @@ impl Mat4 {
     }
 
     /// Creates a right-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_rh(

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -859,19 +859,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that OpenGL expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    /// Useful to map the standard right-handed coordinate system into what OpenGL expects.
     ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
@@ -898,19 +886,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that Vulkan expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points *down*, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
     #[inline]
     #[must_use]
     pub fn perspective_rh_vk(
@@ -924,19 +900,7 @@ impl Mat4 {
 
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -960,19 +924,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -996,22 +948,8 @@ impl Mat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_lh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -1033,8 +971,6 @@ impl Mat4 {
     }
 
     /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
@@ -1062,22 +998,8 @@ impl Mat4 {
 
     /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_rh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -1097,8 +1019,6 @@ impl Mat4 {
     }
 
     /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -884,20 +884,6 @@ impl Mat4 {
         )
     }
 
-    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
-    ///
-    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn perspective_rh_vk(
-        fov_y_radians: f32,
-        aspect_ratio: f32,
-        z_near: f32,
-        z_far: f32,
-    ) -> Self {
-        todo!()
-    }
-
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
     /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
@@ -1071,23 +1057,6 @@ impl Mat4 {
             Vec4::new(0.0, 0.0, c, 0.0),
             Vec4::new(tx, ty, tz, 1.0),
         )
-    }
-
-    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
-    /// range and Y axis pointing down.
-    ///
-    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn orthographic_rh_vk(
-        left: f32,
-        right: f32,
-        bottom: f32,
-        top: f32,
-        near: f32,
-        far: f32,
-    ) -> Self {
-        todo!()
     }
 
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -848,7 +848,22 @@ impl Mat4 {
         Self::look_to_rh(eye, center.sub(eye), up)
     }
 
-    /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
+    /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that OpenGL expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
     #[inline]
@@ -872,7 +887,47 @@ impl Mat4 {
         )
     }
 
+    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that Vulkan expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points *down*, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    #[inline]
+    #[must_use]
+    pub fn perspective_rh_vk(
+        fov_y_radians: f32,
+        aspect_ratio: f32,
+        z_near: f32,
+        z_far: f32,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
     ///
     /// # Panics
     ///
@@ -896,6 +951,20 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
     /// # Panics
     ///
     /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
@@ -918,9 +987,27 @@ impl Mat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
     /// # Panics
     ///
-    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_lh(fov_y_radians: f32, aspect_ratio: f32, z_near: f32) -> Self {
@@ -936,7 +1023,11 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
+    /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
     /// # Panics
     ///
@@ -960,8 +1051,29 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite right-handed perspective projection matrix with
-    /// `[0,1]` depth range.
+    /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_rh(fov_y_radians: f32, aspect_ratio: f32, z_near: f32) -> Self {
@@ -975,8 +1087,15 @@ impl Mat4 {
         )
     }
 
-    /// Creates an infinite reverse right-handed perspective projection matrix
-    /// with `[0,1]` depth range.
+    /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_reverse_rh(
@@ -998,6 +1117,8 @@ impl Mat4 {
     /// range.  This is the same as the OpenGL `glOrtho` function in OpenGL.
     /// See
     /// <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glOrtho.xml>
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that OpenGL expects.
     #[inline]
     #[must_use]
     pub fn orthographic_rh_gl(
@@ -1023,7 +1144,26 @@ impl Mat4 {
         )
     }
 
+    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
+    /// range and Y axis pointing down.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
+    #[inline]
+    #[must_use]
+    pub fn orthographic_rh_vk(
+        left: f32,
+        right: f32,
+        bottom: f32,
+        top: f32,
+        near: f32,
+        far: f32,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a left-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_lh(
@@ -1051,6 +1191,8 @@ impl Mat4 {
     }
 
     /// Creates a right-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_rh(

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -875,20 +875,6 @@ impl Mat4 {
         )
     }
 
-    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
-    ///
-    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn perspective_rh_vk(
-        fov_y_radians: f32,
-        aspect_ratio: f32,
-        z_near: f32,
-        z_far: f32,
-    ) -> Self {
-        todo!()
-    }
-
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
     /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
@@ -1062,23 +1048,6 @@ impl Mat4 {
             Vec4::new(0.0, 0.0, c, 0.0),
             Vec4::new(tx, ty, tz, 1.0),
         )
-    }
-
-    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
-    /// range and Y axis pointing down.
-    ///
-    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn orthographic_rh_vk(
-        left: f32,
-        right: f32,
-        bottom: f32,
-        top: f32,
-        near: f32,
-        far: f32,
-    ) -> Self {
-        todo!()
     }
 
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -850,19 +850,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that OpenGL expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    /// Useful to map the standard right-handed coordinate system into what OpenGL expects.
     ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
@@ -889,19 +877,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that Vulkan expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points *down*, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
     #[inline]
     #[must_use]
     pub fn perspective_rh_vk(
@@ -915,19 +891,7 @@ impl Mat4 {
 
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -951,19 +915,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -987,22 +939,8 @@ impl Mat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_lh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -1024,8 +962,6 @@ impl Mat4 {
     }
 
     /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
@@ -1053,22 +989,8 @@ impl Mat4 {
 
     /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_rh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -1088,8 +1010,6 @@ impl Mat4 {
     }
 
     /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -779,20 +779,6 @@ impl DMat4 {
         )
     }
 
-    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
-    ///
-    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn perspective_rh_vk(
-        fov_y_radians: f64,
-        aspect_ratio: f64,
-        z_near: f64,
-        z_far: f64,
-    ) -> Self {
-        todo!()
-    }
-
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
     /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
@@ -966,23 +952,6 @@ impl DMat4 {
             DVec4::new(0.0, 0.0, c, 0.0),
             DVec4::new(tx, ty, tz, 1.0),
         )
-    }
-
-    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
-    /// range and Y axis pointing down.
-    ///
-    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
-    #[inline]
-    #[must_use]
-    pub fn orthographic_rh_vk(
-        left: f64,
-        right: f64,
-        bottom: f64,
-        top: f64,
-        near: f64,
-        far: f64,
-    ) -> Self {
-        todo!()
     }
 
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -752,7 +752,22 @@ impl DMat4 {
         Self::look_to_rh(eye, center.sub(eye), up)
     }
 
-    /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
+    /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that OpenGL expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
     #[inline]
@@ -776,7 +791,47 @@ impl DMat4 {
         )
     }
 
+    /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that Vulkan expects:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points *down*, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    #[inline]
+    #[must_use]
+    pub fn perspective_rh_vk(
+        fov_y_radians: f64,
+        aspect_ratio: f64,
+        z_near: f64,
+        z_far: f64,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
     ///
     /// # Panics
     ///
@@ -800,6 +855,20 @@ impl DMat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
     /// # Panics
     ///
     /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
@@ -822,9 +891,27 @@ impl DMat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *into the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
     /// # Panics
     ///
-    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_lh(fov_y_radians: f64, aspect_ratio: f64, z_near: f64) -> Self {
@@ -840,7 +927,11 @@ impl DMat4 {
         )
     }
 
-    /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
+    /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
     /// # Panics
     ///
@@ -864,8 +955,29 @@ impl DMat4 {
         )
     }
 
-    /// Creates an infinite right-handed perspective projection matrix with
-    /// `[0,1]` depth range.
+    /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
+    ///
+    /// - `X+` points right
+    /// - `Y+` points up
+    /// - `Z+` points *out of the screen*
+    ///
+    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
+    ///
+    /// - `X+` points right, in the range `[-1, 1]`
+    /// - `Y+` points up, in the range `[-1, 1]`
+    /// - `Z+` points into the screen, in the range `[0, 1]`
+    ///
+    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
+    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` or `z_far` are less than or equal to zero when `glam_assert` is
+    /// enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_rh(fov_y_radians: f64, aspect_ratio: f64, z_near: f64) -> Self {
@@ -879,8 +991,15 @@ impl DMat4 {
         )
     }
 
-    /// Creates an infinite reverse right-handed perspective projection matrix
-    /// with `[0,1]` depth range.
+    /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
+    ///
+    /// # Interpretation
+    ///
+    /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `z_near` is less than or equal to zero when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn perspective_infinite_reverse_rh(
@@ -902,6 +1021,8 @@ impl DMat4 {
     /// range.  This is the same as the OpenGL `glOrtho` function in OpenGL.
     /// See
     /// <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/glOrtho.xml>
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that OpenGL expects.
     #[inline]
     #[must_use]
     pub fn orthographic_rh_gl(
@@ -927,7 +1048,26 @@ impl DMat4 {
         )
     }
 
+    /// Creates a right-handed orthographic projection matrix with `[0,1]` depth
+    /// range and Y axis pointing down.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that Vulkan expects.
+    #[inline]
+    #[must_use]
+    pub fn orthographic_rh_vk(
+        left: f64,
+        right: f64,
+        bottom: f64,
+        top: f64,
+        near: f64,
+        far: f64,
+    ) -> Self {
+        todo!()
+    }
+
     /// Creates a left-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a left-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_lh(
@@ -955,6 +1095,8 @@ impl DMat4 {
     }
 
     /// Creates a right-handed orthographic projection matrix with `[0,1]` depth range.
+    ///
+    /// Useful to map a right-handed coordinate system to the normalized device coordinates that WebGPU/Direct3D/Metal expect.
     #[inline]
     #[must_use]
     pub fn orthographic_rh(

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -754,19 +754,7 @@ impl DMat4 {
 
     /// Creates a right-handed perspective projection matrix with `[-1,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that OpenGL expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range *`[-1, 1]`*
+    /// Useful to map the standard right-handed coordinate system into what OpenGL expects.
     ///
     /// This is the same as the OpenGL `gluPerspective` function.
     /// See <https://www.khronos.org/registry/OpenGL-Refpages/gl2.1/xhtml/gluPerspective.xml>
@@ -793,19 +781,7 @@ impl DMat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range and Y axis pointing down.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that Vulkan expects:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points *down*, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what Vulkan expects.
     #[inline]
     #[must_use]
     pub fn perspective_rh_vk(
@@ -819,19 +795,7 @@ impl DMat4 {
 
     /// Creates a left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard left-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -855,19 +819,7 @@ impl DMat4 {
 
     /// Creates a right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
+    /// Useful to map the standard right-handed coordinate system into what WebGPU/Metal/Direct3D expect.
     ///
     /// # Panics
     ///
@@ -891,22 +843,8 @@ impl DMat4 {
 
     /// Creates an infinite left-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "left-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *into the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_lh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -928,8 +866,6 @@ impl DMat4 {
     }
 
     /// Creates an infinite reverse left-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_lh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///
@@ -957,22 +893,8 @@ impl DMat4 {
 
     /// Creates an infinite right-handed perspective projection matrix with `[0,1]` depth range.
     ///
-    /// # Interpretation
-    ///
-    /// This matrix an be interpreted as a projection that maps from the standard graphics "right-handed" coordinate system:
-    ///
-    /// - `X+` points right
-    /// - `Y+` points up
-    /// - `Z+` points *out of the screen*
-    ///
-    /// ...to the normalized device coordinate system that WebGPU/Direct3D/Metal expect:
-    ///
-    /// - `X+` points right, in the range `[-1, 1]`
-    /// - `Y+` points up, in the range `[-1, 1]`
-    /// - `Z+` points into the screen, in the range `[0, 1]`
-    ///
-    /// Z values near `z_near` map to a normalized-device-coordinate Z value of `0`.
-    /// Z values near infinity map to a normalized-device-coordinate Z value of `1`.
+    /// Like `perspective_rh`, but with an infinite value for `z_far`.
+    /// The result is that points near `z_near` are mapped to depth `0`, and as they move towards infinity the depth approaches `1`.
     ///
     /// # Panics
     ///
@@ -992,8 +914,6 @@ impl DMat4 {
     }
 
     /// Creates an infinite reverse right-handed perspective projection matrix with `[0,1]` depth range.
-    ///
-    /// # Interpretation
     ///
     /// Similar to `perspective_infinite_rh`, but maps `Z = z_near` to a depth of `1` and `Z = infinity` to a depth of `0`.
     ///


### PR DESCRIPTION
Like I mentioned in #569, this PR adds more detailed documentation to the `Mat4::perspective_*` and `Mat4::orthographic_*` family of functions, as well as adding `Mat4::perspective_rh_vk` and `Mat4::orthographic_rh_vk`.

I initially wrote a very detailed doc explaining what world-view coordinates get mapped to what normalized-device-coordinates, but they look very out-of-place and are probably too much. Instead, I added a small subtext among the lines of `Useful to map the standard right-handed coordinate system into what OpenGL expects.`.

I haven't implemented the `*_rh_vk` functions or their tests yet. I would like to receive confirmation that this PR is ok before doing so.