### PR TITLE
Add support for `rand`'s `Uniform` distribution to all Vec types

### DIFF
--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -76,44 +76,95 @@ macro_rules! impl_int_types {
         impl UniformSampler for UniformVec2<$vec2, UniformInt<$t>> {
             type X = $vec2;
 
-            fn new<B1, B2>(_low: B1, _high: B2) -> Self
+            fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
             {
-                todo!()
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(low.x < high.x, "Uniform::new called with `low.x >= high.x");
+                assert!(low.y < high.y, "Uniform::new called with `low.y >= high.y");
+                Self {
+                    x_gen: UniformInt::new(low.x, high.x),
+                    y_gen: UniformInt::new(low.y, high.y),
+                    vec_type: PhantomData,
+                }
             }
 
-            fn new_inclusive<B1, B2>(_low: B1, _high: B2) -> Self
+            fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
             {
-                todo!()
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::new_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::new_inclusive called with `low.y >= high.y"
+                );
+                Self {
+                    x_gen: UniformInt::new_inclusive(low.x, high.x),
+                    y_gen: UniformInt::new_inclusive(low.y, high.y),
+                    vec_type: PhantomData,
+                }
             }
 
-            fn sample<R: Rng + ?Sized>(&self, _rng: &mut R) -> Self::X {
-                todo!()
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                Self::X {
+                    x: self.x_gen.sample(rng),
+                    y: self.y_gen.sample(rng),
+                }
             }
 
-            fn sample_single<R: Rng + ?Sized, B1, B2>(_low: B1, _high: B2, _rng: &mut R) -> Self::X
+            fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
             {
-                todo!()
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single called with `low.y >= high.y"
+                );
+                Self::X {
+                    x: UniformInt::<$t>::sample_single(low.x, high.x, rng),
+                    y: UniformInt::<$t>::sample_single(low.y, high.y, rng),
+                }
             }
 
             fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
-                _low: B1,
-                _high: B2,
-                _rng: &mut R,
+                low_b: B1,
+                high_b: B2,
+                rng: &mut R,
             ) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
             {
-                todo!()
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single_inclusive called with `low.y >= high.y"
+                );
+                Self::X {
+                    x: UniformInt::<$t>::sample_single_inclusive(low.x, high.x, rng),
+                    y: UniformInt::<$t>::sample_single_inclusive(low.y, high.y, rng),
+                }
             }
         }
 
@@ -124,44 +175,113 @@ macro_rules! impl_int_types {
         impl UniformSampler for UniformVec3<$vec3, UniformInt<$t>> {
             type X = $vec3;
 
-            fn new<B1, B2>(_low: B1, _high: B2) -> Self
+            fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
             {
-                todo!()
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(low.x < high.x, "Uniform::new called with `low.x >= high.x");
+                assert!(low.y < high.y, "Uniform::new called with `low.y >= high.y");
+                assert!(low.z < high.z, "Uniform::new called with `low.z >= high.z");
+                Self {
+                    x_gen: UniformInt::new(low.x, high.x),
+                    y_gen: UniformInt::new(low.y, high.y),
+                    z_gen: UniformInt::new(low.z, high.z),
+                    vec_type: PhantomData,
+                }
             }
 
-            fn new_inclusive<B1, B2>(_low: B1, _high: B2) -> Self
+            fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
             {
-                todo!()
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::new_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::new_inclusive called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::new_inclusive called with `low.z >= high.z"
+                );
+                Self {
+                    x_gen: UniformInt::new_inclusive(low.x, high.x),
+                    y_gen: UniformInt::new_inclusive(low.y, high.y),
+                    z_gen: UniformInt::new_inclusive(low.z, high.z),
+                    vec_type: PhantomData,
+                }
             }
 
-            fn sample<R: Rng + ?Sized>(&self, _rng: &mut R) -> Self::X {
-                todo!()
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                Self::X {
+                    x: self.x_gen.sample(rng),
+                    y: self.y_gen.sample(rng),
+                    z: self.z_gen.sample(rng),
+                }
             }
 
-            fn sample_single<R: Rng + ?Sized, B1, B2>(_low: B1, _high: B2, _rng: &mut R) -> Self::X
+            fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
             {
-                todo!()
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::sample_single called with `low.z >= high.z"
+                );
+                Self::X {
+                    x: UniformInt::<$t>::sample_single(low.x, high.x, rng),
+                    y: UniformInt::<$t>::sample_single(low.y, high.y, rng),
+                    z: UniformInt::<$t>::sample_single(low.z, high.z, rng),
+                }
             }
 
             fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
-                _low: B1,
-                _high: B2,
-                _rng: &mut R,
+                low_b: B1,
+                high_b: B2,
+                rng: &mut R,
             ) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
             {
-                todo!()
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single_inclusive called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::sample_single_inclusive called with `low.z >= high.z"
+                );
+                Self::X {
+                    x: UniformInt::<$t>::sample_single_inclusive(low.x, high.x, rng),
+                    y: UniformInt::<$t>::sample_single_inclusive(low.y, high.y, rng),
+                    z: UniformInt::<$t>::sample_single_inclusive(low.z, high.z, rng),
+                }
             }
         }
 
@@ -179,6 +299,10 @@ macro_rules! impl_int_types {
             {
                 let low = *low_b.borrow();
                 let high = *high_b.borrow();
+                assert!(low.x < high.x, "Uniform::new called with `low.x >= high.x");
+                assert!(low.y < high.y, "Uniform::new called with `low.y >= high.y");
+                assert!(low.z < high.z, "Uniform::new called with `low.z >= high.z");
+                assert!(low.w < high.w, "Uniform::new called with `low.w >= high.w");
                 Self {
                     x_gen: UniformInt::new(low.x, high.x),
                     y_gen: UniformInt::new(low.y, high.y),
@@ -188,36 +312,111 @@ macro_rules! impl_int_types {
                 }
             }
 
-            fn new_inclusive<B1, B2>(_low: B1, _high: B2) -> Self
+            fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
             {
-                todo!()
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::new_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::new_inclusive called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::new_inclusive called with `low.z >= high.z"
+                );
+                assert!(
+                    low.w < high.w,
+                    "Uniform::new_inclusive called with `low.w >= high.w"
+                );
+                Self {
+                    x_gen: UniformInt::new_inclusive(low.x, high.x),
+                    y_gen: UniformInt::new_inclusive(low.y, high.y),
+                    z_gen: UniformInt::new_inclusive(low.z, high.z),
+                    w_gen: UniformInt::new_inclusive(low.w, high.w),
+                    vec_type: PhantomData,
+                }
             }
 
-            fn sample<R: Rng + ?Sized>(&self, _rng: &mut R) -> Self::X {
-                todo!()
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                Self::X {
+                    x: self.x_gen.sample(rng),
+                    y: self.y_gen.sample(rng),
+                    z: self.z_gen.sample(rng),
+                    w: self.w_gen.sample(rng),
+                }
             }
 
-            fn sample_single<R: Rng + ?Sized, B1, B2>(_low: B1, _high: B2, _rng: &mut R) -> Self::X
+            fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
             {
-                todo!()
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::sample_single called with `low.z >= high.z"
+                );
+                assert!(
+                    low.w < high.w,
+                    "Uniform::sample_single called with `low.w >= high.w"
+                );
+                Self::X {
+                    x: UniformInt::<$t>::sample_single(low.x, high.x, rng),
+                    y: UniformInt::<$t>::sample_single(low.y, high.y, rng),
+                    z: UniformInt::<$t>::sample_single(low.z, high.z, rng),
+                    w: UniformInt::<$t>::sample_single(low.w, high.w, rng),
+                }
             }
 
             fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
