### PR TITLE
Return the target Quat when the angle is small

### DIFF
--- a/codegen/templates/quat.rs.tera
+++ b/codegen/templates/quat.rs.tera
@@ -729,7 +729,7 @@ impl {{ self_t }} {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {
-            return *self;
+            return rhs;
         }
         let s = (max_angle / angle).clamp(-1.0, 1.0);
         self.slerp(rhs, s)

--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -585,7 +585,7 @@ impl Quat {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {
-            return *self;
+            return rhs;
         }
         let s = (max_angle / angle).clamp(-1.0, 1.0);
         self.slerp(rhs, s)

--- a/src/f32/neon/quat.rs
+++ b/src/f32/neon/quat.rs
@@ -590,7 +590,7 @@ impl Quat {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {
-            return *self;
+            return rhs;
         }
         let s = (max_angle / angle).clamp(-1.0, 1.0);
         self.slerp(rhs, s)

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -597,7 +597,7 @@ impl Quat {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {
-            return *self;
+            return rhs;
         }
         let s = (max_angle / angle).clamp(-1.0, 1.0);
         self.slerp(rhs, s)

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -593,7 +593,7 @@ impl Quat {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {
-            return *self;
+            return rhs;
         }
         let s = (max_angle / angle).clamp(-1.0, 1.0);
         self.slerp(rhs, s)

--- a/src/f32/wasm32/quat.rs
+++ b/src/f32/wasm32/quat.rs
@@ -585,7 +585,7 @@ impl Quat {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {
-            return *self;
+            return rhs;
         }
         let s = (max_angle / angle).clamp(-1.0, 1.0);
         self.slerp(rhs, s)

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -579,7 +579,7 @@ impl DQuat {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {
-            return *self;
+            return rhs;
         }
         let s = (max_angle / angle).clamp(-1.0, 1.0);
         self.slerp(rhs, s)

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -356,6 +356,11 @@ macro_rules! impl_quat_tests {
             );
             assert_approx_eq!(q2, q0.rotate_towards(q1, -FRAC_PI_2), eps);
             assert_approx_eq!(q2, q0.rotate_towards(q1, -FRAC_PI_2 * 1.5), eps);
+
+            // Small angles
+            let q0 = $quat::from_euler(EulerRot::YXZ, 0.0, 0.0, 0.0);
+            let q1 = $quat::from_euler(EulerRot::YXZ, 1e-4, 0.0, 0.0);
+            assert_eq!(q1, q0.rotate_towards(q1, FRAC_PI_2))
         });
 
         glam_test!(test_fmt, {


### PR DESCRIPTION
Returning source `Quat` is misleading as it skips the rotation completely.

See #590 