### PR TITLE
Update links for the `tera` project

### DIFF
--- a/codegen/README.md
+++ b/codegen/README.md
@@ -27,8 +27,8 @@ Rust code. The templates are fairly declarative and easier to follow than the
 macros (in my opinion). I try to stick to basic features of the [templating
 language] to keep things simple.
 
-[`Tera`]: https://tera.netlify.app/
-[templating language]: https://tera.netlify.app/docs/
+[`Tera`]: https://keats.github.io/tera/
+[templating language]: https://keats.github.io/tera/docs/
 
 ### Control variables
 


### PR DESCRIPTION
Since https://github.com/Keats/tera/commit/22b9698780b77c5f9de358410a627aa402f728b2
The `tera` project documentation is at another location:)