### PR TITLE
Add `Vec3::rotate_towards`

### DIFF
--- a/benches/vec3.rs
+++ b/benches/vec3.rs
@@ -184,6 +184,15 @@ bench_select!(
     from => random_vec3
 );
 
+bench_trinop!(
+    vec3_rotate_towards,
+    "vec3 rotate_towards",
+    op => rotate_towards,
+    from1 => random_vec3,
+    from2 => random_vec3,
+    from3 => random_f32
+);
+
 criterion_group!(
     benches,
     vec3_angle_between,
@@ -203,6 +212,7 @@ criterion_group!(
     vec3_to_array_into,
     vec3_to_rgb,
     vec3_to_tuple_into,
+    vec3_rotate_towards,
 );
 
 criterion_main!(benches);

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -34,12 +34,14 @@
         {% set vec3_t = "Vec3" %}
         {% set vec3a_t = "Vec3A" %}
         {% set vec4_t = "Vec4" %}
+        {% set quat_t = "Quat" %}
     {% elif scalar_t == "f64" %}
         {% set self_t = "DVec" ~ dim %}
         {% set vec2_t = "DVec2" %}
         {% set vec3_t = "DVec3" %}
         {% set vec4_t = "DVec4" %}
         {% set from_types = ["Vec" ~ dim, "IVec" ~ dim, "UVec" ~ dim] %}
+        {% set quat_t = "DQuat" %}
     {% endif %}
 {% elif scalar_t == "i8" %}
     {% set is_signed = true %}
@@ -199,6 +201,9 @@
     {% endif %}
     {% if is_float %}
         {{ scalar_t }}::math,
+        {% if dim == 3 %}
+            {{ quat_t }},
+        {% endif %}
     {% endif %}
     {% if from_types %}
         {% for ty in from_types %}
@@ -2109,6 +2114,26 @@ impl {{ self_t }} {
                 math::sqrt(self.length_squared().mul(rhs.length_squared()))))
     }
 
+    /// Rotates towards `rhs` up to `max_angle` (in radians).
+    ///
+    /// When `max_angle` is `0.0`, the result will be equal to `self`. When `max_angle` is equal to
+    /// `self.angle_between(rhs)`, the result will be parallel to `rhs`. If `max_angle` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(self, rhs: Self, max_angle: {{ scalar_t }}) -> Self {
+        let angle_between = self.angle_between(rhs);
+        if angle_between <= 1e-4 {
+            return rhs;
+        }
+        let angle = max_angle.clamp(angle_between - core::{{ scalar_t }}::consts::PI, angle_between);
+        let axis = self
+            .cross(rhs)
+            .try_normalize()
+            .unwrap_or_else(|| self.any_orthogonal_vector().normalize());
+        {{ quat_t }}::from_axis_angle(axis{% if self_t == "Vec3A" %}.into(){% endif%}, angle) * self
+    }
+
     /// Returns some vector that is orthogonal to the given one.
     ///
     /// The input vector must be finite and non-zero.