-                _low: B1,
-                _high: B2,
-                _rng: &mut R,
+                low_b: B1,
+                high_b: B2,
+                rng: &mut R,
             ) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
             {
-                todo!()
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single_inclusive called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::sample_single_inclusive called with `low.z >= high.z"
+                );
+                assert!(
+                    low.w < high.w,
+                    "Uniform::sample_single_inclusive called with `low.w >= high.w"
+                );
+                Self::X {
+                    x: UniformInt::<$t>::sample_single_inclusive(low.x, high.x, rng),
+                    y: UniformInt::<$t>::sample_single_inclusive(low.y, high.y, rng),
+                    z: UniformInt::<$t>::sample_single_inclusive(low.z, high.z, rng),
+                    w: UniformInt::<$t>::sample_single_inclusive(low.w, high.w, rng),
+                }
             }
         }
     };

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -456,7 +456,7 @@ macro_rules! test_vec_type_uniform {
         $vec:ident,
         $t:ty,
         $t_count:tt,
-        $upper_range_multiplier:expr
+        $upper_range_divisor:expr
     ) => {
         /// Tests that we reach the same result, whether we generate the vector
         /// type directly, or generate its internal values $t_count times and
@@ -514,17 +514,17 @@ macro_rules! test_vec_type_uniform {
             test_uniform!(
                 new,
                 <$t>::default(),
-                <$t>::MAX * $upper_range_multiplier,
+                <$t>::MAX / $upper_range_divisor,
                 $vec::default(),
-                $vec::MAX * $upper_range_multiplier
+                $vec::MAX / $upper_range_divisor
             );
 
             test_uniform!(
                 new_inclusive,
                 <$t>::default(),
-                <$t>::MAX * $upper_range_multiplier,
+                <$t>::MAX / $upper_range_divisor,
                 $vec::default(),
-                $vec::MAX * $upper_range_multiplier
+                $vec::MAX / $upper_range_divisor
             );
 
             macro_rules! test_sample_uniform_sampler {
@@ -533,14 +533,14 @@ macro_rules! test_vec_type_uniform {
                         __repeat_code $t_count,
                         <$t as SampleUniform>::Sampler::$sampler_function_name(
                             <$t>::default(),
-                            <$t>::MAX * $upper_range_multiplier,
+                            <$t>::MAX / $upper_range_divisor,
                             &mut int_rng,
                         )
                     );
 
                     let v_vec: $vec = <$vec as SampleUniform>::Sampler::$sampler_function_name(
                         $vec::default(),
-                        $vec::MAX * $upper_range_multiplier,
+                        $vec::MAX / $upper_range_divisor,
                         &mut vec_rng,
                     );
                     assert_eq!(v_int, v_vec.into());
@@ -565,7 +565,7 @@ macro_rules! impl_float_types {
     ($t:ident, $mat2:ident, $mat3:ident, $mat4:ident, $quat:ident, $vec2:ident, $vec3:ident, $vec4:ident) => {
         use rand::distributions::uniform::UniformFloat;
 
-        impl_vec_types!($t, $vec2, $vec3, $vec4, UniformFloat, 0.1);
+        impl_vec_types!($t, $vec2, $vec3, $vec4, UniformFloat, 10.0);
 
         impl Distribution<$mat2> for Standard {
             #[inline]

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -408,8 +408,9 @@ macro_rules! impl_vec_types {
 }
 
 macro_rules! test_vec_type_uniform {
-    // If I put these into a macro in the main branch below, rustc will complain about unused macros
-    // even if I use it.
+    // NOTE: These were intended to be placed in a `macro_rules!` statement in the main rule below,
+    // but rustc wants to complain about unused macros if I try to do that... even if I do use the
+    // macros.
     (__repeat_code 2, $code:expr) => {
         ($code, $code)
     };

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -503,9 +503,9 @@ macro_rules! impl_int_types {
 
         impl_vec_types!($t, $vec2, $vec3, $vec4, UniformInt);
 
-        test_vec_type_uniform!(test_vec2_rand_uniform, $vec2, $t, 2);
-        test_vec_type_uniform!(test_vec3_rand_uniform, $vec3, $t, 3);
-        test_vec_type_uniform!(test_vec4_rand_uniform, $vec4, $t, 4);
+        test_vec_type_uniform!(test_vec2_rand_uniform_equality, $vec2, $t, 2);
+        test_vec_type_uniform!(test_vec3_rand_uniform_equality, $vec3, $t, 3);
+        test_vec_type_uniform!(test_vec4_rand_uniform_equality, $vec4, $t, 4);
     };
 }
 

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -1,13 +1,115 @@
 macro_rules! impl_vec_types {
-    ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident) => {
+    ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident, $uniform:ident) => {
+        use super::{UniformVec2, UniformVec3, UniformVec4};
+        use core::marker::PhantomData;
         use rand::{
-            distributions::{Distribution, Standard},
+            distributions::{
+                uniform::{SampleBorrow, SampleUniform, UniformSampler},
+                Distribution, Standard,
+            },
             Rng,
         };
+
         impl Distribution<$vec2> for Standard {
             #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $vec2 {
                 rng.gen::<[$t; 2]>().into()
+            }
+        }
+
+        impl SampleUniform for $vec2 {
+            type Sampler = UniformVec2<$vec2, $uniform<$t>>;
+        }
+
+        impl UniformSampler for UniformVec2<$vec2, $uniform<$t>> {
+            type X = $vec2;
+
+            fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(low.x < high.x, "Uniform::new called with `low.x >= high.x");
+                assert!(low.y < high.y, "Uniform::new called with `low.y >= high.y");
+                Self {
+                    x_gen: $uniform::new(low.x, high.x),
+                    y_gen: $uniform::new(low.y, high.y),
+                    vec_type: PhantomData,
+                }
+            }
+
+            fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::new_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::new_inclusive called with `low.y >= high.y"
+                );
+                Self {
+                    x_gen: $uniform::new_inclusive(low.x, high.x),
+                    y_gen: $uniform::new_inclusive(low.y, high.y),
+                    vec_type: PhantomData,
+                }
+            }
+
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                Self::X::from([self.x_gen.sample(rng), self.y_gen.sample(rng)])
+            }
+
+            fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single called with `low.y >= high.y"
+                );
+                Self::X::from([
+                    $uniform::<$t>::sample_single(low.x, high.x, rng),
+                    $uniform::<$t>::sample_single(low.y, high.y, rng),
+                ])
+            }
+
+            fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
+                low_b: B1,
+                high_b: B2,
+                rng: &mut R,
+            ) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single_inclusive called with `low.y >= high.y"
+                );
+                Self::X::from([
+                    $uniform::<$t>::sample_single_inclusive(low.x, high.x, rng),
+                    $uniform::<$t>::sample_single_inclusive(low.y, high.y, rng),
+                ])
             }
         }
 
@@ -18,10 +120,262 @@ macro_rules! impl_vec_types {
             }
         }
 
+        impl SampleUniform for $vec3 {
+            type Sampler = UniformVec3<$vec3, $uniform<$t>>;
+        }
+
+        impl UniformSampler for UniformVec3<$vec3, $uniform<$t>> {
+            type X = $vec3;
+
+            fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(low.x < high.x, "Uniform::new called with `low.x >= high.x");
+                assert!(low.y < high.y, "Uniform::new called with `low.y >= high.y");
+                assert!(low.z < high.z, "Uniform::new called with `low.z >= high.z");
+                Self {
+                    x_gen: $uniform::new(low.x, high.x),
+                    y_gen: $uniform::new(low.y, high.y),
+                    z_gen: $uniform::new(low.z, high.z),
+                    vec_type: PhantomData,
+                }
+            }
+
+            fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::new_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::new_inclusive called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::new_inclusive called with `low.z >= high.z"
+                );
+                Self {
+                    x_gen: $uniform::new_inclusive(low.x, high.x),
+                    y_gen: $uniform::new_inclusive(low.y, high.y),
+                    z_gen: $uniform::new_inclusive(low.z, high.z),
+                    vec_type: PhantomData,
+                }
+            }
+
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                Self::X::from([
+                    self.x_gen.sample(rng),
+                    self.y_gen.sample(rng),
+                    self.z_gen.sample(rng),
+                ])
+            }
+
+            fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::sample_single called with `low.z >= high.z"
+                );
+                Self::X::from([
+                    $uniform::<$t>::sample_single(low.x, high.x, rng),
+                    $uniform::<$t>::sample_single(low.y, high.y, rng),
+                    $uniform::<$t>::sample_single(low.z, high.z, rng),
+                ])
+            }
+
+            fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
+                low_b: B1,
+                high_b: B2,
+                rng: &mut R,
+            ) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single_inclusive called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::sample_single_inclusive called with `low.z >= high.z"
+                );
+                Self::X::from([
+                    $uniform::<$t>::sample_single_inclusive(low.x, high.x, rng),
+                    $uniform::<$t>::sample_single_inclusive(low.y, high.y, rng),
+                    $uniform::<$t>::sample_single_inclusive(low.z, high.z, rng),
+                ])
+            }
+        }
+
         impl Distribution<$vec4> for Standard {
             #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $vec4 {
                 rng.gen::<[$t; 4]>().into()
+            }
+        }
+
+        impl SampleUniform for $vec4 {
+            type Sampler = UniformVec4<$vec4, $uniform<$t>>;
+        }
+
+        impl UniformSampler for UniformVec4<$vec4, $uniform<$t>> {
+            type X = $vec4;
+
+            fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(low.x < high.x, "Uniform::new called with `low.x >= high.x");
+                assert!(low.y < high.y, "Uniform::new called with `low.y >= high.y");
+                assert!(low.z < high.z, "Uniform::new called with `low.z >= high.z");
+                assert!(low.w < high.w, "Uniform::new called with `low.w >= high.w");
+                Self {
+                    x_gen: $uniform::new(low.x, high.x),
+                    y_gen: $uniform::new(low.y, high.y),
+                    z_gen: $uniform::new(low.z, high.z),
+                    w_gen: $uniform::new(low.w, high.w),
+                    vec_type: PhantomData,
+                }
+            }
+
+            fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::new_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::new_inclusive called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::new_inclusive called with `low.z >= high.z"
+                );
+                assert!(
+                    low.w < high.w,
+                    "Uniform::new_inclusive called with `low.w >= high.w"
+                );
+                Self {
+                    x_gen: $uniform::new_inclusive(low.x, high.x),
+                    y_gen: $uniform::new_inclusive(low.y, high.y),
+                    z_gen: $uniform::new_inclusive(low.z, high.z),
+                    w_gen: $uniform::new_inclusive(low.w, high.w),
+                    vec_type: PhantomData,
+                }
+            }
+
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                Self::X::from([
+                    self.x_gen.sample(rng),
+                    self.y_gen.sample(rng),
+                    self.z_gen.sample(rng),
+                    self.w_gen.sample(rng),
+                ])
+            }
+
+            fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::sample_single called with `low.z >= high.z"
+                );
+                assert!(
+                    low.w < high.w,
+                    "Uniform::sample_single called with `low.w >= high.w"
+                );
+                Self::X::from([
+                    $uniform::<$t>::sample_single(low.x, high.x, rng),
+                    $uniform::<$t>::sample_single(low.y, high.y, rng),
+                    $uniform::<$t>::sample_single(low.z, high.z, rng),
+                    $uniform::<$t>::sample_single(low.w, high.w, rng),
+                ])
+            }
+
+            fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
+                low_b: B1,
+                high_b: B2,
+                rng: &mut R,
+            ) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                assert!(
+                    low.x < high.x,
+                    "Uniform::sample_single_inclusive called with `low.x >= high.x"
+                );
+                assert!(
+                    low.y < high.y,
+                    "Uniform::sample_single_inclusive called with `low.y >= high.y"
+                );
+                assert!(
+                    low.z < high.z,
+                    "Uniform::sample_single_inclusive called with `low.z >= high.z"
+                );
+                assert!(
+                    low.w < high.w,
+                    "Uniform::sample_single_inclusive called with `low.w >= high.w"
+                );
+                Self::X::from([
+                    $uniform::<$t>::sample_single_inclusive(low.x, high.x, rng),
+                    $uniform::<$t>::sample_single_inclusive(low.y, high.y, rng),
+                    $uniform::<$t>::sample_single_inclusive(low.z, high.z, rng),
+                    $uniform::<$t>::sample_single_inclusive(low.w, high.w, rng),
+                ])
             }
         }
 
