### PR TITLE
Add checked_* elementwise arithmetic operations for {I,U}Vec{2,3,4}

### DIFF
--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -2584,6 +2584,74 @@ impl {{ self_t }} {
 {% if not is_float %}
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        {% for c in components %}
+            let {{ c }} = match self.{{ c }}.checked_add(rhs.{{ c }}) { Some(v) => v, None => {return None} };
+        {%- endfor %}
+
+        Some(Self {
+            {% for c in components %}
+                {{ c }},
+            {%- endfor %}
+        })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        {% for c in components %}
+            let {{ c }} = match self.{{ c }}.checked_sub(rhs.{{ c }}) { Some(v) => v, None => {return None} };
+        {%- endfor %}
+
+        Some(Self {
+            {% for c in components %}
+                {{ c }},
+            {%- endfor %}
+        })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        {% for c in components %}
+            let {{ c }} = match self.{{ c }}.checked_mul(rhs.{{ c }}) { Some(v) => v, None => {return None} };
+        {%- endfor %}
+
+        Some(Self {
+            {% for c in components %}
+                {{ c }},
+            {%- endfor %}
+        })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        {% for c in components %}
+            let {{ c }} = match self.{{ c }}.checked_div(rhs.{{ c }}) { Some(v) => v, None => {return None} };
+        {%- endfor %}
+
+        Some(Self {
+            {% for c in components %}
+                {{ c }},
+            {%- endfor %}
+        })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -2688,6 +2756,40 @@ impl {{ self_t }} {
     {% if is_signed %}
         /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
         ///
+        /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+        #[inline]
+        #[must_use]
+        pub const fn checked_add_unsigned(self, rhs: {{ opposite_signedness_t }}) -> Option<Self> {
+            {% for c in components %}
+                let {{ c }} = match self.{{ c }}.checked_add_unsigned(rhs.{{ c }}) { Some(v) => v, None => {return None} };
+            {%- endfor %}
+
+            Some(Self {
+                {% for c in components %}
+                    {{ c }},
+                {%- endfor %}
+            })
+        }
+
+        /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+        ///
+        /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+        #[inline]
+        #[must_use]
+        pub const fn checked_sub_unsigned(self, rhs: {{ opposite_signedness_t }}) -> Option<Self> {
+            {% for c in components %}
+                let {{ c }} = match self.{{ c }}.checked_sub_unsigned(rhs.{{ c }}) { Some(v) => v, None => {return None} };
+            {%- endfor %}
+
+            Some(Self {
+                {% for c in components %}
+                    {{ c }},
+                {%- endfor %}
+            })
+        }
+
+        /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+        ///
         /// In other words this computes `[self.x.wrapping_add_unsigned(rhs.x), self.y.wrapping_add_unsigned(rhs.y), ..]`.
         #[inline]
         #[must_use]
@@ -2738,6 +2840,23 @@ impl {{ self_t }} {
             }
         }
     {% else %}
+        /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+        ///
+        /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+        #[inline]
+        #[must_use]
+        pub const fn checked_add_signed(self, rhs: {{ opposite_signedness_t }}) -> Option<Self> {
+            {% for c in components %}
+                let {{ c }} = match self.{{ c }}.checked_add_signed(rhs.{{ c }}) { Some(v) => v, None => {return None} };
+            {%- endfor %}
+
+            Some(Self {
+                {% for c in components %}
+                    {{ c }},
+                {%- endfor %}
+            })
+        }
+
         /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
         ///
         /// In other words this computes `[self.x.wrapping_add_signed(rhs.x), self.y.wrapping_add_signed(rhs.y), ..]`.

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -514,6 +514,78 @@ impl I16Vec2 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -606,6 +678,42 @@ impl I16Vec2 {
             x: self.x.saturating_div(rhs.x),
             y: self.y.saturating_div(rhs.y),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: U16Vec2) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: U16Vec2) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -557,6 +557,94 @@ impl I16Vec3 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -657,6 +745,50 @@ impl I16Vec3 {
             y: self.y.saturating_div(rhs.y),
             z: self.z.saturating_div(rhs.z),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: U16Vec3) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: U16Vec3) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -587,6 +587,110 @@ impl I16Vec4 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_mul(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_div(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -695,6 +799,58 @@ impl I16Vec4 {
             z: self.z.saturating_div(rhs.z),
             w: self.w.saturating_div(rhs.w),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: U16Vec4) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add_unsigned(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: U16Vec4) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub_unsigned(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -514,6 +514,78 @@ impl IVec2 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -606,6 +678,42 @@ impl IVec2 {
             x: self.x.saturating_div(rhs.x),
             y: self.y.saturating_div(rhs.y),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: UVec2) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: UVec2) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -557,6 +557,94 @@ impl IVec3 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -657,6 +745,50 @@ impl IVec3 {
             y: self.y.saturating_div(rhs.y),
             z: self.z.saturating_div(rhs.z),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: UVec3) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: UVec3) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -587,6 +587,110 @@ impl IVec4 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_mul(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_div(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -695,6 +799,58 @@ impl IVec4 {
             z: self.z.saturating_div(rhs.z),
             w: self.w.saturating_div(rhs.w),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: UVec4) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add_unsigned(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: UVec4) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub_unsigned(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -514,6 +514,78 @@ impl I64Vec2 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -606,6 +678,42 @@ impl I64Vec2 {
             x: self.x.saturating_div(rhs.x),
             y: self.y.saturating_div(rhs.y),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: U64Vec2) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: U64Vec2) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -557,6 +557,94 @@ impl I64Vec3 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -657,6 +745,50 @@ impl I64Vec3 {
             y: self.y.saturating_div(rhs.y),
             z: self.z.saturating_div(rhs.z),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: U64Vec3) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: U64Vec3) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -587,6 +587,110 @@ impl I64Vec4 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_mul(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_div(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -695,6 +799,58 @@ impl I64Vec4 {
             z: self.z.saturating_div(rhs.z),
             w: self.w.saturating_div(rhs.w),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: U64Vec4) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add_unsigned(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: U64Vec4) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub_unsigned(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -514,6 +514,78 @@ impl I8Vec2 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -606,6 +678,42 @@ impl I8Vec2 {
             x: self.x.saturating_div(rhs.x),
             y: self.y.saturating_div(rhs.y),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: U8Vec2) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: U8Vec2) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -557,6 +557,94 @@ impl I8Vec3 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -657,6 +745,50 @@ impl I8Vec3 {
             y: self.y.saturating_div(rhs.y),
             z: self.z.saturating_div(rhs.z),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: U8Vec3) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: U8Vec3) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -587,6 +587,110 @@ impl I8Vec4 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_mul(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_div(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -695,6 +799,58 @@ impl I8Vec4 {
             z: self.z.saturating_div(rhs.z),
             w: self.w.saturating_div(rhs.w),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_unsigned(self, rhs: U8Vec4) -> Option<Self> {
+        let x = match self.x.checked_add_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add_unsigned(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and unsigned vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub_unsigned(self, rhs: U8Vec4) -> Option<Self> {
+        let x = match self.x.checked_sub_unsigned(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub_unsigned(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub_unsigned(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub_unsigned(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and unsigned vector `rhs`.

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -409,6 +409,78 @@ impl U16Vec2 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -501,6 +573,24 @@ impl U16Vec2 {
             x: self.x.saturating_div(rhs.x),
             y: self.y.saturating_div(rhs.y),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: I16Vec2) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -470,6 +470,94 @@ impl U16Vec3 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -570,6 +658,28 @@ impl U16Vec3 {
             y: self.y.saturating_div(rhs.y),
             z: self.z.saturating_div(rhs.z),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: I16Vec3) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_signed(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -492,6 +492,110 @@ impl U16Vec4 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_mul(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_div(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -600,6 +704,32 @@ impl U16Vec4 {
             z: self.z.saturating_div(rhs.z),
             w: self.w.saturating_div(rhs.w),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: I16Vec4) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_signed(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add_signed(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -409,6 +409,78 @@ impl UVec2 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -501,6 +573,24 @@ impl UVec2 {
             x: self.x.saturating_div(rhs.x),
             y: self.y.saturating_div(rhs.y),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: IVec2) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -470,6 +470,94 @@ impl UVec3 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -570,6 +658,28 @@ impl UVec3 {
             y: self.y.saturating_div(rhs.y),
             z: self.z.saturating_div(rhs.z),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: IVec3) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_signed(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -492,6 +492,110 @@ impl UVec4 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_mul(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_div(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -600,6 +704,32 @@ impl UVec4 {
             z: self.z.saturating_div(rhs.z),
             w: self.w.saturating_div(rhs.w),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: IVec4) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_signed(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add_signed(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -409,6 +409,78 @@ impl U64Vec2 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -501,6 +573,24 @@ impl U64Vec2 {
             x: self.x.saturating_div(rhs.x),
             y: self.y.saturating_div(rhs.y),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: I64Vec2) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -470,6 +470,94 @@ impl U64Vec3 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -570,6 +658,28 @@ impl U64Vec3 {
             y: self.y.saturating_div(rhs.y),
             z: self.z.saturating_div(rhs.z),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: I64Vec3) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_signed(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -492,6 +492,110 @@ impl U64Vec4 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_mul(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_div(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -600,6 +704,32 @@ impl U64Vec4 {
             z: self.z.saturating_div(rhs.z),
             w: self.w.saturating_div(rhs.w),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: I64Vec4) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_signed(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add_signed(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -409,6 +409,78 @@ impl U8Vec2 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -501,6 +573,24 @@ impl U8Vec2 {
             x: self.x.saturating_div(rhs.x),
             y: self.y.saturating_div(rhs.y),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: I8Vec2) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -470,6 +470,94 @@ impl U8Vec3 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -570,6 +658,28 @@ impl U8Vec3 {
             y: self.y.saturating_div(rhs.y),
             z: self.z.saturating_div(rhs.z),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: I8Vec3) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_signed(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -492,6 +492,110 @@ impl U8Vec4 {
 
     /// Returns a vector containing the wrapping addition of `self` and `rhs`.
     ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_add(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping subtraction of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x - rhs.x, self.y - rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_sub(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_sub(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_sub(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_sub(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping multiplication of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x * rhs.x, self.y * rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_mul(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_mul(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_mul(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_mul(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping division of `self` and `rhs`.
+    ///
+    /// In other words this computes `Some([self.x / rhs.x, self.y / rhs.y, ..])` but returns `None` on any division by zero.
+    #[inline]
+    #[must_use]
+    pub const fn checked_div(self, rhs: Self) -> Option<Self> {
+        let x = match self.x.checked_div(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_div(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_div(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_div(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and `rhs`.
+    ///
     /// In other words this computes `[self.x.wrapping_add(rhs.x), self.y.wrapping_add(rhs.y), ..]`.
     #[inline]
     #[must_use]
@@ -600,6 +704,32 @@ impl U8Vec4 {
             z: self.z.saturating_div(rhs.z),
             w: self.w.saturating_div(rhs.w),
         }
+    }
+
+    /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.
+    ///
+    /// In other words this computes `Some([self.x + rhs.x, self.y + rhs.y, ..])` but returns `None` on any overflow.
+    #[inline]
+    #[must_use]
+    pub const fn checked_add_signed(self, rhs: I8Vec4) -> Option<Self> {
+        let x = match self.x.checked_add_signed(rhs.x) {
+            Some(v) => v,
+            None => return None,
+        };
+        let y = match self.y.checked_add_signed(rhs.y) {
+            Some(v) => v,
+            None => return None,
+        };
+        let z = match self.z.checked_add_signed(rhs.z) {
+            Some(v) => v,
+            None => return None,
+        };
+        let w = match self.w.checked_add_signed(rhs.w) {
+            Some(v) => v,
+            None => return None,
+        };
+
+        Some(Self { x, y, z, w })
     }
 
     /// Returns a vector containing the wrapping addition of `self` and signed vector `rhs`.

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -730,46 +730,46 @@ macro_rules! impl_vec2_signed_integer_tests {
         impl_vec2_signed_tests!($t, $new, $vec2, $vec3, $mask, $masknew);
 
         glam_test!(test_signum, {
-            assert_eq!($vec3::ZERO.signum(), $vec3::ZERO);
-            assert_eq!($vec3::ONE.signum(), $vec3::ONE);
-            assert_eq!((-$vec3::ONE).signum(), -$vec3::ONE);
+            assert_eq!($vec2::ZERO.signum(), $vec2::ZERO);
+            assert_eq!($vec2::ONE.signum(), $vec2::ONE);
+            assert_eq!((-$vec2::ONE).signum(), -$vec2::ONE);
         });
 
         glam_test!(test_checked_add, {
-            assert_eq!($vec3::MAX.checked_add($vec3::ONE), None);
-            assert_eq!($vec3::MAX.checked_add($vec3::X), None);
-            assert_eq!($vec3::MAX.checked_add($vec3::Y), None);
-            assert_eq!($vec3::MAX.checked_add($vec3::ZERO), Some($vec3::MAX));
+            assert_eq!($vec2::MAX.checked_add($vec2::ONE), None);
+            assert_eq!($vec2::MAX.checked_add($vec2::X), None);
+            assert_eq!($vec2::MAX.checked_add($vec2::Y), None);
+            assert_eq!($vec2::MAX.checked_add($vec2::ZERO), Some($vec2::MAX));
         });
 
         glam_test!(test_checked_sub, {
-            assert_eq!($vec3::MIN.checked_sub($vec3::ONE), None);
-            assert_eq!($vec3::MIN.checked_sub($vec3::X), None);
-            assert_eq!($vec3::MIN.checked_sub($vec3::Y), None);
-            assert_eq!($vec3::MIN.checked_sub($vec3::ZERO), Some($vec3::MIN));
+            assert_eq!($vec2::MIN.checked_sub($vec2::ONE), None);
+            assert_eq!($vec2::MIN.checked_sub($vec2::X), None);
+            assert_eq!($vec2::MIN.checked_sub($vec2::Y), None);
+            assert_eq!($vec2::MIN.checked_sub($vec2::ZERO), Some($vec2::MIN));
         });
 
         glam_test!(test_checked_mul, {
-            assert_eq!($vec3::MIN.checked_mul($vec3::MIN), None);
-            assert_eq!($vec3::MAX.checked_mul($vec3::MIN), None);
-            assert_eq!($vec3::MIN.checked_mul($vec3::MAX), None);
-            assert_eq!($vec3::MAX.checked_mul($vec3::MAX), None);
-            assert_eq!($vec3::ZERO.checked_mul($vec3::MIN), Some($vec3::ZERO));
-            assert_eq!($vec3::MAX.checked_mul($vec3::ZERO), Some($vec3::ZERO));
-            assert_eq!($vec3::MIN.checked_mul($vec3::ONE), Some($vec3::MIN));
-            assert_eq!($vec3::MAX.checked_mul($vec3::ONE), Some($vec3::MAX));
-            assert_eq!($vec3::ZERO.checked_mul($vec3::ZERO), Some($vec3::ZERO));
-            assert_eq!($vec3::ONE.checked_mul($vec3::ONE), Some($vec3::ONE));
+            assert_eq!($vec2::MIN.checked_mul($vec2::MIN), None);
+            assert_eq!($vec2::MAX.checked_mul($vec2::MIN), None);
+            assert_eq!($vec2::MIN.checked_mul($vec2::MAX), None);
+            assert_eq!($vec2::MAX.checked_mul($vec2::MAX), None);
+            assert_eq!($vec2::ZERO.checked_mul($vec2::MIN), Some($vec2::ZERO));
+            assert_eq!($vec2::MAX.checked_mul($vec2::ZERO), Some($vec2::ZERO));
+            assert_eq!($vec2::MIN.checked_mul($vec2::ONE), Some($vec2::MIN));
+            assert_eq!($vec2::MAX.checked_mul($vec2::ONE), Some($vec2::MAX));
+            assert_eq!($vec2::ZERO.checked_mul($vec2::ZERO), Some($vec2::ZERO));
+            assert_eq!($vec2::ONE.checked_mul($vec2::ONE), Some($vec2::ONE));
         });
 
         glam_test!(test_checked_div, {
-            assert_eq!($vec3::MIN.checked_div($vec3::ZERO), None);
-            assert_eq!($vec3::MAX.checked_div($vec3::ZERO), None);
-            assert_eq!($vec3::MAX.checked_div($vec3::X), None);
-            assert_eq!($vec3::MAX.checked_div($vec3::Y), None);
-            assert_eq!($vec3::ZERO.checked_div($vec3::ONE), Some($vec3::ZERO));
-            assert_eq!($vec3::MIN.checked_div($vec3::ONE), Some($vec3::MIN));
-            assert_eq!($vec3::MAX.checked_div($vec3::ONE), Some($vec3::MAX));
+            assert_eq!($vec2::MIN.checked_div($vec2::ZERO), None);
+            assert_eq!($vec2::MAX.checked_div($vec2::ZERO), None);
+            assert_eq!($vec2::MAX.checked_div($vec2::X), None);
+            assert_eq!($vec2::MAX.checked_div($vec2::Y), None);
+            assert_eq!($vec2::ZERO.checked_div($vec2::ONE), Some($vec2::ZERO));
+            assert_eq!($vec2::MIN.checked_div($vec2::ONE), Some($vec2::MIN));
+            assert_eq!($vec2::MAX.checked_div($vec2::ONE), Some($vec2::MAX));
         });
 
         glam_test!(test_manhattan_distance, {

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -1681,10 +1681,7 @@ mod i8vec2 {
     });
 
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            I8Vec2::MAX.checked_add_unsigned(U8Vec2::ONE),
-            None
-        );
+        assert_eq!(I8Vec2::MAX.checked_add_unsigned(U8Vec2::ONE), None);
         assert_eq!(
             I8Vec2::NEG_ONE.checked_add_unsigned(U8Vec2::ONE),
             Some(I8Vec2::ZERO)
@@ -1692,10 +1689,7 @@ mod i8vec2 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            I8Vec2::MIN.checked_sub_unsigned(U8Vec2::ONE),
-            None
-        );
+        assert_eq!(I8Vec2::MIN.checked_sub_unsigned(U8Vec2::ONE), None);
         assert_eq!(
             I8Vec2::ZERO.checked_sub_unsigned(U8Vec2::ONE),
             Some(I8Vec2::NEG_ONE)
@@ -2005,12 +1999,8 @@ mod i16vec2 {
         );
     });
 
-
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            I16Vec2::MAX.checked_add_unsigned(U16Vec2::ONE),
-            None
-        );
+        assert_eq!(I16Vec2::MAX.checked_add_unsigned(U16Vec2::ONE), None);
         assert_eq!(
             I16Vec2::NEG_ONE.checked_add_unsigned(U16Vec2::ONE),
             Some(I16Vec2::ZERO)
@@ -2018,10 +2008,7 @@ mod i16vec2 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            I16Vec2::MIN.checked_sub_unsigned(U16Vec2::ONE),
-            None
-        );
+        assert_eq!(I16Vec2::MIN.checked_sub_unsigned(U16Vec2::ONE), None);
         assert_eq!(
             I16Vec2::ZERO.checked_sub_unsigned(U16Vec2::ONE),
             Some(I16Vec2::NEG_ONE)
@@ -2310,10 +2297,7 @@ mod ivec2 {
     });
 
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            IVec2::MAX.checked_add_unsigned(UVec2::ONE),
-            None
-        );
+        assert_eq!(IVec2::MAX.checked_add_unsigned(UVec2::ONE), None);
         assert_eq!(
             IVec2::NEG_ONE.checked_add_unsigned(UVec2::ONE),
             Some(IVec2::ZERO)
@@ -2321,10 +2305,7 @@ mod ivec2 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            IVec2::MIN.checked_sub_unsigned(UVec2::ONE),
-            None
-        );
+        assert_eq!(IVec2::MIN.checked_sub_unsigned(UVec2::ONE), None);
         assert_eq!(
             IVec2::ZERO.checked_sub_unsigned(UVec2::ONE),
             Some(IVec2::NEG_ONE)
@@ -2541,10 +2522,7 @@ mod i64vec2 {
     });
 
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            I64Vec2::MAX.checked_add_unsigned(U64Vec2::ONE),
-            None
-        );
+        assert_eq!(I64Vec2::MAX.checked_add_unsigned(U64Vec2::ONE), None);
         assert_eq!(
             I64Vec2::NEG_ONE.checked_add_unsigned(U64Vec2::ONE),
             Some(I64Vec2::ZERO)
@@ -2552,10 +2530,7 @@ mod i64vec2 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            I64Vec2::MIN.checked_sub_unsigned(U64Vec2::ONE),
-            None
-        );
+        assert_eq!(I64Vec2::MIN.checked_sub_unsigned(U64Vec2::ONE), None);
         assert_eq!(
             I64Vec2::ZERO.checked_sub_unsigned(U64Vec2::ONE),
             Some(I64Vec2::NEG_ONE)

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -735,6 +735,43 @@ macro_rules! impl_vec2_signed_integer_tests {
             assert_eq!((-$vec3::ONE).signum(), -$vec3::ONE);
         });
 
+        glam_test!(test_checked_add, {
+            assert_eq!($vec3::MAX.checked_add($vec3::ONE), None);
+            assert_eq!($vec3::MAX.checked_add($vec3::X), None);
+            assert_eq!($vec3::MAX.checked_add($vec3::Y), None);
+            assert_eq!($vec3::MAX.checked_add($vec3::ZERO), Some($vec3::MAX));
+        });
+
+        glam_test!(test_checked_sub, {
+            assert_eq!($vec3::MIN.checked_sub($vec3::ONE), None);
+            assert_eq!($vec3::MIN.checked_sub($vec3::X), None);
+            assert_eq!($vec3::MIN.checked_sub($vec3::Y), None);
+            assert_eq!($vec3::MIN.checked_sub($vec3::ZERO), Some($vec3::MIN));
+        });
+
+        glam_test!(test_checked_mul, {
+            assert_eq!($vec3::MIN.checked_mul($vec3::MIN), None);
+            assert_eq!($vec3::MAX.checked_mul($vec3::MIN), None);
+            assert_eq!($vec3::MIN.checked_mul($vec3::MAX), None);
+            assert_eq!($vec3::MAX.checked_mul($vec3::MAX), None);
+            assert_eq!($vec3::ZERO.checked_mul($vec3::MIN), Some($vec3::ZERO));
+            assert_eq!($vec3::MAX.checked_mul($vec3::ZERO), Some($vec3::ZERO));
+            assert_eq!($vec3::MIN.checked_mul($vec3::ONE), Some($vec3::MIN));
+            assert_eq!($vec3::MAX.checked_mul($vec3::ONE), Some($vec3::MAX));
+            assert_eq!($vec3::ZERO.checked_mul($vec3::ZERO), Some($vec3::ZERO));
+            assert_eq!($vec3::ONE.checked_mul($vec3::ONE), Some($vec3::ONE));
+        });
+
+        glam_test!(test_checked_div, {
+            assert_eq!($vec3::MIN.checked_div($vec3::ZERO), None);
+            assert_eq!($vec3::MAX.checked_div($vec3::ZERO), None);
+            assert_eq!($vec3::MAX.checked_div($vec3::X), None);
+            assert_eq!($vec3::MAX.checked_div($vec3::Y), None);
+            assert_eq!($vec3::ZERO.checked_div($vec3::ONE), Some($vec3::ZERO));
+            assert_eq!($vec3::MIN.checked_div($vec3::ONE), Some($vec3::MIN));
+            assert_eq!($vec3::MAX.checked_div($vec3::ONE), Some($vec3::MAX));
+        });
+
         glam_test!(test_manhattan_distance, {
             assert_eq!($vec2::new(5, 2).manhattan_distance($vec2::new(23, 16)), 32);
             assert_eq!($vec2::new(30, 11).manhattan_distance($vec2::new(30, 11)), 0);
@@ -777,6 +814,36 @@ macro_rules! impl_vec2_signed_integer_tests {
 macro_rules! impl_vec2_unsigned_integer_tests {
     ($t:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
         impl_vec2_tests!($t, $new, $vec2, $vec3, $mask, $masknew);
+
+        glam_test!(test_checked_add, {
+            assert_eq!($vec2::MAX.checked_add($vec2::ONE), None);
+            assert_eq!($vec2::MAX.checked_add($vec2::X), None);
+            assert_eq!($vec2::MAX.checked_add($vec2::Y), None);
+            assert_eq!($vec2::MAX.checked_add($vec2::ZERO), Some($vec2::MAX));
+        });
+
+        glam_test!(test_checked_sub, {
+            assert_eq!($vec2::ZERO.checked_sub($vec2::ONE), None);
+            assert_eq!($vec2::ZERO.checked_sub($vec2::X), None);
+            assert_eq!($vec2::ZERO.checked_sub($vec2::Y), None);
+            assert_eq!($vec2::ZERO.checked_sub($vec2::ZERO), Some($vec2::MIN));
+        });
+
+        glam_test!(test_checked_mul, {
+            assert_eq!($vec2::MAX.checked_mul($vec2::MAX), None);
+            assert_eq!($vec2::MAX.checked_mul($vec2::ZERO), Some($vec2::ZERO));
+            assert_eq!($vec2::MAX.checked_mul($vec2::ONE), Some($vec2::MAX));
+            assert_eq!($vec2::ZERO.checked_mul($vec2::ZERO), Some($vec2::ZERO));
+            assert_eq!($vec2::ONE.checked_mul($vec2::ONE), Some($vec2::ONE));
+        });
+
+        glam_test!(test_checked_div, {
+            assert_eq!($vec2::MAX.checked_div($vec2::ZERO), None);
+            assert_eq!($vec2::MAX.checked_div($vec2::X), None);
+            assert_eq!($vec2::MAX.checked_div($vec2::Y), None);
+            assert_eq!($vec2::ZERO.checked_div($vec2::ONE), Some($vec2::ZERO));
+            assert_eq!($vec2::MAX.checked_div($vec2::ONE), Some($vec2::MAX));
+        });
 
         glam_test!(test_manhattan_distance, {
             assert_eq!($vec2::new(5, 2).manhattan_distance($vec2::new(23, 16)), 32);
@@ -1613,6 +1680,28 @@ mod i8vec2 {
         );
     });
 
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            I8Vec2::MAX.checked_add_unsigned(U8Vec2::ONE),
+            None
+        );
+        assert_eq!(
+            I8Vec2::NEG_ONE.checked_add_unsigned(U8Vec2::ONE),
+            Some(I8Vec2::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            I8Vec2::MIN.checked_sub_unsigned(U8Vec2::ONE),
+            None
+        );
+        assert_eq!(
+            I8Vec2::ZERO.checked_sub_unsigned(U8Vec2::ONE),
+            Some(I8Vec2::NEG_ONE)
+        );
+    });
+
     glam_test!(test_wrapping_add_unsigned, {
         assert_eq!(
             I8Vec2::new(i8::MAX, i8::MAX).wrapping_add_unsigned(U8Vec2::new(1, 1)),
@@ -1916,6 +2005,29 @@ mod i16vec2 {
         );
     });
 
+
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            I16Vec2::MAX.checked_add_unsigned(U16Vec2::ONE),
+            None
+        );
+        assert_eq!(
+            I16Vec2::NEG_ONE.checked_add_unsigned(U16Vec2::ONE),
+            Some(I16Vec2::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            I16Vec2::MIN.checked_sub_unsigned(U16Vec2::ONE),
+            None
+        );
+        assert_eq!(
+            I16Vec2::ZERO.checked_sub_unsigned(U16Vec2::ONE),
+            Some(I16Vec2::NEG_ONE)
+        );
+    });
+
     glam_test!(test_wrapping_add_unsigned, {
         assert_eq!(
             I16Vec2::new(i16::MAX, i16::MAX).wrapping_add_unsigned(U16Vec2::new(1, 1)),
@@ -2197,6 +2309,28 @@ mod ivec2 {
         );
     });
 
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            IVec2::MAX.checked_add_unsigned(UVec2::ONE),
+            None
+        );
+        assert_eq!(
+            IVec2::NEG_ONE.checked_add_unsigned(UVec2::ONE),
+            Some(IVec2::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            IVec2::MIN.checked_sub_unsigned(UVec2::ONE),
+            None
+        );
+        assert_eq!(
+            IVec2::ZERO.checked_sub_unsigned(UVec2::ONE),
+            Some(IVec2::NEG_ONE)
+        );
+    });
+
     glam_test!(test_wrapping_add_unsigned, {
         assert_eq!(
             IVec2::new(i32::MAX, i32::MAX).wrapping_add_unsigned(UVec2::new(1, 1)),
@@ -2404,6 +2538,28 @@ mod i64vec2 {
         );
         assert!(I64Vec2::try_from(U64Vec2::new(u64::MAX, 2)).is_err());
         assert!(I64Vec2::try_from(U64Vec2::new(1, u64::MAX)).is_err());
+    });
+
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            I64Vec2::MAX.checked_add_unsigned(U64Vec2::ONE),
+            None
+        );
+        assert_eq!(
+            I64Vec2::NEG_ONE.checked_add_unsigned(U64Vec2::ONE),
+            Some(I64Vec2::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            I64Vec2::MIN.checked_sub_unsigned(U64Vec2::ONE),
+            None
+        );
+        assert_eq!(
+            I64Vec2::ZERO.checked_sub_unsigned(U64Vec2::ONE),
+            Some(I64Vec2::NEG_ONE)
+        );
     });
 
     glam_test!(test_wrapping_add_unsigned, {

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -850,6 +850,46 @@ macro_rules! impl_vec3_signed_integer_tests {
             assert_eq!((-$vec3::ONE).signum(), -$vec3::ONE);
         });
 
+        glam_test!(test_checked_add, {
+            assert_eq!($vec3::MAX.checked_add($vec3::ONE), None);
+            assert_eq!($vec3::MAX.checked_add($vec3::X), None);
+            assert_eq!($vec3::MAX.checked_add($vec3::Y), None);
+            assert_eq!($vec3::MAX.checked_add($vec3::Z), None);
+            assert_eq!($vec3::MAX.checked_add($vec3::ZERO), Some($vec3::MAX));
+        });
+
+        glam_test!(test_checked_sub, {
+            assert_eq!($vec3::MIN.checked_sub($vec3::ONE), None);
+            assert_eq!($vec3::MIN.checked_sub($vec3::X), None);
+            assert_eq!($vec3::MIN.checked_sub($vec3::Y), None);
+            assert_eq!($vec3::MIN.checked_sub($vec3::Z), None);
+            assert_eq!($vec3::MIN.checked_sub($vec3::ZERO), Some($vec3::MIN));
+        });
+
+        glam_test!(test_checked_mul, {
+            assert_eq!($vec3::MIN.checked_mul($vec3::MIN), None);
+            assert_eq!($vec3::MAX.checked_mul($vec3::MIN), None);
+            assert_eq!($vec3::MIN.checked_mul($vec3::MAX), None);
+            assert_eq!($vec3::MAX.checked_mul($vec3::MAX), None);
+            assert_eq!($vec3::ZERO.checked_mul($vec3::MIN), Some($vec3::ZERO));
+            assert_eq!($vec3::MAX.checked_mul($vec3::ZERO), Some($vec3::ZERO));
+            assert_eq!($vec3::MIN.checked_mul($vec3::ONE), Some($vec3::MIN));
+            assert_eq!($vec3::MAX.checked_mul($vec3::ONE), Some($vec3::MAX));
+            assert_eq!($vec3::ZERO.checked_mul($vec3::ZERO), Some($vec3::ZERO));
+            assert_eq!($vec3::ONE.checked_mul($vec3::ONE), Some($vec3::ONE));
+        });
+
+        glam_test!(test_checked_div, {
+            assert_eq!($vec3::MIN.checked_div($vec3::ZERO), None);
+            assert_eq!($vec3::MAX.checked_div($vec3::ZERO), None);
+            assert_eq!($vec3::MAX.checked_div($vec3::X), None);
+            assert_eq!($vec3::MAX.checked_div($vec3::Y), None);
+            assert_eq!($vec3::MAX.checked_div($vec3::Z), None);
+            assert_eq!($vec3::ZERO.checked_div($vec3::ONE), Some($vec3::ZERO));
+            assert_eq!($vec3::MIN.checked_div($vec3::ONE), Some($vec3::MIN));
+            assert_eq!($vec3::MAX.checked_div($vec3::ONE), Some($vec3::MAX));
+        });
+
         glam_test!(test_manhattan_distance, {
             assert_eq!(
                 $vec3::new(3, 27, 98).manhattan_distance($vec3::new(20, 65, 97)),
@@ -907,6 +947,39 @@ macro_rules! impl_vec3_signed_integer_tests {
 macro_rules! impl_vec3_unsigned_integer_tests {
     ($t:ident, $new:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
         impl_vec3_tests!($t, $new, $vec3, $mask, $masknew);
+
+        glam_test!(test_checked_add, {
+            assert_eq!($vec3::MAX.checked_add($vec3::ONE), None);
+            assert_eq!($vec3::MAX.checked_add($vec3::X), None);
+            assert_eq!($vec3::MAX.checked_add($vec3::Y), None);
+            assert_eq!($vec3::MAX.checked_add($vec3::Z), None);
+            assert_eq!($vec3::MAX.checked_add($vec3::ZERO), Some($vec3::MAX));
+        });
+
+        glam_test!(test_checked_sub, {
+            assert_eq!($vec3::ZERO.checked_sub($vec3::ONE), None);
+            assert_eq!($vec3::ZERO.checked_sub($vec3::X), None);
+            assert_eq!($vec3::ZERO.checked_sub($vec3::Y), None);
+            assert_eq!($vec3::ZERO.checked_sub($vec3::Z), None);
+            assert_eq!($vec3::ZERO.checked_sub($vec3::ZERO), Some($vec3::MIN));
+        });
+
+        glam_test!(test_checked_mul, {
+            assert_eq!($vec3::MAX.checked_mul($vec3::MAX), None);
+            assert_eq!($vec3::MAX.checked_mul($vec3::ZERO), Some($vec3::ZERO));
+            assert_eq!($vec3::MAX.checked_mul($vec3::ONE), Some($vec3::MAX));
+            assert_eq!($vec3::ZERO.checked_mul($vec3::ZERO), Some($vec3::ZERO));
+            assert_eq!($vec3::ONE.checked_mul($vec3::ONE), Some($vec3::ONE));
+        });
+
+        glam_test!(test_checked_div, {
+            assert_eq!($vec3::MAX.checked_div($vec3::ZERO), None);
+            assert_eq!($vec3::MAX.checked_div($vec3::X), None);
+            assert_eq!($vec3::MAX.checked_div($vec3::Y), None);
+            assert_eq!($vec3::MAX.checked_div($vec3::Z), None);
+            assert_eq!($vec3::ZERO.checked_div($vec3::ONE), Some($vec3::ZERO));
+            assert_eq!($vec3::MAX.checked_div($vec3::ONE), Some($vec3::MAX));
+        });
 
         glam_test!(test_manhattan_distance, {
             assert_eq!(
@@ -2026,6 +2099,28 @@ mod i8vec3 {
         );
     });
 
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            I8Vec3::MAX.checked_add_unsigned(U8Vec3::ONE),
+            None
+        );
+        assert_eq!(
+            I8Vec3::NEG_ONE.checked_add_unsigned(U8Vec3::ONE),
+            Some(I8Vec3::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            I8Vec3::MIN.checked_sub_unsigned(U8Vec3::ONE),
+            None
+        );
+        assert_eq!(
+            I8Vec3::ZERO.checked_sub_unsigned(U8Vec3::ONE),
+            Some(I8Vec3::NEG_ONE)
+        );
+    });
+
     glam_test!(test_wrapping_add_unsigned, {
         assert_eq!(
             I8Vec3::new(i8::MAX, i8::MAX, i8::MAX).wrapping_add_unsigned(U8Vec3::new(1, 1, 1)),
@@ -2337,6 +2432,28 @@ mod i16vec3 {
         );
     });
 
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            I16Vec3::MAX.checked_add_unsigned(U16Vec3::ONE),
+            None
+        );
+        assert_eq!(
+            I16Vec3::NEG_ONE.checked_add_unsigned(U16Vec3::ONE),
+            Some(I16Vec3::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            I16Vec3::MIN.checked_sub_unsigned(U16Vec3::ONE),
+            None
+        );
+        assert_eq!(
+            I16Vec3::ZERO.checked_sub_unsigned(U16Vec3::ONE),
+            Some(I16Vec3::NEG_ONE)
+        );
+    });
+
     glam_test!(test_wrapping_add_unsigned, {
         assert_eq!(
             I16Vec3::new(i16::MAX, i16::MAX, i16::MAX).wrapping_add_unsigned(U16Vec3::new(1, 1, 1)),
@@ -2629,6 +2746,28 @@ mod ivec3 {
         );
     });
 
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            IVec3::MAX.checked_add_unsigned(UVec3::ONE),
+            None
+        );
+        assert_eq!(
+            IVec3::NEG_ONE.checked_add_unsigned(UVec3::ONE),
+            Some(IVec3::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            IVec3::MIN.checked_sub_unsigned(UVec3::ONE),
+            None
+        );
+        assert_eq!(
+            IVec3::ZERO.checked_sub_unsigned(UVec3::ONE),
+            Some(IVec3::NEG_ONE)
+        );
+    });
+
     glam_test!(test_wrapping_add_unsigned, {
         assert_eq!(
             IVec3::new(i32::MAX, i32::MAX, i32::MAX).wrapping_add_unsigned(UVec3::new(1, 1, 1)),
@@ -2838,6 +2977,28 @@ mod i64vec3 {
         assert!(I64Vec3::try_from(U64Vec3::new(u64::MAX, 2, 3)).is_err());
         assert!(I64Vec3::try_from(U64Vec3::new(1, u64::MAX, 3)).is_err());
         assert!(I64Vec3::try_from(U64Vec3::new(1, 2, u64::MAX)).is_err());
+    });
+
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            I64Vec3::MAX.checked_add_unsigned(U64Vec3::ONE),
+            None
+        );
+        assert_eq!(
+            I64Vec3::NEG_ONE.checked_add_unsigned(U64Vec3::ONE),
+            Some(I64Vec3::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            I64Vec3::MIN.checked_sub_unsigned(U64Vec3::ONE),
+            None
+        );
+        assert_eq!(
+            I64Vec3::ZERO.checked_sub_unsigned(U64Vec3::ONE),
+            Some(I64Vec3::NEG_ONE)
+        );
     });
 
     glam_test!(test_wrapping_add_unsigned, {

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -2100,10 +2100,7 @@ mod i8vec3 {
     });
 
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            I8Vec3::MAX.checked_add_unsigned(U8Vec3::ONE),
-            None
-        );
+        assert_eq!(I8Vec3::MAX.checked_add_unsigned(U8Vec3::ONE), None);
         assert_eq!(
             I8Vec3::NEG_ONE.checked_add_unsigned(U8Vec3::ONE),
             Some(I8Vec3::ZERO)
@@ -2111,10 +2108,7 @@ mod i8vec3 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            I8Vec3::MIN.checked_sub_unsigned(U8Vec3::ONE),
-            None
-        );
+        assert_eq!(I8Vec3::MIN.checked_sub_unsigned(U8Vec3::ONE), None);
         assert_eq!(
             I8Vec3::ZERO.checked_sub_unsigned(U8Vec3::ONE),
             Some(I8Vec3::NEG_ONE)
@@ -2433,10 +2427,7 @@ mod i16vec3 {
     });
 
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            I16Vec3::MAX.checked_add_unsigned(U16Vec3::ONE),
-            None
-        );
+        assert_eq!(I16Vec3::MAX.checked_add_unsigned(U16Vec3::ONE), None);
         assert_eq!(
             I16Vec3::NEG_ONE.checked_add_unsigned(U16Vec3::ONE),
             Some(I16Vec3::ZERO)
@@ -2444,10 +2435,7 @@ mod i16vec3 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            I16Vec3::MIN.checked_sub_unsigned(U16Vec3::ONE),
-            None
-        );
+        assert_eq!(I16Vec3::MIN.checked_sub_unsigned(U16Vec3::ONE), None);
         assert_eq!(
             I16Vec3::ZERO.checked_sub_unsigned(U16Vec3::ONE),
             Some(I16Vec3::NEG_ONE)
@@ -2747,10 +2735,7 @@ mod ivec3 {
     });
 
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            IVec3::MAX.checked_add_unsigned(UVec3::ONE),
-            None
-        );
+        assert_eq!(IVec3::MAX.checked_add_unsigned(UVec3::ONE), None);
         assert_eq!(
             IVec3::NEG_ONE.checked_add_unsigned(UVec3::ONE),
             Some(IVec3::ZERO)
@@ -2758,10 +2743,7 @@ mod ivec3 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            IVec3::MIN.checked_sub_unsigned(UVec3::ONE),
-            None
-        );
+        assert_eq!(IVec3::MIN.checked_sub_unsigned(UVec3::ONE), None);
         assert_eq!(
             IVec3::ZERO.checked_sub_unsigned(UVec3::ONE),
             Some(IVec3::NEG_ONE)
@@ -2980,10 +2962,7 @@ mod i64vec3 {
     });
 
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            I64Vec3::MAX.checked_add_unsigned(U64Vec3::ONE),
-            None
-        );
+        assert_eq!(I64Vec3::MAX.checked_add_unsigned(U64Vec3::ONE), None);
         assert_eq!(
             I64Vec3::NEG_ONE.checked_add_unsigned(U64Vec3::ONE),
             Some(I64Vec3::ZERO)
@@ -2991,10 +2970,7 @@ mod i64vec3 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            I64Vec3::MIN.checked_sub_unsigned(U64Vec3::ONE),
-            None
-        );
+        assert_eq!(I64Vec3::MIN.checked_sub_unsigned(U64Vec3::ONE), None);
         assert_eq!(
             I64Vec3::ZERO.checked_sub_unsigned(U64Vec3::ONE),
             Some(I64Vec3::NEG_ONE)

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -968,6 +968,49 @@ macro_rules! impl_vec4_signed_integer_tests {
             assert_eq!((-$vec4::ONE).signum(), -$vec4::ONE);
         });
 
+        glam_test!(test_checked_add, {
+            assert_eq!($vec4::MAX.checked_add($vec4::ONE), None);
+            assert_eq!($vec4::MAX.checked_add($vec4::X), None);
+            assert_eq!($vec4::MAX.checked_add($vec4::Y), None);
+            assert_eq!($vec4::MAX.checked_add($vec4::Z), None);
+            assert_eq!($vec4::MAX.checked_add($vec4::W), None);
+            assert_eq!($vec4::MAX.checked_add($vec4::ZERO), Some($vec4::MAX));
+        });
+
+        glam_test!(test_checked_sub, {
+            assert_eq!($vec4::MIN.checked_sub($vec4::ONE), None);
+            assert_eq!($vec4::MIN.checked_sub($vec4::X), None);
+            assert_eq!($vec4::MIN.checked_sub($vec4::Y), None);
+            assert_eq!($vec4::MIN.checked_sub($vec4::Z), None);
+            assert_eq!($vec4::MIN.checked_sub($vec4::W), None);
+            assert_eq!($vec4::MIN.checked_sub($vec4::ZERO), Some($vec4::MIN));
+        });
+
+        glam_test!(test_checked_mul, {
+            assert_eq!($vec4::MIN.checked_mul($vec4::MIN), None);
+            assert_eq!($vec4::MAX.checked_mul($vec4::MIN), None);
+            assert_eq!($vec4::MIN.checked_mul($vec4::MAX), None);
+            assert_eq!($vec4::MAX.checked_mul($vec4::MAX), None);
+            assert_eq!($vec4::ZERO.checked_mul($vec4::MIN), Some($vec4::ZERO));
+            assert_eq!($vec4::MAX.checked_mul($vec4::ZERO), Some($vec4::ZERO));
+            assert_eq!($vec4::MIN.checked_mul($vec4::ONE), Some($vec4::MIN));
+            assert_eq!($vec4::MAX.checked_mul($vec4::ONE), Some($vec4::MAX));
+            assert_eq!($vec4::ZERO.checked_mul($vec4::ZERO), Some($vec4::ZERO));
+            assert_eq!($vec4::ONE.checked_mul($vec4::ONE), Some($vec4::ONE));
+        });
+
+        glam_test!(test_checked_div, {
+            assert_eq!($vec4::MIN.checked_div($vec4::ZERO), None);
+            assert_eq!($vec4::MAX.checked_div($vec4::ZERO), None);
+            assert_eq!($vec4::MAX.checked_div($vec4::X), None);
+            assert_eq!($vec4::MAX.checked_div($vec4::Y), None);
+            assert_eq!($vec4::MAX.checked_div($vec4::Z), None);
+            assert_eq!($vec4::MAX.checked_div($vec4::W), None);
+            assert_eq!($vec4::ZERO.checked_div($vec4::ONE), Some($vec4::ZERO));
+            assert_eq!($vec4::MIN.checked_div($vec4::ONE), Some($vec4::MIN));
+            assert_eq!($vec4::MAX.checked_div($vec4::ONE), Some($vec4::MAX));
+        });
+
         glam_test!(test_manhattan_distance, {
             assert_eq!(
                 $vec4::new(41, 8, 21, 87).manhattan_distance($vec4::new(49, 48, 28, 40)),
@@ -1024,6 +1067,42 @@ macro_rules! impl_vec4_signed_integer_tests {
 macro_rules! impl_vec4_unsigned_integer_tests {
     ($t:ident, $new:ident, $vec4:ident, $vec3:ident, $vec2:ident, $mask:ident, $masknew:ident) => {
         impl_vec4_tests!($t, $new, $vec4, $vec3, $vec2, $mask, $masknew);
+
+        glam_test!(test_checked_add, {
+            assert_eq!($vec4::MAX.checked_add($vec4::ONE), None);
+            assert_eq!($vec4::MAX.checked_add($vec4::X), None);
+            assert_eq!($vec4::MAX.checked_add($vec4::Y), None);
+            assert_eq!($vec4::MAX.checked_add($vec4::Z), None);
+            assert_eq!($vec4::MAX.checked_add($vec4::W), None);
+            assert_eq!($vec4::MAX.checked_add($vec4::ZERO), Some($vec4::MAX));
+        });
+
+        glam_test!(test_checked_sub, {
+            assert_eq!($vec4::ZERO.checked_sub($vec4::ONE), None);
+            assert_eq!($vec4::ZERO.checked_sub($vec4::X), None);
+            assert_eq!($vec4::ZERO.checked_sub($vec4::Y), None);
+            assert_eq!($vec4::ZERO.checked_sub($vec4::Z), None);
+            assert_eq!($vec4::ZERO.checked_sub($vec4::W), None);
+            assert_eq!($vec4::ZERO.checked_sub($vec4::ZERO), Some($vec4::MIN));
+        });
+
+        glam_test!(test_checked_mul, {
+            assert_eq!($vec4::MAX.checked_mul($vec4::MAX), None);
+            assert_eq!($vec4::MAX.checked_mul($vec4::ZERO), Some($vec4::ZERO));
+            assert_eq!($vec4::MAX.checked_mul($vec4::ONE), Some($vec4::MAX));
+            assert_eq!($vec4::ZERO.checked_mul($vec4::ZERO), Some($vec4::ZERO));
+            assert_eq!($vec4::ONE.checked_mul($vec4::ONE), Some($vec4::ONE));
+        });
+
+        glam_test!(test_checked_div, {
+            assert_eq!($vec4::MAX.checked_div($vec4::ZERO), None);
+            assert_eq!($vec4::MAX.checked_div($vec4::X), None);
+            assert_eq!($vec4::MAX.checked_div($vec4::Y), None);
+            assert_eq!($vec4::MAX.checked_div($vec4::Z), None);
+            assert_eq!($vec4::MAX.checked_div($vec4::W), None);
+            assert_eq!($vec4::ZERO.checked_div($vec4::ONE), Some($vec4::ZERO));
+            assert_eq!($vec4::MAX.checked_div($vec4::ONE), Some($vec4::MAX));
+        });
 
         glam_test!(test_manhattan_distance, {
             assert_eq!(
@@ -2161,7 +2240,7 @@ mod i8vec4 {
         );
     });
 
-    glam_test!(test_wrapping_sub, {
+    glam_test!(test_wrapping_m, {
         assert_eq!(
             I8Vec4::new(i8::MAX, 5, i8::MIN, 0).wrapping_sub(I8Vec4::new(1, 3, i8::MAX, 0)),
             I8Vec4::new(126, 2, 1, 0)
@@ -2207,6 +2286,28 @@ mod i8vec4 {
         assert_eq!(
             I8Vec4::new(i8::MAX, i8::MIN, 0, 0).saturating_div(I8Vec4::new(2, 2, 3, 4)),
             I8Vec4::new(63, -64, 0, 0)
+        );
+    });
+
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            I8Vec4::MAX.checked_add_unsigned(U8Vec4::ONE),
+            None
+        );
+        assert_eq!(
+            I8Vec4::NEG_ONE.checked_add_unsigned(U8Vec4::ONE),
+            Some(I8Vec4::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            I8Vec4::MIN.checked_sub_unsigned(U8Vec4::ONE),
+            None
+        );
+        assert_eq!(
+            I8Vec4::ZERO.checked_sub_unsigned(U8Vec4::ONE),
+            Some(I8Vec4::NEG_ONE)
         );
     });
 
@@ -2556,6 +2657,29 @@ mod i16vec4 {
         );
     });
 
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            I16Vec4::MAX.checked_add_unsigned(U16Vec4::ONE),
+            None
+        );
+        assert_eq!(
+            I16Vec4::NEG_ONE.checked_add_unsigned(U16Vec4::ONE),
+            Some(I16Vec4::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            I16Vec4::MIN.checked_sub_unsigned(U16Vec4::ONE),
+            None
+        );
+        assert_eq!(
+            I16Vec4::ZERO.checked_sub_unsigned(U16Vec4::ONE),
+            Some(I16Vec4::NEG_ONE)
+        );
+    });
+
+
     glam_test!(test_wrapping_add_unsigned, {
         assert_eq!(
             I16Vec4::new(i16::MAX, i16::MAX, i16::MAX, i16::MAX)
@@ -2885,6 +3009,28 @@ mod ivec4 {
         );
     });
 
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            IVec4::MAX.checked_add_unsigned(UVec4::ONE),
+            None
+        );
+        assert_eq!(
+            IVec4::NEG_ONE.checked_add_unsigned(UVec4::ONE),
+            Some(IVec4::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            IVec4::MIN.checked_sub_unsigned(UVec4::ONE),
+            None
+        );
+        assert_eq!(
+            IVec4::ZERO.checked_sub_unsigned(UVec4::ONE),
+            Some(IVec4::NEG_ONE)
+        );
+    });
+
     glam_test!(test_wrapping_add_unsigned, {
         assert_eq!(
             IVec4::new(i32::MAX, i32::MAX, i32::MAX, i32::MAX)
@@ -3136,6 +3282,28 @@ mod i64vec4 {
         assert!(I64Vec4::try_from(U64Vec4::new(1, u64::MAX, 3, 4)).is_err());
         assert!(I64Vec4::try_from(U64Vec4::new(1, 2, u64::MAX, 4)).is_err());
         assert!(I64Vec4::try_from(U64Vec4::new(1, 2, 3, u64::MAX)).is_err());
+    });
+
+    glam_test!(test_checked_add_unsigned, {
+        assert_eq!(
+            I64Vec4::MAX.checked_add_unsigned(U64Vec4::ONE),
+            None
+        );
+        assert_eq!(
+            I64Vec4::NEG_ONE.checked_add_unsigned(U64Vec4::ONE),
+            Some(I64Vec4::ZERO)
+        );
+    });
+
+    glam_test!(test_checked_sub_unsigned, {
+        assert_eq!(
+            I64Vec4::MIN.checked_sub_unsigned(U64Vec4::ONE),
+            None
+        );
+        assert_eq!(
+            I64Vec4::ZERO.checked_sub_unsigned(U64Vec4::ONE),
+            Some(I64Vec4::NEG_ONE)
+        );
     });
 
     glam_test!(test_wrapping_add_unsigned, {

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -2290,10 +2290,7 @@ mod i8vec4 {
     });
 
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            I8Vec4::MAX.checked_add_unsigned(U8Vec4::ONE),
-            None
-        );
+        assert_eq!(I8Vec4::MAX.checked_add_unsigned(U8Vec4::ONE), None);
         assert_eq!(
             I8Vec4::NEG_ONE.checked_add_unsigned(U8Vec4::ONE),
             Some(I8Vec4::ZERO)
@@ -2301,10 +2298,7 @@ mod i8vec4 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            I8Vec4::MIN.checked_sub_unsigned(U8Vec4::ONE),
-            None
-        );
+        assert_eq!(I8Vec4::MIN.checked_sub_unsigned(U8Vec4::ONE), None);
         assert_eq!(
             I8Vec4::ZERO.checked_sub_unsigned(U8Vec4::ONE),
             Some(I8Vec4::NEG_ONE)
@@ -2658,10 +2652,7 @@ mod i16vec4 {
     });
 
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            I16Vec4::MAX.checked_add_unsigned(U16Vec4::ONE),
-            None
-        );
+        assert_eq!(I16Vec4::MAX.checked_add_unsigned(U16Vec4::ONE), None);
         assert_eq!(
             I16Vec4::NEG_ONE.checked_add_unsigned(U16Vec4::ONE),
             Some(I16Vec4::ZERO)
@@ -2669,16 +2660,12 @@ mod i16vec4 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            I16Vec4::MIN.checked_sub_unsigned(U16Vec4::ONE),
-            None
-        );
+        assert_eq!(I16Vec4::MIN.checked_sub_unsigned(U16Vec4::ONE), None);
         assert_eq!(
             I16Vec4::ZERO.checked_sub_unsigned(U16Vec4::ONE),
             Some(I16Vec4::NEG_ONE)
         );
     });
-
 
     glam_test!(test_wrapping_add_unsigned, {
         assert_eq!(
@@ -3010,10 +2997,7 @@ mod ivec4 {
     });
 
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            IVec4::MAX.checked_add_unsigned(UVec4::ONE),
-            None
-        );
+        assert_eq!(IVec4::MAX.checked_add_unsigned(UVec4::ONE), None);
         assert_eq!(
             IVec4::NEG_ONE.checked_add_unsigned(UVec4::ONE),
             Some(IVec4::ZERO)
@@ -3021,10 +3005,7 @@ mod ivec4 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            IVec4::MIN.checked_sub_unsigned(UVec4::ONE),
-            None
-        );
+        assert_eq!(IVec4::MIN.checked_sub_unsigned(UVec4::ONE), None);
         assert_eq!(
             IVec4::ZERO.checked_sub_unsigned(UVec4::ONE),
             Some(IVec4::NEG_ONE)
@@ -3285,10 +3266,7 @@ mod i64vec4 {
     });
 
     glam_test!(test_checked_add_unsigned, {
-        assert_eq!(
-            I64Vec4::MAX.checked_add_unsigned(U64Vec4::ONE),
-            None
-        );
+        assert_eq!(I64Vec4::MAX.checked_add_unsigned(U64Vec4::ONE), None);
         assert_eq!(
             I64Vec4::NEG_ONE.checked_add_unsigned(U64Vec4::ONE),
             Some(I64Vec4::ZERO)
@@ -3296,10 +3274,7 @@ mod i64vec4 {
     });
 
     glam_test!(test_checked_sub_unsigned, {
-        assert_eq!(
-            I64Vec4::MIN.checked_sub_unsigned(U64Vec4::ONE),
-            None
-        );
+        assert_eq!(I64Vec4::MIN.checked_sub_unsigned(U64Vec4::ONE), None);
         assert_eq!(
             I64Vec4::ZERO.checked_sub_unsigned(U64Vec4::ONE),
             Some(I64Vec4::NEG_ONE)

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -2240,7 +2240,7 @@ mod i8vec4 {
         );
     });
 
-    glam_test!(test_wrapping_m, {
+    glam_test!(test_wrapping_sub, {
         assert_eq!(
             I8Vec4::new(i8::MAX, 5, i8::MIN, 0).wrapping_sub(I8Vec4::new(1, 3, i8::MAX, 0)),
             I8Vec4::new(126, 2, 1, 0)


### PR DESCRIPTION
For integer vectors, it's often useful to check if an operation would overflow. This helps with writing more robust code without having to do checks with `if` statements. Since we already have `wrapping_` and `saturating_` from Rust standard library, I figured having `checked_` would be welcome as well.

The test code is sadly very repetitive, as it's not generated from a template. Hopefully I got it all copy-pasted correctly!