@@ -2205,7 +2230,7 @@ impl {{ self_t }} {
     /// Rotates towards `rhs` up to `max_angle` (in radians).
     ///
     /// When `max_angle` is `0.0`, the result will be equal to `self`. When `max_angle` is equal to
-    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `max_angle` is negative,
+    /// `self.angle_between(rhs)`, the result will be parallel to `rhs`. If `max_angle` is negative,
     /// rotates towards the exact opposite of `rhs`. Will not go past the target.
     #[inline]
     #[must_use]

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -2124,8 +2124,9 @@ impl {{ self_t }} {
     pub fn rotate_towards(self, rhs: Self, max_angle: {{ scalar_t }}) -> Self {
         let angle_between = self.angle_between(rhs);
         if angle_between <= 1e-4 {
-            return rhs;
+            return self;
         }
+        // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(angle_between - core::{{ scalar_t }}::consts::PI, angle_between);
         let axis = self
             .cross(rhs)
@@ -2238,7 +2239,7 @@ impl {{ self_t }} {
         let a = self.angle_to(rhs);
         let abs_a = math::abs(a);
         if abs_a <= 1e-4 {
-            return rhs;
+            return *self;
         }
         // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(abs_a - core::{{ scalar_t }}::consts::PI, abs_a) * math::signum(a);

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -894,8 +894,9 @@ impl Vec3A {
     pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         let angle_between = self.angle_between(rhs);
         if angle_between <= 1e-4 {
-            return rhs;
+            return self;
         }
+        // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
         let axis = self
             .cross(rhs)

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -1,6 +1,6 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::{coresimd::*, f32::math, BVec3, BVec3A, Vec2, Vec3, Vec4};
+use crate::{coresimd::*, f32::math, BVec3, BVec3A, Quat, Vec2, Vec3, Vec4};
 
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -882,6 +882,26 @@ impl Vec3A {
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
         )
+    }
+
+    /// Rotates towards `rhs` up to `max_angle` (in radians).
+    ///
+    /// When `max_angle` is `0.0`, the result will be equal to `self`. When `max_angle` is equal to
+    /// `self.angle_between(rhs)`, the result will be parallel to `rhs`. If `max_angle` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
+        let angle_between = self.angle_between(rhs);
+        if angle_between <= 1e-4 {
+            return rhs;
+        }
+        let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
+        let axis = self
+            .cross(rhs)
+            .try_normalize()
+            .unwrap_or_else(|| self.any_orthogonal_vector().normalize());
+        Quat::from_axis_angle(axis.into(), angle) * self
     }
 
     /// Returns some vector that is orthogonal to the given one.

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -938,8 +938,9 @@ impl Vec3A {
     pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         let angle_between = self.angle_between(rhs);
         if angle_between <= 1e-4 {
-            return rhs;
+            return self;
         }
+        // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
         let axis = self
             .cross(rhs)

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -1,6 +1,6 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::{f32::math, neon::*, BVec3, BVec3A, Vec2, Vec3, Vec4};
+use crate::{f32::math, neon::*, BVec3, BVec3A, Quat, Vec2, Vec3, Vec4};
 
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -926,6 +926,26 @@ impl Vec3A {
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
         )
+    }
+
+    /// Rotates towards `rhs` up to `max_angle` (in radians).
+    ///
+    /// When `max_angle` is `0.0`, the result will be equal to `self`. When `max_angle` is equal to
+    /// `self.angle_between(rhs)`, the result will be parallel to `rhs`. If `max_angle` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
+        let angle_between = self.angle_between(rhs);
+        if angle_between <= 1e-4 {
+            return rhs;
+        }
+        let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
+        let axis = self
+            .cross(rhs)
+            .try_normalize()
+            .unwrap_or_else(|| self.any_orthogonal_vector().normalize());
+        Quat::from_axis_angle(axis.into(), angle) * self
     }
 
     /// Returns some vector that is orthogonal to the given one.

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -941,8 +941,9 @@ impl Vec3A {
     pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         let angle_between = self.angle_between(rhs);
         if angle_between <= 1e-4 {
-            return rhs;
+            return self;
         }
+        // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
         let axis = self
             .cross(rhs)

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -1,6 +1,6 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::{f32::math, BVec3, BVec3A, Vec2, Vec3, Vec4};
+use crate::{f32::math, BVec3, BVec3A, Quat, Vec2, Vec3, Vec4};
 
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -929,6 +929,26 @@ impl Vec3A {
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
         )
+    }
+
+    /// Rotates towards `rhs` up to `max_angle` (in radians).
+    ///
+    /// When `max_angle` is `0.0`, the result will be equal to `self`. When `max_angle` is equal to
+    /// `self.angle_between(rhs)`, the result will be parallel to `rhs`. If `max_angle` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
+        let angle_between = self.angle_between(rhs);
+        if angle_between <= 1e-4 {
+            return rhs;
+        }
+        let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
+        let axis = self
+            .cross(rhs)
+            .try_normalize()
+            .unwrap_or_else(|| self.any_orthogonal_vector().normalize());
+        Quat::from_axis_angle(axis.into(), angle) * self
     }
 
     /// Returns some vector that is orthogonal to the given one.

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -946,8 +946,9 @@ impl Vec3A {
     pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         let angle_between = self.angle_between(rhs);
         if angle_between <= 1e-4 {
-            return rhs;
+            return self;
         }
+        // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
         let axis = self
             .cross(rhs)

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -1,6 +1,6 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::{f32::math, sse2::*, BVec3, BVec3A, Vec2, Vec3, Vec4};
+use crate::{f32::math, sse2::*, BVec3, BVec3A, Quat, Vec2, Vec3, Vec4};
 
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -934,6 +934,26 @@ impl Vec3A {
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
         )
+    }
+
+    /// Rotates towards `rhs` up to `max_angle` (in radians).
+    ///
+    /// When `max_angle` is `0.0`, the result will be equal to `self`. When `max_angle` is equal to
+    /// `self.angle_between(rhs)`, the result will be parallel to `rhs`. If `max_angle` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
+        let angle_between = self.angle_between(rhs);
+        if angle_between <= 1e-4 {
+            return rhs;
+        }
+        let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
+        let axis = self
+            .cross(rhs)
+            .try_normalize()
+            .unwrap_or_else(|| self.any_orthogonal_vector().normalize());
+        Quat::from_axis_angle(axis.into(), angle) * self
     }
 
     /// Returns some vector that is orthogonal to the given one.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -921,7 +921,7 @@ impl Vec2 {
     /// Rotates towards `rhs` up to `max_angle` (in radians).
     ///
     /// When `max_angle` is `0.0`, the result will be equal to `self`. When `max_angle` is equal to
