### PR TITLE
Add a compilation error if neither `std` nor `libm` features are specified

### DIFF
--- a/src/f32/math.rs
+++ b/src/f32/math.rs
@@ -140,7 +140,7 @@ mod libm_math {
     }
 }
 
-#[cfg(not(feature = "libm"))]
+#[cfg(all(not(feature = "libm"), feature = "std"))]
 mod std_math {
     #[inline(always)]
     pub(crate) fn abs(f: f32) -> f32 {
@@ -234,8 +234,88 @@ mod std_math {
     }
 }
 
+// Used to reduce the number of compilation errors, in the event that no other
+// math backend is specified.
+#[cfg(all(not(feature = "libm"), not(feature = "std")))]
+mod no_backend_math {
+    pub(crate) fn abs(_: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn acos_approx(_: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn atan2(_: f32, _: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn sin(_: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn sin_cos(_: f32) -> (f32, f32) {
+        unimplemented!()
+    }
+
+    pub(crate) fn tan(_: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn sqrt(_: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn copysign(_: f32, _: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn signum(_: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn round(_: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn trunc(_: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn ceil(_: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn floor(_: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn exp(_: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn powf(_: f32, _: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub(crate) fn mul_add(_: f32, _: f32, _: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub fn div_euclid(_: f32, _: f32) -> f32 {
+        unimplemented!()
+    }
+
+    pub fn rem_euclid(_: f32, _: f32) -> f32 {
+        unimplemented!()
+    }
+}
+
 #[cfg(feature = "libm")]
 pub(crate) use libm_math::*;
 
-#[cfg(not(feature = "libm"))]
+#[cfg(all(not(feature = "libm"), feature = "std"))]
 pub(crate) use std_math::*;
+
+#[cfg(all(not(feature = "libm"), not(feature = "std")))]
+pub(crate) use no_backend_math::*;

--- a/src/f64/math.rs
+++ b/src/f64/math.rs
@@ -105,7 +105,7 @@ mod libm_math {
     }
 }
 
-#[cfg(not(feature = "libm"))]
+#[cfg(all(not(feature = "libm"), feature = "std"))]
 mod std_math {
     #[inline(always)]
     pub(crate) fn abs(f: f64) -> f64 {
@@ -198,8 +198,88 @@ mod std_math {
     }
 }
 
+// Used to reduce the number of compilation errors, in the event that no other
+// math backend is specified.
+#[cfg(all(not(feature = "libm"), not(feature = "std")))]
+mod no_backend_math {
+    pub(crate) fn abs(_: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn acos_approx(_: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn atan2(_: f64, _: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn sin(_: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn sin_cos(_: f64) -> (f64, f64) {
+        unimplemented!()
+    }
+
+    pub(crate) fn tan(_: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn sqrt(_: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn copysign(_: f64, _: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn signum(_: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn round(_: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn trunc(_: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn ceil(_: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn floor(_: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn exp(_: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn powf(_: f64, _: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub(crate) fn mul_add(_: f64, _: f64, _: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub fn div_euclid(_: f64, _: f64) -> f64 {
+        unimplemented!()
+    }
+
+    pub fn rem_euclid(_: f64, _: f64) -> f64 {
+        unimplemented!()
+    }
+}
+
 #[cfg(feature = "libm")]
 pub(crate) use libm_math::*;
 
-#[cfg(not(feature = "libm"))]
+#[cfg(all(not(feature = "libm"), feature = "std"))]
 pub(crate) use std_math::*;
+
+#[cfg(all(not(feature = "libm"), not(feature = "std")))]
+pub(crate) use no_backend_math::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,9 @@ The minimum supported Rust version is `1.68.2`.
     feature(portable_simd)
 )]
 
+#![cfg(all(not(feature = "std"), not(feature = "libm")))]
+compile_error!("You must specify a math backend using either the `std` feature or `libm` feature");
+
 #[macro_use]
 mod macros;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,7 @@ The minimum supported Rust version is `1.68.2`.
     feature(portable_simd)
 )]
 
-#![cfg(all(not(feature = "std"), not(feature = "libm")))]
+#[cfg(all(not(feature = "std"), not(feature = "libm")))]
 compile_error!("You must specify a math backend using either the `std` feature or `libm` feature");
 
 #[macro_use]


### PR DESCRIPTION
Glam would previously cryptically error out during compilation, if neither the `std` nor `libm` features were specified. This is due to `no_std` being turned on, which removed many methods from the `f32` and `f64` primitives, while glam simultaneously would try to use those methods.

To solve this, I added a compilation error if no math backend is specified.

However, this `compile_error!()` does not silence the compilation errors generated by the use of non-existent methods. To silence them, I added a new module to `glam::f32::math` and `glam::f64::math` - one which defines the methods, but points them all to `unimplemented!()`.

The end result is that, if a backend is specified, glam compiles as normal - but if no backend is specified, glam returns a compilation error:
```shell
PS $root\bitshifter.glam-rs> cargo build --no-default-features
   Compiling glam v0.29.2 ($root\bitshifter.glam-rs)
error: You must specify a math backend using either the `std` feature or `libm` feature
   --> src\lib.rs:276:1
    |
276 | compile_error!("You must specify a math backend using either the `std` feature or `libm` feature");
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: could not compile `glam` (lib) due to 1 previous error

PS $root\bitshifter.glam-rs> cargo build --no-default-features --features std
   Compiling glam v0.29.2 ($root\bitshifter.glam-rs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.90s

PS $root\bitshifter.glam-rs> cargo build --no-default-features --features libm
   Compiling glam v0.29.2 ($root\bitshifter.glam-rs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.34s

PS $root\bitshifter.glam-rs> cargo build --no-default-features --features std,libm
   Compiling glam v0.29.2 ($root\bitshifter.glam-rs)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 8.31s
```