### PR TITLE
Fix VecN::write_to_slice

### DIFF
--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -529,7 +529,7 @@ impl {{ self_t }} {
             assert!(slice.len() >= 4);
             unsafe { vst1q_f32(slice.as_mut_ptr(), self.0); }
         {% else %}
-            slice.copy_from_slice(&self.to_array());
+            slice[..{{ dim }}].copy_from_slice(&self.to_array());
         {% endif %}
     }
 

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -143,7 +143,7 @@ impl Vec3A {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Creates a [`Vec3A`] from the `x`, `y` and `z` elements of `self` discarding `w`.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -145,7 +145,7 @@ impl Vec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -148,7 +148,7 @@ impl Vec3A {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Creates a [`Vec3A`] from the `x`, `y` and `z` elements of `self` discarding `w`.

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -150,7 +150,7 @@ impl Vec3A {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Creates a [`Vec3A`] from the `x`, `y` and `z` elements of `self` discarding `w`.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -169,7 +169,7 @@ impl Vec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -156,7 +156,7 @@ impl Vec3A {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Creates a [`Vec3A`] from the `x`, `y` and `z` elements of `self` discarding `w`.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -134,7 +134,7 @@ impl Vec2 {
     /// Panics if `slice` is less than 2 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..2].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from `self` and the given `z` value.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -141,7 +141,7 @@ impl Vec3 {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Internal method for creating a 3D vector from a 4D vector, discarding `w`.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -142,7 +142,7 @@ impl Vec3A {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Creates a [`Vec3A`] from the `x`, `y` and `z` elements of `self` discarding `w`.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -144,7 +144,7 @@ impl Vec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -134,7 +134,7 @@ impl DVec2 {
     /// Panics if `slice` is less than 2 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f64]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..2].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from `self` and the given `z` value.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -141,7 +141,7 @@ impl DVec3 {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f64]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Internal method for creating a 3D vector from a 4D vector, discarding `w`.

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -160,7 +160,7 @@ impl DVec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [f64]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -126,7 +126,7 @@ impl I16Vec2 {
     /// Panics if `slice` is less than 2 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i16]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..2].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from `self` and the given `z` value.

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -135,7 +135,7 @@ impl I16Vec3 {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i16]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Internal method for creating a 3D vector from a 4D vector, discarding `w`.

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -152,7 +152,7 @@ impl I16Vec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i16]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -126,7 +126,7 @@ impl IVec2 {
     /// Panics if `slice` is less than 2 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..2].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from `self` and the given `z` value.

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -135,7 +135,7 @@ impl IVec3 {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Internal method for creating a 3D vector from a 4D vector, discarding `w`.

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -152,7 +152,7 @@ impl IVec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -126,7 +126,7 @@ impl I64Vec2 {
     /// Panics if `slice` is less than 2 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i64]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..2].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from `self` and the given `z` value.

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -135,7 +135,7 @@ impl I64Vec3 {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i64]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Internal method for creating a 3D vector from a 4D vector, discarding `w`.

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -152,7 +152,7 @@ impl I64Vec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i64]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -126,7 +126,7 @@ impl I8Vec2 {
     /// Panics if `slice` is less than 2 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i8]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..2].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from `self` and the given `z` value.

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -135,7 +135,7 @@ impl I8Vec3 {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i8]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Internal method for creating a 3D vector from a 4D vector, discarding `w`.

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -152,7 +152,7 @@ impl I8Vec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [i8]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -117,7 +117,7 @@ impl U16Vec2 {
     /// Panics if `slice` is less than 2 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u16]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..2].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from `self` and the given `z` value.

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -123,7 +123,7 @@ impl U16Vec3 {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u16]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Internal method for creating a 3D vector from a 4D vector, discarding `w`.

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -137,7 +137,7 @@ impl U16Vec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u16]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -117,7 +117,7 @@ impl UVec2 {
     /// Panics if `slice` is less than 2 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..2].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from `self` and the given `z` value.

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -123,7 +123,7 @@ impl UVec3 {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Internal method for creating a 3D vector from a 4D vector, discarding `w`.

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -137,7 +137,7 @@ impl UVec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u32]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -117,7 +117,7 @@ impl U64Vec2 {
     /// Panics if `slice` is less than 2 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u64]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..2].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from `self` and the given `z` value.

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -123,7 +123,7 @@ impl U64Vec3 {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u64]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Internal method for creating a 3D vector from a 4D vector, discarding `w`.

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -137,7 +137,7 @@ impl U64Vec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u64]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -117,7 +117,7 @@ impl U8Vec2 {
     /// Panics if `slice` is less than 2 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u8]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..2].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from `self` and the given `z` value.

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -123,7 +123,7 @@ impl U8Vec3 {
     /// Panics if `slice` is less than 3 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u8]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..3].copy_from_slice(&self.to_array());
     }
 
     /// Internal method for creating a 3D vector from a 4D vector, discarding `w`.

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -137,7 +137,7 @@ impl U8Vec4 {
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
     pub fn write_to_slice(self, slice: &mut [u8]) {
-        slice.copy_from_slice(&self.to_array());
+        slice[..4].copy_from_slice(&self.to_array());
     }
 
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -613,6 +613,11 @@ macro_rules! impl_vec2_tests {
             v.write_to_slice(&mut a);
             assert_eq!(v, $vec2::from_slice(&a));
 
+            let mut a = [0 as $t; 17];
+            v.write_to_slice(&mut a);
+            assert_eq!(v, $vec2::from_slice(&a[..2]));
+            assert_eq!([0 as $t; 15], a[2..]);
+
             should_panic!({ $vec2::ONE.write_to_slice(&mut [0 as $t]) });
             should_panic!({ $vec2::from_slice(&[0 as $t]) });
         });

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -718,6 +718,11 @@ macro_rules! impl_vec3_tests {
             v.write_to_slice(&mut a);
             assert_eq!(v, $vec3::from_slice(&a));
 
+            let mut a = [0 as $t; 17];
+            v.write_to_slice(&mut a);
+            assert_eq!(v, $vec3::from_slice(&a[..3]));
+            assert_eq!([0 as $t; 14], a[3..]);
+
             should_panic!({ $vec3::ONE.write_to_slice(&mut [0 as $t; 2]) });
             should_panic!({ $vec3::from_slice(&[0 as $t; 2]) });
         });

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -836,6 +836,11 @@ macro_rules! impl_vec4_tests {
             let mut a = [0 as $t, 0 as $t, 0 as $t, 0 as $t];
             v.write_to_slice(&mut a);
             assert_eq!(v, $vec4::from_slice(&a));
+
+            let mut a = [0 as $t; 17];
+            v.write_to_slice(&mut a);
+            assert_eq!(v, $vec4::from_slice(&a[..4]));
+            assert_eq!([0 as $t; 13], a[4..]);
         });
 
         glam_test!(test_sum, {


### PR DESCRIPTION
Fix regression introduced in #571.

`VecN::write_to_slice` expects the slice length to be >= dim, not == dim.

`slice::copy_from_slice` expects both slices to have the same length.