-    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `max_angle` is negative,
+    /// `self.angle_between(rhs)`, the result will be parallel to `rhs`. If `max_angle` is negative,
     /// rotates towards the exact opposite of `rhs`. Will not go past the target.
     #[inline]
     #[must_use]

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -929,7 +929,7 @@ impl Vec2 {
         let a = self.angle_to(rhs);
         let abs_a = math::abs(a);
         if abs_a <= 1e-4 {
-            return rhs;
+            return *self;
         }
         // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(abs_a - core::f32::consts::PI, abs_a) * math::signum(a);

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -931,8 +931,9 @@ impl Vec3 {
     pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         let angle_between = self.angle_between(rhs);
         if angle_between <= 1e-4 {
-            return rhs;
+            return self;
         }
+        // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
         let axis = self
             .cross(rhs)

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -1,6 +1,6 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::{f32::math, BVec3, BVec3A, Vec2, Vec4};
+use crate::{f32::math, BVec3, BVec3A, Quat, Vec2, Vec4};
 
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -919,6 +919,26 @@ impl Vec3 {
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
         )
+    }
+
+    /// Rotates towards `rhs` up to `max_angle` (in radians).
+    ///
+    /// When `max_angle` is `0.0`, the result will be equal to `self`. When `max_angle` is equal to
+    /// `self.angle_between(rhs)`, the result will be parallel to `rhs`. If `max_angle` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
+        let angle_between = self.angle_between(rhs);
+        if angle_between <= 1e-4 {
+            return rhs;
+        }
+        let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
+        let axis = self
+            .cross(rhs)
+            .try_normalize()
+            .unwrap_or_else(|| self.any_orthogonal_vector().normalize());
+        Quat::from_axis_angle(axis, angle) * self
     }
 
     /// Returns some vector that is orthogonal to the given one.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -1,6 +1,6 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::{f32::math, wasm32::*, BVec3, BVec3A, Vec2, Vec3, Vec4};
+use crate::{f32::math, wasm32::*, BVec3, BVec3A, Quat, Vec2, Vec3, Vec4};
 
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -897,6 +897,26 @@ impl Vec3A {
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
         )
+    }
+
+    /// Rotates towards `rhs` up to `max_angle` (in radians).
+    ///
+    /// When `max_angle` is `0.0`, the result will be equal to `self`. When `max_angle` is equal to
+    /// `self.angle_between(rhs)`, the result will be parallel to `rhs`. If `max_angle` is negative,
+    /// rotates towards the exact opposite of `rhs`. Will not go past the target.
+    #[inline]
+    #[must_use]
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
+        let angle_between = self.angle_between(rhs);
+        if angle_between <= 1e-4 {
+            return rhs;
+        }
+        let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
+        let axis = self
+            .cross(rhs)
+            .try_normalize()
+            .unwrap_or_else(|| self.any_orthogonal_vector().normalize());
+        Quat::from_axis_angle(axis.into(), angle) * self
     }
 
     /// Returns some vector that is orthogonal to the given one.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -909,8 +909,9 @@ impl Vec3A {
     pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         let angle_between = self.angle_between(rhs);
         if angle_between <= 1e-4 {
-            return rhs;
+            return self;
         }