@@ -62,369 +416,17 @@ macro_rules! impl_vec_types {
 
 macro_rules! impl_int_types {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident) => {
-        impl_vec_types!($t, $vec2, $vec3, $vec4);
-        use super::{UniformVec2, UniformVec3, UniformVec4};
-        use core::marker::PhantomData;
-        use rand::distributions::uniform::{
-            SampleBorrow, SampleUniform, UniformInt, UniformSampler,
-        };
+        use rand::distributions::uniform::UniformInt;
 
-        impl SampleUniform for $vec2 {
-            type Sampler = UniformVec2<$vec2, UniformInt<$t>>;
-        }
-
-        impl UniformSampler for UniformVec2<$vec2, UniformInt<$t>> {
-            type X = $vec2;
-
-            fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(low.x < high.x, "Uniform::new called with `low.x >= high.x");
-                assert!(low.y < high.y, "Uniform::new called with `low.y >= high.y");
-                Self {
-                    x_gen: UniformInt::new(low.x, high.x),
-                    y_gen: UniformInt::new(low.y, high.y),
-                    vec_type: PhantomData,
-                }
-            }
-
-            fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(
-                    low.x < high.x,
-                    "Uniform::new_inclusive called with `low.x >= high.x"
-                );
-                assert!(
-                    low.y < high.y,
-                    "Uniform::new_inclusive called with `low.y >= high.y"
-                );
-                Self {
-                    x_gen: UniformInt::new_inclusive(low.x, high.x),
-                    y_gen: UniformInt::new_inclusive(low.y, high.y),
-                    vec_type: PhantomData,
-                }
-            }
-
-            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
-                Self::X {
-                    x: self.x_gen.sample(rng),
-                    y: self.y_gen.sample(rng),
-                }
-            }
-
-            fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Self::X
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(
-                    low.x < high.x,
-                    "Uniform::sample_single called with `low.x >= high.x"
-                );
-                assert!(
-                    low.y < high.y,
-                    "Uniform::sample_single called with `low.y >= high.y"
-                );
-                Self::X {
-                    x: UniformInt::<$t>::sample_single(low.x, high.x, rng),
-                    y: UniformInt::<$t>::sample_single(low.y, high.y, rng),
-                }
-            }
-
-            fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
-                low_b: B1,
-                high_b: B2,
-                rng: &mut R,
-            ) -> Self::X
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(
-                    low.x < high.x,
-                    "Uniform::sample_single_inclusive called with `low.x >= high.x"
-                );
-                assert!(
-                    low.y < high.y,
-                    "Uniform::sample_single_inclusive called with `low.y >= high.y"
-                );
-                Self::X {
-                    x: UniformInt::<$t>::sample_single_inclusive(low.x, high.x, rng),
-                    y: UniformInt::<$t>::sample_single_inclusive(low.y, high.y, rng),
-                }
-            }
-        }
-
-        impl SampleUniform for $vec3 {
-            type Sampler = UniformVec3<$vec3, UniformInt<$t>>;
-        }
-
-        impl UniformSampler for UniformVec3<$vec3, UniformInt<$t>> {
-            type X = $vec3;
-
-            fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(low.x < high.x, "Uniform::new called with `low.x >= high.x");
-                assert!(low.y < high.y, "Uniform::new called with `low.y >= high.y");
-                assert!(low.z < high.z, "Uniform::new called with `low.z >= high.z");
-                Self {
-                    x_gen: UniformInt::new(low.x, high.x),
-                    y_gen: UniformInt::new(low.y, high.y),
-                    z_gen: UniformInt::new(low.z, high.z),
-                    vec_type: PhantomData,
-                }
-            }
-
-            fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(
-                    low.x < high.x,
-                    "Uniform::new_inclusive called with `low.x >= high.x"
-                );
-                assert!(
-                    low.y < high.y,
-                    "Uniform::new_inclusive called with `low.y >= high.y"
-                );
-                assert!(
-                    low.z < high.z,
-                    "Uniform::new_inclusive called with `low.z >= high.z"
-                );
-                Self {
-                    x_gen: UniformInt::new_inclusive(low.x, high.x),
-                    y_gen: UniformInt::new_inclusive(low.y, high.y),
-                    z_gen: UniformInt::new_inclusive(low.z, high.z),
-                    vec_type: PhantomData,
-                }
-            }
-
-            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
-                Self::X {
-                    x: self.x_gen.sample(rng),
-                    y: self.y_gen.sample(rng),
-                    z: self.z_gen.sample(rng),
-                }
-            }
-
-            fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Self::X
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(
-                    low.x < high.x,
-                    "Uniform::sample_single called with `low.x >= high.x"
-                );
-                assert!(
-                    low.y < high.y,
-                    "Uniform::sample_single called with `low.y >= high.y"
-                );
-                assert!(
-                    low.z < high.z,
-                    "Uniform::sample_single called with `low.z >= high.z"
-                );
-                Self::X {
-                    x: UniformInt::<$t>::sample_single(low.x, high.x, rng),
-                    y: UniformInt::<$t>::sample_single(low.y, high.y, rng),
-                    z: UniformInt::<$t>::sample_single(low.z, high.z, rng),
-                }
-            }
-
-            fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
-                low_b: B1,
-                high_b: B2,
-                rng: &mut R,
-            ) -> Self::X
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(
-                    low.x < high.x,
-                    "Uniform::sample_single_inclusive called with `low.x >= high.x"
-                );
-                assert!(
-                    low.y < high.y,
-                    "Uniform::sample_single_inclusive called with `low.y >= high.y"
-                );
-                assert!(
-                    low.z < high.z,
-                    "Uniform::sample_single_inclusive called with `low.z >= high.z"
-                );
-                Self::X {
-                    x: UniformInt::<$t>::sample_single_inclusive(low.x, high.x, rng),
-                    y: UniformInt::<$t>::sample_single_inclusive(low.y, high.y, rng),
-                    z: UniformInt::<$t>::sample_single_inclusive(low.z, high.z, rng),
-                }
-            }
-        }
-
-        impl SampleUniform for $vec4 {
-            type Sampler = UniformVec4<$vec4, UniformInt<$t>>;
-        }
-
-        impl UniformSampler for UniformVec4<$vec4, UniformInt<$t>> {
-            type X = $vec4;
-
-            fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(low.x < high.x, "Uniform::new called with `low.x >= high.x");
-                assert!(low.y < high.y, "Uniform::new called with `low.y >= high.y");
-                assert!(low.z < high.z, "Uniform::new called with `low.z >= high.z");
-                assert!(low.w < high.w, "Uniform::new called with `low.w >= high.w");
-                Self {
-                    x_gen: UniformInt::new(low.x, high.x),
-                    y_gen: UniformInt::new(low.y, high.y),
-                    z_gen: UniformInt::new(low.z, high.z),
-                    w_gen: UniformInt::new(low.w, high.w),
-                    vec_type: PhantomData,
-                }
-            }
-
-            fn new_inclusive<B1, B2>(low_b: B1, high_b: B2) -> Self
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(
-                    low.x < high.x,
-                    "Uniform::new_inclusive called with `low.x >= high.x"
-                );
-                assert!(
-                    low.y < high.y,
-                    "Uniform::new_inclusive called with `low.y >= high.y"
-                );
-                assert!(
-                    low.z < high.z,
-                    "Uniform::new_inclusive called with `low.z >= high.z"
-                );
-                assert!(
-                    low.w < high.w,
-                    "Uniform::new_inclusive called with `low.w >= high.w"
-                );
-                Self {
-                    x_gen: UniformInt::new_inclusive(low.x, high.x),
-                    y_gen: UniformInt::new_inclusive(low.y, high.y),
-                    z_gen: UniformInt::new_inclusive(low.z, high.z),
-                    w_gen: UniformInt::new_inclusive(low.w, high.w),
-                    vec_type: PhantomData,
-                }
-            }
-
-            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
-                Self::X {
-                    x: self.x_gen.sample(rng),
-                    y: self.y_gen.sample(rng),
-                    z: self.z_gen.sample(rng),
-                    w: self.w_gen.sample(rng),
-                }
-            }
-
-            fn sample_single<R: Rng + ?Sized, B1, B2>(low_b: B1, high_b: B2, rng: &mut R) -> Self::X
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(
-                    low.x < high.x,
-                    "Uniform::sample_single called with `low.x >= high.x"
-                );
-                assert!(
-                    low.y < high.y,
-                    "Uniform::sample_single called with `low.y >= high.y"
-                );
-                assert!(
-                    low.z < high.z,
-                    "Uniform::sample_single called with `low.z >= high.z"
-                );
-                assert!(
-                    low.w < high.w,
-                    "Uniform::sample_single called with `low.w >= high.w"
-                );
-                Self::X {
-                    x: UniformInt::<$t>::sample_single(low.x, high.x, rng),
-                    y: UniformInt::<$t>::sample_single(low.y, high.y, rng),
-                    z: UniformInt::<$t>::sample_single(low.z, high.z, rng),
-                    w: UniformInt::<$t>::sample_single(low.w, high.w, rng),
-                }
-            }
-
-            fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
-                low_b: B1,
-                high_b: B2,
-                rng: &mut R,
-            ) -> Self::X
-            where
-                B1: SampleBorrow<Self::X> + Sized,
-                B2: SampleBorrow<Self::X> + Sized,
-            {
-                let low = *low_b.borrow();
-                let high = *high_b.borrow();
-                assert!(
-                    low.x < high.x,
-                    "Uniform::sample_single_inclusive called with `low.x >= high.x"
-                );
-                assert!(
-                    low.y < high.y,
-                    "Uniform::sample_single_inclusive called with `low.y >= high.y"
-                );
-                assert!(
-                    low.z < high.z,
-                    "Uniform::sample_single_inclusive called with `low.z >= high.z"
-                );
-                assert!(
-                    low.w < high.w,
-                    "Uniform::sample_single_inclusive called with `low.w >= high.w"
-                );
-                Self::X {
-                    x: UniformInt::<$t>::sample_single_inclusive(low.x, high.x, rng),
-                    y: UniformInt::<$t>::sample_single_inclusive(low.y, high.y, rng),
-                    z: UniformInt::<$t>::sample_single_inclusive(low.z, high.z, rng),
-                    w: UniformInt::<$t>::sample_single_inclusive(low.w, high.w, rng),
-                }
-            }
-        }
+        impl_vec_types!($t, $vec2, $vec3, $vec4, UniformInt);
     };
 }
 
 macro_rules! impl_float_types {
     ($t:ident, $mat2:ident, $mat3:ident, $mat4:ident, $quat:ident, $vec2:ident, $vec3:ident, $vec4:ident) => {
-        impl_vec_types!($t, $vec2, $vec3, $vec4);
+        use rand::distributions::uniform::UniformFloat;
+
+        impl_vec_types!($t, $vec2, $vec3, $vec4, UniformFloat);
 
         impl Distribution<$mat2> for Standard {
             #[inline]

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -412,78 +412,90 @@ macro_rules! impl_int_types {
         use rand::distributions::uniform::UniformInt;
 
         impl_vec_types!($t, $vec2, $vec3, $vec4, UniformInt);
-        
+
         #[test]
         fn test_vec2_rand_uniform() {
             use rand::{distributions::Uniform, Rng, SeedableRng};
             use rand_xoshiro::Xoshiro256Plus;
-            
+
             macro_rules! test_uniform {
                 ($int_uniform:expr, $vec_uniform:expr) => {
                     let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
                     let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
                     let full_int_uniform = $int_uniform;
                     let full_vec_uniform = $vec_uniform;
-                    
+
                     let v_int: ($t, $t) = (
                         int_rng.sample(full_int_uniform),
                         int_rng.sample(full_int_uniform),
                     );
                     let v_vec: $vec2 = vec_rng.sample(full_vec_uniform);
                     assert_eq!(v_int, v_vec.into());
-                }
+                };
             }
-            
+
             test_uniform!(
                 Uniform::new(<$t>::default(), <$t>::MAX),
                 Uniform::new($vec2::default(), $vec2::MAX)
             );
-            
+
             test_uniform!(
                 Uniform::new(&<$t>::default(), &<$t>::MAX),
                 Uniform::new(&$vec2::default(), &$vec2::MAX)
             );
-            
+
             test_uniform!(
                 Uniform::new_inclusive(<$t>::default(), <$t>::MAX),
                 Uniform::new_inclusive($vec2::default(), $vec2::MAX)
             );
-            
+
             test_uniform!(
                 Uniform::new_inclusive(&<$t>::default(), &<$t>::MAX),
                 Uniform::new_inclusive(&$vec2::default(), &$vec2::MAX)
             );
-            
+
             macro_rules! test_sample_uniform_sampler {
                 ($sampler_function_name:ident) => {
                     let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
                     let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
-                    
+
                     let v_int: ($t, $t) = (
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(
+                            <$t>::default(),
+                            <$t>::MAX,
+                            &mut int_rng,
+                        ),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(
+                            <$t>::default(),
+                            <$t>::MAX,
+                            &mut int_rng,
+                        ),
                     );
-                    let v_vec: $vec2 = <$vec2 as SampleUniform>::Sampler::$sampler_function_name($vec2::default(), $vec2::MAX, &mut vec_rng);
+                    let v_vec: $vec2 = <$vec2 as SampleUniform>::Sampler::$sampler_function_name(
+                        $vec2::default(),
+                        $vec2::MAX,
+                        &mut vec_rng,
+                    );
                     assert_eq!(v_int, v_vec.into());
-                }
+                };
             }
-            
+
             test_sample_uniform_sampler!(sample_single);
             test_sample_uniform_sampler!(sample_single_inclusive);
         }
-        
+
         #[test]
         fn test_vec3_rand_uniform() {
             use rand::{distributions::Uniform, Rng, SeedableRng};
             use rand_xoshiro::Xoshiro256Plus;
-            
+
             macro_rules! test_uniform {
                 ($int_uniform:expr, $vec_uniform:expr) => {
                     let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
                     let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
                     let full_int_uniform = $int_uniform;
                     let full_vec_uniform = $vec_uniform;
-                    
+
                     let v_int: ($t, $t, $t) = (
                         int_rng.sample(full_int_uniform),
                         int_rng.sample(full_int_uniform),
@@ -491,60 +503,76 @@ macro_rules! impl_int_types {
                     );
                     let v_vec: $vec3 = vec_rng.sample(full_vec_uniform);
                     assert_eq!(v_int, v_vec.into());
-                }
+                };
             }
-            
+
             test_uniform!(
                 Uniform::new(<$t>::default(), <$t>::MAX),
                 Uniform::new($vec3::default(), $vec3::MAX)
             );
-            
+
             test_uniform!(
                 Uniform::new(&<$t>::default(), &<$t>::MAX),
                 Uniform::new(&$vec3::default(), &$vec3::MAX)
             );
-            
+
             test_uniform!(
                 Uniform::new_inclusive(<$t>::default(), <$t>::MAX),
                 Uniform::new_inclusive($vec3::default(), $vec3::MAX)
             );
-            
+
             test_uniform!(
                 Uniform::new_inclusive(&<$t>::default(), &<$t>::MAX),
                 Uniform::new_inclusive(&$vec3::default(), &$vec3::MAX)
             );
-            
+
             macro_rules! test_sample_uniform_sampler {
                 ($sampler_function_name:ident) => {
                     let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
                     let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
-                    
+
                     let v_int: ($t, $t, $t) = (
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(
+                            <$t>::default(),
+                            <$t>::MAX,
+                            &mut int_rng,
+                        ),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(
+                            <$t>::default(),
+                            <$t>::MAX,
+                            &mut int_rng,
+                        ),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(
+                            <$t>::default(),
+                            <$t>::MAX,
+                            &mut int_rng,
+                        ),
                     );
-                    let v_vec: $vec3 = <$vec3 as SampleUniform>::Sampler::$sampler_function_name($vec3::default(), $vec3::MAX, &mut vec_rng);
+                    let v_vec: $vec3 = <$vec3 as SampleUniform>::Sampler::$sampler_function_name(
+                        $vec3::default(),
+                        $vec3::MAX,
+                        &mut vec_rng,
+                    );
                     assert_eq!(v_int, v_vec.into());
-                }
+                };
             }
-            
+
             test_sample_uniform_sampler!(sample_single);
             test_sample_uniform_sampler!(sample_single_inclusive);
         }
-        
+
         #[test]
         fn test_vec4_rand_uniform() {
             use rand::{distributions::Uniform, Rng, SeedableRng};
             use rand_xoshiro::Xoshiro256Plus;
-            
+
             macro_rules! test_uniform {
                 ($int_uniform:expr, $vec_uniform:expr) => {
                     let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
                     let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
                     let full_int_uniform = $int_uniform;
                     let full_vec_uniform = $vec_uniform;
-                    
+
                     let v_int: ($t, $t, $t, $t) = (
                         int_rng.sample(full_int_uniform),
                         int_rng.sample(full_int_uniform),
@@ -553,45 +581,65 @@ macro_rules! impl_int_types {
                     );
                     let v_vec: $vec4 = vec_rng.sample(full_vec_uniform);
                     assert_eq!(v_int, v_vec.into());
-                }
+                };
             }
-            
+
             test_uniform!(
                 Uniform::new(<$t>::default(), <$t>::MAX),
                 Uniform::new($vec4::default(), $vec4::MAX)
             );
-            
+
             test_uniform!(
                 Uniform::new(&<$t>::default(), &<$t>::MAX),
                 Uniform::new(&$vec4::default(), &$vec4::MAX)
             );
-            
+
             test_uniform!(
                 Uniform::new_inclusive(<$t>::default(), <$t>::MAX),
                 Uniform::new_inclusive($vec4::default(), $vec4::MAX)
             );
-            
+
             test_uniform!(
                 Uniform::new_inclusive(&<$t>::default(), &<$t>::MAX),
                 Uniform::new_inclusive(&$vec4::default(), &$vec4::MAX)
             );
-            
+
             macro_rules! test_sample_uniform_sampler {
                 ($sampler_function_name:ident) => {
                     let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
                     let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
-                    
+
                     let v_int: ($t, $t, $t, $t) = (
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(
+                            <$t>::default(),
+                            <$t>::MAX,
+                            &mut int_rng,
+                        ),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(
+                            <$t>::default(),
+                            <$t>::MAX,
+                            &mut int_rng,
+                        ),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(
+                            <$t>::default(),
+                            <$t>::MAX,
+                            &mut int_rng,
+                        ),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(
+                            <$t>::default(),
+                            <$t>::MAX,
+                            &mut int_rng,
+                        ),
                     );
-                    let v_vec: $vec4 = <$vec4 as SampleUniform>::Sampler::$sampler_function_name($vec4::default(), $vec4::MAX, &mut vec_rng);
+                    let v_vec: $vec4 = <$vec4 as SampleUniform>::Sampler::$sampler_function_name(
+                        $vec4::default(),
+                        $vec4::MAX,
+                        &mut vec_rng,
+                    );
                     assert_eq!(v_int, v_vec.into());
-                }
+                };
             }
-            
+
             test_sample_uniform_sampler!(sample_single);
             test_sample_uniform_sampler!(sample_single_inclusive);
         }

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -508,14 +508,12 @@ macro_rules! impl_float_types {
     };
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UniformVec2<T, G> {
     x_gen: G,
     y_gen: G,
     vec_type: core::marker::PhantomData<T>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UniformVec3<T, G> {
     x_gen: G,
     y_gen: G,
@@ -523,7 +521,6 @@ pub struct UniformVec3<T, G> {
     vec_type: core::marker::PhantomData<T>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UniformVec4<T, G> {
     x_gen: G,
     y_gen: G,

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -1,7 +1,6 @@
 macro_rules! impl_vec_types {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident, $uniform:ident) => {
         use super::{UniformVec2, UniformVec3, UniformVec4};
-        use core::marker::PhantomData;
         use rand::{
             distributions::{
                 uniform::{SampleBorrow, SampleUniform, UniformSampler},
@@ -18,10 +17,10 @@ macro_rules! impl_vec_types {
         }
 
         impl SampleUniform for $vec2 {
-            type Sampler = UniformVec2<$vec2, $uniform<$t>>;
+            type Sampler = UniformVec2<$uniform<$t>>;
         }
 
-        impl UniformSampler for UniformVec2<$vec2, $uniform<$t>> {
+        impl UniformSampler for UniformVec2<$uniform<$t>> {
             type X = $vec2;
 
             fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
@@ -36,7 +35,6 @@ macro_rules! impl_vec_types {
                 Self {
                     x_gen: $uniform::new(low.x, high.x),
                     y_gen: $uniform::new(low.y, high.y),
-                    vec_type: PhantomData,
                 }
             }
 
@@ -58,7 +56,6 @@ macro_rules! impl_vec_types {
                 Self {
                     x_gen: $uniform::new_inclusive(low.x, high.x),
                     y_gen: $uniform::new_inclusive(low.y, high.y),
-                    vec_type: PhantomData,
                 }
             }
 
@@ -121,10 +118,10 @@ macro_rules! impl_vec_types {
         }
 
         impl SampleUniform for $vec3 {
-            type Sampler = UniformVec3<$vec3, $uniform<$t>>;
+            type Sampler = UniformVec3<$uniform<$t>>;
         }
 
-        impl UniformSampler for UniformVec3<$vec3, $uniform<$t>> {
+        impl UniformSampler for UniformVec3<$uniform<$t>> {
             type X = $vec3;
 
             fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
@@ -141,7 +138,6 @@ macro_rules! impl_vec_types {
                     x_gen: $uniform::new(low.x, high.x),
                     y_gen: $uniform::new(low.y, high.y),
                     z_gen: $uniform::new(low.z, high.z),
-                    vec_type: PhantomData,
                 }
             }
 
@@ -168,7 +164,6 @@ macro_rules! impl_vec_types {
                     x_gen: $uniform::new_inclusive(low.x, high.x),
                     y_gen: $uniform::new_inclusive(low.y, high.y),
                     z_gen: $uniform::new_inclusive(low.z, high.z),
-                    vec_type: PhantomData,
                 }
             }
 
@@ -245,10 +240,10 @@ macro_rules! impl_vec_types {
         }
 
         impl SampleUniform for $vec4 {
-            type Sampler = UniformVec4<$vec4, $uniform<$t>>;
+            type Sampler = UniformVec4<$uniform<$t>>;
         }
 
-        impl UniformSampler for UniformVec4<$vec4, $uniform<$t>> {
+        impl UniformSampler for UniformVec4<$uniform<$t>> {
             type X = $vec4;
 
             fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
@@ -267,7 +262,6 @@ macro_rules! impl_vec_types {
                     y_gen: $uniform::new(low.y, high.y),
                     z_gen: $uniform::new(low.z, high.z),
                     w_gen: $uniform::new(low.w, high.w),
-                    vec_type: PhantomData,
                 }
             }
 
@@ -299,7 +293,6 @@ macro_rules! impl_vec_types {
                     y_gen: $uniform::new_inclusive(low.y, high.y),
                     z_gen: $uniform::new_inclusive(low.z, high.z),
                     w_gen: $uniform::new_inclusive(low.w, high.w),
-                    vec_type: PhantomData,
                 }
             }
 
@@ -509,27 +502,24 @@ macro_rules! impl_float_types {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct UniformVec2<T, G> {
+pub struct UniformVec2<G> {
     x_gen: G,
     y_gen: G,
-    vec_type: core::marker::PhantomData<T>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct UniformVec3<T, G> {
+pub struct UniformVec3<G> {
     x_gen: G,
     y_gen: G,
     z_gen: G,
-    vec_type: core::marker::PhantomData<T>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct UniformVec4<T, G> {
+pub struct UniformVec4<G> {
     x_gen: G,
     y_gen: G,
     z_gen: G,
     w_gen: G,
-    vec_type: core::marker::PhantomData<T>,
 }
 
 mod f32 {

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -1,5 +1,3 @@
-use rand::distributions::uniform::{UniformFloat, UniformInt};
-
 macro_rules! impl_vec_types {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident) => {
         use rand::{
@@ -65,17 +63,17 @@ macro_rules! impl_vec_types {
 macro_rules! impl_int_types {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident) => {
         impl_vec_types!($t, $vec2, $vec3, $vec4);
-        use super::{UniformIntVec2, UniformIntVec3, UniformIntVec4};
+        use super::{UniformVec2, UniformVec3, UniformVec4};
         use core::marker::PhantomData;
         use rand::distributions::uniform::{
             SampleBorrow, SampleUniform, UniformInt, UniformSampler,
         };
 
         impl SampleUniform for $vec2 {
-            type Sampler = UniformIntVec2<$vec2, $t>;
+            type Sampler = UniformVec2<$vec2, UniformInt<$t>>;
         }
 
-        impl UniformSampler for UniformIntVec2<$vec2, $t> {
+        impl UniformSampler for UniformVec2<$vec2, UniformInt<$t>> {
             type X = $vec2;
 
             fn new<B1, B2>(low: B1, high: B2) -> Self
@@ -94,16 +92,36 @@ macro_rules! impl_int_types {
                 todo!()
             }
 
-            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                todo!()
+            }
+
+            fn sample_single<R: Rng + ?Sized, B1, B2>(low: B1, high: B2, rng: &mut R) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                todo!()
+            }
+
+            fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
+                low: B1,
+                high: B2,
+                rng: &mut R,
+            ) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
                 todo!()
             }
         }
 
         impl SampleUniform for $vec3 {
-            type Sampler = UniformIntVec3<$vec3, $t>;
+            type Sampler = UniformVec3<$vec3, UniformInt<$t>>;
         }
 
-        impl UniformSampler for UniformIntVec3<$vec3, $t> {
+        impl UniformSampler for UniformVec3<$vec3, UniformInt<$t>> {
             type X = $vec3;
 
             fn new<B1, B2>(low: B1, high: B2) -> Self
@@ -122,16 +140,36 @@ macro_rules! impl_int_types {
                 todo!()
             }
 
-            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                todo!()
+            }
+
+            fn sample_single<R: Rng + ?Sized, B1, B2>(low: B1, high: B2, rng: &mut R) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                todo!()
+            }
+
+            fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
+                low: B1,
+                high: B2,
+                rng: &mut R,
+            ) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
                 todo!()
             }
         }
 
         impl SampleUniform for $vec4 {
-            type Sampler = UniformIntVec4<$vec4, $t>;
+            type Sampler = UniformVec4<$vec4, UniformInt<$t>>;
         }
 
-        impl UniformSampler for UniformIntVec4<$vec4, $t> {
+        impl UniformSampler for UniformVec4<$vec4, UniformInt<$t>> {
             type X = $vec4;
 
             fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
@@ -158,7 +196,27 @@ macro_rules! impl_int_types {
                 todo!()
             }
 
-            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                todo!()
+            }
+
+            fn sample_single<R: Rng + ?Sized, B1, B2>(low: B1, high: B2, rng: &mut R) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                todo!()
+            }
+
+            fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
+                low: B1,
+                high: B2,
+                rng: &mut R,
+            ) -> Self::X
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
                 todo!()
             }
         }
@@ -250,50 +308,26 @@ macro_rules! impl_float_types {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct UniformFloatVec2<T, I> {
-    x_gen: UniformFloat<I>,
-    y_gen: UniformFloat<I>,
+pub struct UniformVec2<T, G> {
+    x_gen: G,
+    y_gen: G,
     vec_type: core::marker::PhantomData<T>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct UniformFloatVec3<T, I> {
-    x_gen: UniformFloat<I>,
-    y_gen: UniformFloat<I>,
-    z_gen: UniformFloat<I>,
+pub struct UniformVec3<T, G> {
+    x_gen: G,
+    y_gen: G,
+    z_gen: G,
     vec_type: core::marker::PhantomData<T>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
-pub struct UniformFloatVec4<T, I> {
-    x_gen: UniformFloat<I>,
-    y_gen: UniformFloat<I>,
-    z_gen: UniformFloat<I>,
-    w_gen: UniformFloat<I>,
-    vec_type: core::marker::PhantomData<T>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct UniformIntVec2<T, I> {
-    x_gen: UniformInt<I>,
-    y_gen: UniformInt<I>,
-    vec_type: core::marker::PhantomData<T>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct UniformIntVec3<T, I> {
-    x_gen: UniformInt<I>,
-    y_gen: UniformInt<I>,
-    z_gen: UniformInt<I>,
-    vec_type: core::marker::PhantomData<T>,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct UniformIntVec4<T, I> {
-    x_gen: UniformInt<I>,
-    y_gen: UniformInt<I>,
-    z_gen: UniformInt<I>,
-    w_gen: UniformInt<I>,
+pub struct UniformVec4<T, G> {
+    x_gen: G,
+    y_gen: G,
+    z_gen: G,
+    w_gen: G,
     vec_type: core::marker::PhantomData<T>,
 }
 

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -76,7 +76,7 @@ macro_rules! impl_int_types {
         impl UniformSampler for UniformVec2<$vec2, UniformInt<$t>> {
             type X = $vec2;
 
-            fn new<B1, B2>(low: B1, high: B2) -> Self
+            fn new<B1, B2>(_low: B1, _high: B2) -> Self
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
@@ -84,7 +84,7 @@ macro_rules! impl_int_types {
                 todo!()
             }
 
-            fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+            fn new_inclusive<B1, B2>(_low: B1, _high: B2) -> Self
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
@@ -92,11 +92,11 @@ macro_rules! impl_int_types {
                 todo!()
             }
 
-            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+            fn sample<R: Rng + ?Sized>(&self, _rng: &mut R) -> Self::X {
                 todo!()
             }
 
-            fn sample_single<R: Rng + ?Sized, B1, B2>(low: B1, high: B2, rng: &mut R) -> Self::X
+            fn sample_single<R: Rng + ?Sized, B1, B2>(_low: B1, _high: B2, _rng: &mut R) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
@@ -105,9 +105,9 @@ macro_rules! impl_int_types {
             }
 
             fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
-                low: B1,
-                high: B2,
-                rng: &mut R,
+                _low: B1,
+                _high: B2,
+                _rng: &mut R,
             ) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,
@@ -124,7 +124,7 @@ macro_rules! impl_int_types {
         impl UniformSampler for UniformVec3<$vec3, UniformInt<$t>> {
             type X = $vec3;
 
-            fn new<B1, B2>(low: B1, high: B2) -> Self
+            fn new<B1, B2>(_low: B1, _high: B2) -> Self
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
@@ -132,7 +132,7 @@ macro_rules! impl_int_types {
                 todo!()
             }
 
-            fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+            fn new_inclusive<B1, B2>(_low: B1, _high: B2) -> Self
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
@@ -140,11 +140,11 @@ macro_rules! impl_int_types {
                 todo!()
             }
 
-            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+            fn sample<R: Rng + ?Sized>(&self, _rng: &mut R) -> Self::X {
                 todo!()
             }
 
-            fn sample_single<R: Rng + ?Sized, B1, B2>(low: B1, high: B2, rng: &mut R) -> Self::X
+            fn sample_single<R: Rng + ?Sized, B1, B2>(_low: B1, _high: B2, _rng: &mut R) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
@@ -153,9 +153,9 @@ macro_rules! impl_int_types {
             }
 
             fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
-                low: B1,
-                high: B2,
-                rng: &mut R,
+                _low: B1,
+                _high: B2,
+                _rng: &mut R,
             ) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,
@@ -188,7 +188,7 @@ macro_rules! impl_int_types {
                 }
             }
 
-            fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+            fn new_inclusive<B1, B2>(_low: B1, _high: B2) -> Self
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
@@ -196,11 +196,11 @@ macro_rules! impl_int_types {
                 todo!()
             }
 
-            fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+            fn sample<R: Rng + ?Sized>(&self, _rng: &mut R) -> Self::X {
                 todo!()
             }
 
-            fn sample_single<R: Rng + ?Sized, B1, B2>(low: B1, high: B2, rng: &mut R) -> Self::X
+            fn sample_single<R: Rng + ?Sized, B1, B2>(_low: B1, _high: B2, _rng: &mut R) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,
                 B2: SampleBorrow<Self::X> + Sized,
@@ -209,9 +209,9 @@ macro_rules! impl_int_types {
             }
 
             fn sample_single_inclusive<R: Rng + ?Sized, B1, B2>(
-                low: B1,
-                high: B2,
-                rng: &mut R,
+                _low: B1,
+                _high: B2,
+                _rng: &mut R,
             ) -> Self::X
             where
                 B1: SampleBorrow<Self::X> + Sized,

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -1,5 +1,11 @@
+use rand::distributions::uniform::{UniformFloat, UniformInt};
+
 macro_rules! impl_vec_types {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident) => {
+        use rand::{
+            distributions::{Distribution, Standard},
+            Rng,
+        };
         impl Distribution<$vec2> for Standard {
             #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $vec2 {
@@ -52,6 +58,109 @@ macro_rules! impl_vec_types {
             let mut rng2 = Xoshiro256Plus::seed_from_u64(0);
             let b: $vec4 = rng2.gen();
             assert_eq!(a, b.into());
+        }
+    };
+}
+
+macro_rules! impl_int_types {
+    ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident) => {
+        impl_vec_types!($t, $vec2, $vec3, $vec4);
+        use super::{UniformIntVec2, UniformIntVec3, UniformIntVec4};
+        use core::marker::PhantomData;
+        use rand::distributions::uniform::{
+            SampleBorrow, SampleUniform, UniformInt, UniformSampler,
+        };
+
+        impl SampleUniform for $vec2 {
+            type Sampler = UniformIntVec2<$vec2, $t>;
+        }
+
+        impl UniformSampler for UniformIntVec2<$vec2, $t> {
+            type X = $vec2;
+
+            fn new<B1, B2>(low: B1, high: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                todo!()
+            }
+
+            fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                todo!()
+            }
+
+            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                todo!()
+            }
+        }
+
+        impl SampleUniform for $vec3 {
+            type Sampler = UniformIntVec3<$vec3, $t>;
+        }
+
+        impl UniformSampler for UniformIntVec3<$vec3, $t> {
+            type X = $vec3;
+
+            fn new<B1, B2>(low: B1, high: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                todo!()
+            }
+
+            fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                todo!()
+            }
+
+            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                todo!()
+            }
+        }
+
+        impl SampleUniform for $vec4 {
+            type Sampler = UniformIntVec4<$vec4, $t>;
+        }
+
+        impl UniformSampler for UniformIntVec4<$vec4, $t> {
+            type X = $vec4;
+
+            fn new<B1, B2>(low_b: B1, high_b: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                let low = *low_b.borrow();
+                let high = *high_b.borrow();
+                Self {
+                    x_gen: UniformInt::new(low.x, high.x),
+                    y_gen: UniformInt::new(low.y, high.y),
+                    z_gen: UniformInt::new(low.z, high.z),
+                    w_gen: UniformInt::new(low.w, high.w),
+                    vec_type: PhantomData,
+                }
+            }
+
+            fn new_inclusive<B1, B2>(low: B1, high: B2) -> Self
+            where
+                B1: SampleBorrow<Self::X> + Sized,
+                B2: SampleBorrow<Self::X> + Sized,
+            {
+                todo!()
+            }
+
+            fn sample<R: rand::Rng + ?Sized>(&self, rng: &mut R) -> Self::X {
+                todo!()
+            }
         }
     };
 }
@@ -140,14 +249,58 @@ macro_rules! impl_float_types {
     };
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct UniformFloatVec2<T, I> {
+    x_gen: UniformFloat<I>,
+    y_gen: UniformFloat<I>,
+    vec_type: core::marker::PhantomData<T>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct UniformFloatVec3<T, I> {
+    x_gen: UniformFloat<I>,
+    y_gen: UniformFloat<I>,
+    z_gen: UniformFloat<I>,
+    vec_type: core::marker::PhantomData<T>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct UniformFloatVec4<T, I> {
+    x_gen: UniformFloat<I>,
+    y_gen: UniformFloat<I>,
+    z_gen: UniformFloat<I>,
+    w_gen: UniformFloat<I>,
+    vec_type: core::marker::PhantomData<T>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct UniformIntVec2<T, I> {
+    x_gen: UniformInt<I>,
+    y_gen: UniformInt<I>,
+    vec_type: core::marker::PhantomData<T>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct UniformIntVec3<T, I> {
+    x_gen: UniformInt<I>,
+    y_gen: UniformInt<I>,
+    z_gen: UniformInt<I>,
+    vec_type: core::marker::PhantomData<T>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct UniformIntVec4<T, I> {
+    x_gen: UniformInt<I>,
+    y_gen: UniformInt<I>,
+    z_gen: UniformInt<I>,
+    w_gen: UniformInt<I>,
+    vec_type: core::marker::PhantomData<T>,
+}
+
 mod f32 {
     use crate::f32::math;
     use crate::{Mat2, Mat3, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
     use core::f32::consts::TAU;
-    use rand::{
-        distributions::{Distribution, Standard},
-        Rng,
-    };
 
     impl_float_types!(f32, Mat2, Mat3, Mat4, Quat, Vec2, Vec3, Vec4);
 
@@ -174,90 +327,54 @@ mod f64 {
     use crate::f64::math;
     use crate::{DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4};
     use core::f64::consts::TAU;
-    use rand::{
-        distributions::{Distribution, Standard},
-        Rng,
-    };
 
     impl_float_types!(f64, DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4);
 }
 
 mod i8 {
     use crate::{I8Vec2, I8Vec3, I8Vec4};
-    use rand::{
-        distributions::{Distribution, Standard},
-        Rng,
-    };
 
-    impl_vec_types!(i8, I8Vec2, I8Vec3, I8Vec4);
+    impl_int_types!(i8, I8Vec2, I8Vec3, I8Vec4);
 }
 
 mod i16 {
     use crate::{I16Vec2, I16Vec3, I16Vec4};
-    use rand::{
-        distributions::{Distribution, Standard},
-        Rng,
-    };
 
-    impl_vec_types!(i16, I16Vec2, I16Vec3, I16Vec4);
+    impl_int_types!(i16, I16Vec2, I16Vec3, I16Vec4);
 }
 
 mod i32 {
     use crate::{IVec2, IVec3, IVec4};
-    use rand::{
-        distributions::{Distribution, Standard},
-        Rng,
-    };
 
-    impl_vec_types!(i32, IVec2, IVec3, IVec4);
+    impl_int_types!(i32, IVec2, IVec3, IVec4);
 }
 
 mod i64 {
     use crate::{I64Vec2, I64Vec3, I64Vec4};
-    use rand::{
-        distributions::{Distribution, Standard},
-        Rng,
-    };
 
-    impl_vec_types!(i64, I64Vec2, I64Vec3, I64Vec4);
+    impl_int_types!(i64, I64Vec2, I64Vec3, I64Vec4);
 }
 
 mod u8 {
     use crate::{U8Vec2, U8Vec3, U8Vec4};
-    use rand::{
-        distributions::{Distribution, Standard},
-        Rng,
-    };
 
-    impl_vec_types!(u8, U8Vec2, U8Vec3, U8Vec4);
+    impl_int_types!(u8, U8Vec2, U8Vec3, U8Vec4);
 }
 
 mod u16 {
     use crate::{U16Vec2, U16Vec3, U16Vec4};
-    use rand::{
-        distributions::{Distribution, Standard},
-        Rng,
-    };
 
-    impl_vec_types!(u16, U16Vec2, U16Vec3, U16Vec4);
+    impl_int_types!(u16, U16Vec2, U16Vec3, U16Vec4);
 }
 
 mod u32 {
     use crate::{UVec2, UVec3, UVec4};
-    use rand::{
-        distributions::{Distribution, Standard},
-        Rng,
-    };
 
-    impl_vec_types!(u32, UVec2, UVec3, UVec4);
+    impl_int_types!(u32, UVec2, UVec3, UVec4);
 }
 
 mod u64 {
     use crate::{U64Vec2, U64Vec3, U64Vec4};
-    use rand::{
-        distributions::{Distribution, Standard},
-        Rng,
-    };
 
-    impl_vec_types!(u64, U64Vec2, U64Vec3, U64Vec4);
+    impl_int_types!(u64, U64Vec2, U64Vec3, U64Vec4);
 }

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -373,7 +373,7 @@ macro_rules! impl_vec_types {
         }
 
         #[test]
-        fn test_vec2_rand() {
+        fn test_vec2_rand_standard() {
             use rand::{Rng, SeedableRng};
             use rand_xoshiro::Xoshiro256Plus;
             let mut rng1 = Xoshiro256Plus::seed_from_u64(0);
@@ -384,7 +384,7 @@ macro_rules! impl_vec_types {
         }
 
         #[test]
-        fn test_vec3_rand() {
+        fn test_vec3_rand_standard() {
             use rand::{Rng, SeedableRng};
             use rand_xoshiro::Xoshiro256Plus;
             let mut rng1 = Xoshiro256Plus::seed_from_u64(0);
@@ -395,7 +395,7 @@ macro_rules! impl_vec_types {
         }
 
         #[test]
-        fn test_vec4_rand() {
+        fn test_vec4_rand_standard() {
             use rand::{Rng, SeedableRng};
             use rand_xoshiro::Xoshiro256Plus;
             let mut rng1 = Xoshiro256Plus::seed_from_u64(0);
@@ -412,6 +412,189 @@ macro_rules! impl_int_types {
         use rand::distributions::uniform::UniformInt;
 
         impl_vec_types!($t, $vec2, $vec3, $vec4, UniformInt);
+        
+        #[test]
+        fn test_vec2_rand_uniform() {
+            use rand::{distributions::Uniform, Rng, SeedableRng};
+            use rand_xoshiro::Xoshiro256Plus;
+            
+            macro_rules! test_uniform {
+                ($int_uniform:expr, $vec_uniform:expr) => {
+                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let full_int_uniform = $int_uniform;
+                    let full_vec_uniform = $vec_uniform;
+                    
+                    let v_int: ($t, $t) = (
+                        int_rng.sample(full_int_uniform),
+                        int_rng.sample(full_int_uniform),
+                    );
+                    let v_vec: $vec2 = vec_rng.sample(full_vec_uniform);
+                    assert_eq!(v_int, v_vec.into());
+                }
+            }
+            
+            test_uniform!(
+                Uniform::new(<$t>::default(), <$t>::MAX),
+                Uniform::new($vec2::default(), $vec2::MAX)
+            );
+            
+            test_uniform!(
+                Uniform::new(&<$t>::default(), &<$t>::MAX),
+                Uniform::new(&$vec2::default(), &$vec2::MAX)
+            );
+            
+            test_uniform!(
+                Uniform::new_inclusive(<$t>::default(), <$t>::MAX),
+                Uniform::new_inclusive($vec2::default(), $vec2::MAX)
+            );
+            
+            test_uniform!(
+                Uniform::new_inclusive(&<$t>::default(), &<$t>::MAX),
+                Uniform::new_inclusive(&$vec2::default(), &$vec2::MAX)
+            );
+            
+            macro_rules! test_sample_uniform_sampler {
+                ($sampler_function_name:ident) => {
+                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
+                    
+                    let v_int: ($t, $t) = (
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                    );
+                    let v_vec: $vec2 = <$vec2 as SampleUniform>::Sampler::$sampler_function_name($vec2::default(), $vec2::MAX, &mut vec_rng);
+                    assert_eq!(v_int, v_vec.into());
+                }
+            }
+            
+            test_sample_uniform_sampler!(sample_single);
+            test_sample_uniform_sampler!(sample_single_inclusive);
+        }
+        
+        #[test]
+        fn test_vec3_rand_uniform() {
+            use rand::{distributions::Uniform, Rng, SeedableRng};
+            use rand_xoshiro::Xoshiro256Plus;
+            
+            macro_rules! test_uniform {
+                ($int_uniform:expr, $vec_uniform:expr) => {
+                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let full_int_uniform = $int_uniform;
+                    let full_vec_uniform = $vec_uniform;
+                    
+                    let v_int: ($t, $t, $t) = (
+                        int_rng.sample(full_int_uniform),
+                        int_rng.sample(full_int_uniform),
+                        int_rng.sample(full_int_uniform),
+                    );
+                    let v_vec: $vec3 = vec_rng.sample(full_vec_uniform);
+                    assert_eq!(v_int, v_vec.into());
+                }
+            }
+            
+            test_uniform!(
+                Uniform::new(<$t>::default(), <$t>::MAX),
+                Uniform::new($vec3::default(), $vec3::MAX)
+            );
+            
+            test_uniform!(
+                Uniform::new(&<$t>::default(), &<$t>::MAX),
+                Uniform::new(&$vec3::default(), &$vec3::MAX)
+            );
+            
+            test_uniform!(
+                Uniform::new_inclusive(<$t>::default(), <$t>::MAX),
+                Uniform::new_inclusive($vec3::default(), $vec3::MAX)
+            );
+            
+            test_uniform!(
+                Uniform::new_inclusive(&<$t>::default(), &<$t>::MAX),
+                Uniform::new_inclusive(&$vec3::default(), &$vec3::MAX)
+            );
+            
+            macro_rules! test_sample_uniform_sampler {
+                ($sampler_function_name:ident) => {
+                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
+                    
+                    let v_int: ($t, $t, $t) = (
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                    );
+                    let v_vec: $vec3 = <$vec3 as SampleUniform>::Sampler::$sampler_function_name($vec3::default(), $vec3::MAX, &mut vec_rng);
+                    assert_eq!(v_int, v_vec.into());
+                }
+            }
+            
+            test_sample_uniform_sampler!(sample_single);
+            test_sample_uniform_sampler!(sample_single_inclusive);
+        }
+        
+        #[test]
+        fn test_vec4_rand_uniform() {
+            use rand::{distributions::Uniform, Rng, SeedableRng};
+            use rand_xoshiro::Xoshiro256Plus;
+            
+            macro_rules! test_uniform {
+                ($int_uniform:expr, $vec_uniform:expr) => {
+                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let full_int_uniform = $int_uniform;
+                    let full_vec_uniform = $vec_uniform;
+                    
+                    let v_int: ($t, $t, $t, $t) = (
+                        int_rng.sample(full_int_uniform),
+                        int_rng.sample(full_int_uniform),
+                        int_rng.sample(full_int_uniform),
+                        int_rng.sample(full_int_uniform),
+                    );
+                    let v_vec: $vec4 = vec_rng.sample(full_vec_uniform);
+                    assert_eq!(v_int, v_vec.into());
+                }
+            }
+            
+            test_uniform!(
+                Uniform::new(<$t>::default(), <$t>::MAX),
+                Uniform::new($vec4::default(), $vec4::MAX)
+            );
+            
+            test_uniform!(
+                Uniform::new(&<$t>::default(), &<$t>::MAX),
+                Uniform::new(&$vec4::default(), &$vec4::MAX)
+            );
+            
+            test_uniform!(
+                Uniform::new_inclusive(<$t>::default(), <$t>::MAX),
+                Uniform::new_inclusive($vec4::default(), $vec4::MAX)
+            );
+            
+            test_uniform!(
+                Uniform::new_inclusive(&<$t>::default(), &<$t>::MAX),
+                Uniform::new_inclusive(&$vec4::default(), &$vec4::MAX)
+            );
+            
+            macro_rules! test_sample_uniform_sampler {
+                ($sampler_function_name:ident) => {
+                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
+                    
+                    let v_int: ($t, $t, $t, $t) = (
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(<$t>::default(), <$t>::MAX, &mut int_rng),
+                    );
+                    let v_vec: $vec4 = <$vec4 as SampleUniform>::Sampler::$sampler_function_name($vec4::default(), $vec4::MAX, &mut vec_rng);
+                    assert_eq!(v_int, v_vec.into());
+                }
+            }
+            
+            test_sample_uniform_sampler!(sample_single);
+            test_sample_uniform_sampler!(sample_single_inclusive);
+        }
     };
 }
 

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -634,7 +634,7 @@ macro_rules! impl_float_types {
         }
 
         #[test]
-        fn test_quat_rand() {
+        fn test_quat_rand_standard() {
             use rand::{Rng, SeedableRng};
             use rand_xoshiro::Xoshiro256Plus;
             let mut rng1 = Xoshiro256Plus::seed_from_u64(0);

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -508,12 +508,14 @@ macro_rules! impl_float_types {
     };
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UniformVec2<T, G> {
     x_gen: G,
     y_gen: G,
     vec_type: core::marker::PhantomData<T>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UniformVec3<T, G> {
     x_gen: G,
     y_gen: G,
@@ -521,6 +523,7 @@ pub struct UniformVec3<T, G> {
     vec_type: core::marker::PhantomData<T>,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UniformVec4<T, G> {
     x_gen: G,
     y_gen: G,

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -420,9 +420,11 @@ macro_rules! test_vec_type_uniform {
     (__repeat_code 4, $code:expr) => {
         ($code, $code, $code, $code)
     };
-    ($test_name:ident, $vec:ident, $t:ty, $t_count:tt) => {
+    ($equality_test_name:ident, $vec:ident, $t:ty, $t_count:tt) => {
+        // Tests that we reach the same result, whether we generate the vector type directly, or
+        // generate its internal values $t_count times and convert the result into the vector type.
         #[test]
-        fn $test_name() {
+        fn $equality_test_name() {
             use rand::{distributions::Uniform, Rng, SeedableRng};
             use rand_xoshiro::Xoshiro256Plus;
 
@@ -488,6 +490,10 @@ macro_rules! test_vec_type_uniform {
             test_sample_uniform_sampler!(sample_single);
             test_sample_uniform_sampler!(sample_single_inclusive);
         }
+        
+        // TODO: Test to ensure that all generated numbers are within specified range. This is
+        // technically covered by `rand`'s own tests, as we're currently just wrapping `rand`'s
+        // Uniform generators, but it's nice to have for completeness.
     };
 }
 

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -407,242 +407,98 @@ macro_rules! impl_vec_types {
     };
 }
 
+macro_rules! test_vec_type_uniform {
+    // If I put these into a macro in the main branch below, rustc will complain about unused macros
+    // even if I use it.
+    (__repeat_code 2, $code:expr) => {
+        ($code, $code)
+    };
+    (__repeat_code 3, $code:expr) => {
+        ($code, $code, $code)
+    };
+    (__repeat_code 4, $code:expr) => {
+        ($code, $code, $code, $code)
+    };
+    ($test_name:ident, $vec:ident, $t:ty, $t_count:tt) => {
+        #[test]
+        fn $test_name() {
+            use rand::{distributions::Uniform, Rng, SeedableRng};
+            use rand_xoshiro::Xoshiro256Plus;
+
+            macro_rules! test_uniform {
+                ($int_uniform:expr, $vec_uniform:expr) => {
+                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let full_int_uniform = $int_uniform;
+                    let full_vec_uniform = $vec_uniform;
+
+                    let v_int = test_vec_type_uniform!(
+                        __repeat_code $t_count,
+                        int_rng.sample(full_int_uniform)
+                    );
+                    let v_vec: $vec = vec_rng.sample(full_vec_uniform);
+                    assert_eq!(v_int, v_vec.into());
+                };
+            }
+
+            test_uniform!(
+                Uniform::new(<$t>::default(), <$t>::MAX),
+                Uniform::new($vec::default(), $vec::MAX)
+            );
+
+            test_uniform!(
+                Uniform::new(&<$t>::default(), &<$t>::MAX),
+                Uniform::new(&$vec::default(), &$vec::MAX)
+            );
+
+            test_uniform!(
+                Uniform::new_inclusive(<$t>::default(), <$t>::MAX),
+                Uniform::new_inclusive($vec::default(), $vec::MAX)
+            );
+
+            test_uniform!(
+                Uniform::new_inclusive(&<$t>::default(), &<$t>::MAX),
+                Uniform::new_inclusive(&$vec::default(), &$vec::MAX)
+            );
+
+            macro_rules! test_sample_uniform_sampler {
+                ($sampler_function_name:ident) => {
+                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
+                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
+
+                    let v_int = test_vec_type_uniform!(
+                        __repeat_code $t_count,
+                        <$t as SampleUniform>::Sampler::$sampler_function_name(
+                            <$t>::default(),
+                            <$t>::MAX,
+                            &mut int_rng,
+                        )
+                    );
+
+                    let v_vec: $vec = <$vec as SampleUniform>::Sampler::$sampler_function_name(
+                        $vec::default(),
+                        $vec::MAX,
+                        &mut vec_rng,
+                    );
+                    assert_eq!(v_int, v_vec.into());
+                };
+            }
+
+            test_sample_uniform_sampler!(sample_single);
+            test_sample_uniform_sampler!(sample_single_inclusive);
+        }
+    };
+}
+
 macro_rules! impl_int_types {
     ($t:ty, $vec2:ident, $vec3:ident, $vec4:ident) => {
         use rand::distributions::uniform::UniformInt;
 
         impl_vec_types!($t, $vec2, $vec3, $vec4, UniformInt);
 
-        #[test]
-        fn test_vec2_rand_uniform() {
-            use rand::{distributions::Uniform, Rng, SeedableRng};
-            use rand_xoshiro::Xoshiro256Plus;
-
-            macro_rules! test_uniform {
-                ($int_uniform:expr, $vec_uniform:expr) => {
-                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
-                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
-                    let full_int_uniform = $int_uniform;
-                    let full_vec_uniform = $vec_uniform;
-
-                    let v_int: ($t, $t) = (
-                        int_rng.sample(full_int_uniform),
-                        int_rng.sample(full_int_uniform),
-                    );
-                    let v_vec: $vec2 = vec_rng.sample(full_vec_uniform);
-                    assert_eq!(v_int, v_vec.into());
-                };
-            }
-
-            test_uniform!(
-                Uniform::new(<$t>::default(), <$t>::MAX),
-                Uniform::new($vec2::default(), $vec2::MAX)
-            );
-
-            test_uniform!(
-                Uniform::new(&<$t>::default(), &<$t>::MAX),
-                Uniform::new(&$vec2::default(), &$vec2::MAX)
-            );
-
-            test_uniform!(
-                Uniform::new_inclusive(<$t>::default(), <$t>::MAX),
-                Uniform::new_inclusive($vec2::default(), $vec2::MAX)
-            );
-
-            test_uniform!(
-                Uniform::new_inclusive(&<$t>::default(), &<$t>::MAX),
-                Uniform::new_inclusive(&$vec2::default(), &$vec2::MAX)
-            );
-
-            macro_rules! test_sample_uniform_sampler {
-                ($sampler_function_name:ident) => {
-                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
-                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
-
-                    let v_int: ($t, $t) = (
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(
-                            <$t>::default(),
-                            <$t>::MAX,
-                            &mut int_rng,
-                        ),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(
-                            <$t>::default(),
-                            <$t>::MAX,
-                            &mut int_rng,
-                        ),
-                    );
-                    let v_vec: $vec2 = <$vec2 as SampleUniform>::Sampler::$sampler_function_name(
-                        $vec2::default(),
-                        $vec2::MAX,
-                        &mut vec_rng,
-                    );
-                    assert_eq!(v_int, v_vec.into());
-                };
-            }
-
-            test_sample_uniform_sampler!(sample_single);
-            test_sample_uniform_sampler!(sample_single_inclusive);
-        }
-
-        #[test]
-        fn test_vec3_rand_uniform() {
-            use rand::{distributions::Uniform, Rng, SeedableRng};
-            use rand_xoshiro::Xoshiro256Plus;
-
-            macro_rules! test_uniform {
-                ($int_uniform:expr, $vec_uniform:expr) => {
-                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
-                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
-                    let full_int_uniform = $int_uniform;
-                    let full_vec_uniform = $vec_uniform;
-
-                    let v_int: ($t, $t, $t) = (
-                        int_rng.sample(full_int_uniform),
-                        int_rng.sample(full_int_uniform),
-                        int_rng.sample(full_int_uniform),
-                    );
-                    let v_vec: $vec3 = vec_rng.sample(full_vec_uniform);
-                    assert_eq!(v_int, v_vec.into());
-                };
-            }
-
-            test_uniform!(
-                Uniform::new(<$t>::default(), <$t>::MAX),
-                Uniform::new($vec3::default(), $vec3::MAX)
-            );
-
-            test_uniform!(
-                Uniform::new(&<$t>::default(), &<$t>::MAX),
-                Uniform::new(&$vec3::default(), &$vec3::MAX)
-            );
-
-            test_uniform!(
-                Uniform::new_inclusive(<$t>::default(), <$t>::MAX),
-                Uniform::new_inclusive($vec3::default(), $vec3::MAX)
-            );
-
-            test_uniform!(
-                Uniform::new_inclusive(&<$t>::default(), &<$t>::MAX),
-                Uniform::new_inclusive(&$vec3::default(), &$vec3::MAX)
-            );
-
-            macro_rules! test_sample_uniform_sampler {
-                ($sampler_function_name:ident) => {
-                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
-                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
-
-                    let v_int: ($t, $t, $t) = (
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(
-                            <$t>::default(),
-                            <$t>::MAX,
-                            &mut int_rng,
-                        ),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(
-                            <$t>::default(),
-                            <$t>::MAX,
-                            &mut int_rng,
-                        ),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(
-                            <$t>::default(),
-                            <$t>::MAX,
-                            &mut int_rng,
-                        ),
-                    );
-                    let v_vec: $vec3 = <$vec3 as SampleUniform>::Sampler::$sampler_function_name(
-                        $vec3::default(),
-                        $vec3::MAX,
-                        &mut vec_rng,
-                    );
-                    assert_eq!(v_int, v_vec.into());
-                };
-            }
-
-            test_sample_uniform_sampler!(sample_single);
-            test_sample_uniform_sampler!(sample_single_inclusive);
-        }
-
-        #[test]
-        fn test_vec4_rand_uniform() {
-            use rand::{distributions::Uniform, Rng, SeedableRng};
-            use rand_xoshiro::Xoshiro256Plus;
-
-            macro_rules! test_uniform {
-                ($int_uniform:expr, $vec_uniform:expr) => {
-                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
-                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
-                    let full_int_uniform = $int_uniform;
-                    let full_vec_uniform = $vec_uniform;
-
-                    let v_int: ($t, $t, $t, $t) = (
-                        int_rng.sample(full_int_uniform),
-                        int_rng.sample(full_int_uniform),
-                        int_rng.sample(full_int_uniform),
-                        int_rng.sample(full_int_uniform),
-                    );
-                    let v_vec: $vec4 = vec_rng.sample(full_vec_uniform);
-                    assert_eq!(v_int, v_vec.into());
-                };
-            }
-
-            test_uniform!(
-                Uniform::new(<$t>::default(), <$t>::MAX),
-                Uniform::new($vec4::default(), $vec4::MAX)
-            );
-
-            test_uniform!(
-                Uniform::new(&<$t>::default(), &<$t>::MAX),
-                Uniform::new(&$vec4::default(), &$vec4::MAX)
-            );
-
-            test_uniform!(
-                Uniform::new_inclusive(<$t>::default(), <$t>::MAX),
-                Uniform::new_inclusive($vec4::default(), $vec4::MAX)
-            );
-
-            test_uniform!(
-                Uniform::new_inclusive(&<$t>::default(), &<$t>::MAX),
-                Uniform::new_inclusive(&$vec4::default(), &$vec4::MAX)
-            );
-
-            macro_rules! test_sample_uniform_sampler {
-                ($sampler_function_name:ident) => {
-                    let mut int_rng = Xoshiro256Plus::seed_from_u64(0);
-                    let mut vec_rng = Xoshiro256Plus::seed_from_u64(0);
-
-                    let v_int: ($t, $t, $t, $t) = (
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(
-                            <$t>::default(),
-                            <$t>::MAX,
-                            &mut int_rng,
-                        ),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(
-                            <$t>::default(),
-                            <$t>::MAX,
-                            &mut int_rng,
-                        ),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(
-                            <$t>::default(),
-                            <$t>::MAX,
-                            &mut int_rng,
-                        ),
-                        <$t as SampleUniform>::Sampler::$sampler_function_name(
-                            <$t>::default(),
-                            <$t>::MAX,
-                            &mut int_rng,
-                        ),
-                    );
-                    let v_vec: $vec4 = <$vec4 as SampleUniform>::Sampler::$sampler_function_name(
-                        $vec4::default(),
-                        $vec4::MAX,
-                        &mut vec_rng,
-                    );
-                    assert_eq!(v_int, v_vec.into());
-                };
-            }
-
-            test_sample_uniform_sampler!(sample_single);
-            test_sample_uniform_sampler!(sample_single_inclusive);
-        }
+        test_vec_type_uniform!(test_vec2_rand_uniform, $vec2, $t, 2);
+        test_vec_type_uniform!(test_vec3_rand_uniform, $vec3, $t, 3);
+        test_vec_type_uniform!(test_vec4_rand_uniform, $vec4, $t, 4);
     };
 }
 

--- a/src/features/impl_rand.rs
+++ b/src/features/impl_rand.rs
@@ -522,7 +522,6 @@ macro_rules! impl_int_types {
 
         impl_vec_types!($t, $vec2, $vec3, $vec4, UniformInt);
 
-        test_vec_type_uniform!(test_vec3_rand_uniform_equality, $vec3, $t, 3);
         test_vec_type_uniform!(
             test_vec2_rand_uniform_equality,
             $vec2,
@@ -722,8 +721,6 @@ mod u16 {
 }
 
 mod u32 {
-    use rand::SeedableRng;
-
     use crate::{UVec2, UVec3, UVec4};
 
     impl_int_types!(u32, UVec2, UVec3, UVec4);


### PR DESCRIPTION
Closes #579.

This PR makes the following changes to the `glam` crate:

* Adds support for `rand`'s `Uniform` distribution to all Vec types
* Reorganizes the imports for the `impl_rand.rs` file into their relevant macros, easing readability and maintainability

# This is still a Work-In-Progress

I have yet to do the following:

* Add tests for Float Vec types

I suspect that the code quality could also be improved in some places. If you spot any way to improve it, let me know! (or if you're bitshifter, feel free to commit directly to my PR!)

# Some notes

The `UniformVec*` structs used to handle uniform distribution are part of a non-public module, and thus cannot be navigated to in the documentation. While I can rectify this upon request, I don't believe it's necessary, since the way `rand` intends for the user to perform `Uniform` distribution is through the `rand::distributions::Uniform` type, rather than using the backend types directly.

I have not added (de)serialization support to the `UniformVec*` structs. However, `rand` offers (de)serialization of its distribution structs, so I am unsure if (de)serialization is wanted for `UniformVec*`.