+        // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(angle_between - core::f32::consts::PI, angle_between);
         let axis = self
             .cross(rhs)

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -921,7 +921,7 @@ impl DVec2 {
     /// Rotates towards `rhs` up to `max_angle` (in radians).
     ///
     /// When `max_angle` is `0.0`, the result will be equal to `self`. When `max_angle` is equal to
-    /// `self.angle_between(rhs)`, the result will be equal to `rhs`. If `max_angle` is negative,
+    /// `self.angle_between(rhs)`, the result will be parallel to `rhs`. If `max_angle` is negative,
     /// rotates towards the exact opposite of `rhs`. Will not go past the target.
     #[inline]
     #[must_use]

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -929,7 +929,7 @@ impl DVec2 {
         let a = self.angle_to(rhs);
         let abs_a = math::abs(a);
         if abs_a <= 1e-4 {
-            return rhs;
+            return *self;
         }
         // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(abs_a - core::f64::consts::PI, abs_a) * math::signum(a);

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -931,8 +931,9 @@ impl DVec3 {
     pub fn rotate_towards(self, rhs: Self, max_angle: f64) -> Self {
         let angle_between = self.angle_between(rhs);
         if angle_between <= 1e-4 {
-            return rhs;
+            return self;
         }
+        // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(angle_between - core::f64::consts::PI, angle_between);
         let axis = self
             .cross(rhs)

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -992,6 +992,13 @@ macro_rules! impl_vec2_float_tests {
             );
             assert_approx_eq!(v2, v0.rotate_towards(v1, -FRAC_PI_2), eps);
             assert_approx_eq!(v2, v0.rotate_towards(v1, -FRAC_PI_2 * 1.5), eps);
+
+            // Not normalized
+            assert_approx_eq!(v1 * 2., (v0 * 2.).rotate_towards(v1, FRAC_PI_2), eps);
+            assert_approx_eq!(v1, v0.rotate_towards(v1 * 2., FRAC_PI_2), eps);
+
+            // Parralel
+            assert_approx_eq!(v2, v0.rotate_towards(-v0, FRAC_PI_2), eps);
         });
 
         glam_test!(test_midpoint, {

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -1109,6 +1109,45 @@ macro_rules! impl_vec3_float_tests {
             assert_approx_eq!(v1, v0.move_towards(v1, v0.distance(v1) + 1.0));
         });
 
+        glam_test!(test_rotate_towards, {
+            use core::$t::consts::PI;
+
+            // Positive angle
+            assert_approx_eq!($vec3::X, $vec3::X.rotate_towards($vec3::NEG_Y, 0.0));
+            assert_approx_eq!(
+                $vec3::new($t::sqrt(2.0) / 2.0, -$t::sqrt(2.0) / 2.0, 0.0),
+                $vec3::X.rotate_towards($vec3::NEG_Y, PI / 4.)
+            );
+            assert_approx_eq!(
+                $vec3::new($t::sqrt(2.0) / 2.0, 0.0, $t::sqrt(2.0) / 2.0),
+                $vec3::X.rotate_towards($vec3::Z, PI / 4.)
+            );
+            assert_approx_eq!($vec3::NEG_Y, $vec3::X.rotate_towards($vec3::NEG_Y, PI / 2.));
+            assert_approx_eq!($vec3::NEG_Y, $vec3::X.rotate_towards($vec3::NEG_Y, PI));
+
+            // Negative angle
+            assert_approx_eq!(
+                $vec3::new($t::sqrt(2.0) / 2.0, $t::sqrt(2.0) / 2.0, 0.0),
+                $vec3::X.rotate_towards($vec3::NEG_Y, -PI / 4.)
+            );
+            assert_approx_eq!($vec3::Y, $vec3::X.rotate_towards($vec3::NEG_Y, -PI / 2.));
+            assert_approx_eq!($vec3::Y, $vec3::X.rotate_towards($vec3::NEG_Y, -PI), 2e-7);
+
+            // Not normalized
+            assert_approx_eq!(
+                $vec3::NEG_Y * 2.,
+                ($vec3::X * 2.).rotate_towards($vec3::NEG_Y, PI / 2.),
+                2e-7
+            );
+            assert_approx_eq!(
+                $vec3::NEG_Y,
+                $vec3::X.rotate_towards($vec3::NEG_Y * 2., PI / 2.)
+            );
+
+            // Parralel
+            assert_approx_eq!($vec3::Y, $vec3::X.rotate_towards($vec3::NEG_X, PI / 2.));
+        });
+
         glam_test!(test_midpoint, {
             let v0 = $vec3::new(-1.0, -1.0, -1.0);
             let v1 = $vec3::new(1.0, 1.0, 1.0);


### PR DESCRIPTION
Added `Vec3::rotate_towards` with identical behavior to `Vec2::rotate_towards`

I added some extra tests to `Vec2::rotate_towards` as well, and adjusted the docs to be more accurate since the method does not interpolate the lengths of the vectors.

I noticed another issue with that. `Vec2::rotate_towards` returned `rhs` when the angle is too small. This means that only in that case the length of the resulting vector is equal to that of `rhs` instead of `self`.
It also differs from `Quat::rotate_towards` which returns `self` when the angle is too small, so I've updated it to return `self` instead.