### PR TITLE
Refactor `with_` and add new `set_` method for vector types

### DIFF
--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -627,14 +627,16 @@ impl {{ self_t }} {
     /// Returns a new version of this {{ dim }}D vector with the given `{{ c }}` value.
     #[inline]
     #[must_use]
-    pub fn with_{{ c }}(&self, {{ c }}: {{ scalar_t }}) -> Self {
-        {% if self_t == "Vec3A" or self_t == "Vec4" %}
-            let mut new = *self;
-            new.{{ c }} = {{ c }};
-            new
-        {% else %}
-            Self { {{ c }}, ..*self }
-        {% endif %}
+    pub fn with_{{ c }}(self, {{ c }}: {{ scalar_t }}) -> Self {
+        Self::new(
+            {% for i in range(start = 0, end = dim) %}
+                {% if c == components[i] %}
+                    {{ c }},
+                {% else %}
+                    self.{{ components[i] }},
+                {% endif %}
+            {% endfor %}
+        )
     }
 {% endfor %}
 

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -616,7 +616,7 @@ impl {{ self_t }} {
 
 
 {% for c in components %}
-    /// Sets the {{ c }} component of this {{ dim }}D vector
+    /// Sets the `{{ c }}` component of this {{ dim }}D vector
     #[inline]
     #[must_use]
     pub fn set_{{ c }}(mut self, {{ c }}: {{ scalar_t }}) -> Self {
@@ -624,7 +624,7 @@ impl {{ self_t }} {
         self
     }
 
-    /// Returns a new version of this {{ dim }}D vector with the given {{ c }} value.
+    /// Returns a new version of this {{ dim }}D vector with the given `{{ c }}` value.
     #[inline]
     #[must_use]
     pub fn with_{{ c }}(&self, {{ c }}: {{ scalar_t }}) -> Self {

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -616,12 +616,25 @@ impl {{ self_t }} {
 
 
 {% for c in components %}
-    /// Creates a {{ dim }}D vector from `self` with the given value of `{{ c }}`.
+    /// Sets the {{ c }} component of this {{ dim }}D vector
     #[inline]
     #[must_use]
-    pub fn with_{{ c }}(mut self, {{ c }}: {{ scalar_t }}) -> Self {
+    pub fn set_{{ c }}(mut self, {{ c }}: {{ scalar_t }}) -> Self {
         self.{{ c }} = {{ c }};
         self
+    }
+
+    /// Returns a new version of this {{ dim }}D vector with the given {{ c }} value.
+    #[inline]
+    #[must_use]
+    pub fn with_{{ c }}(&self, {{ c }}: {{ scalar_t }}) -> Self {
+        {% if self_t == "Vec3A" or self_t == "Vec4" %}
+            let mut new = *self;
+            new.{{ c }} = {{ c }};
+            new
+        {% else %}
+            Self { {{ c }}, ..*self }
+        {% endif %}
     }
 {% endfor %}
 

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -619,9 +619,9 @@ impl {{ self_t }} {
     /// Sets the `{{ c }}` component of this {{ dim }}D vector
     #[inline]
     #[must_use]
-    pub fn set_{{ c }}(mut self, {{ c }}: {{ scalar_t }}) -> Self {
+    pub fn set_{{ c }}(&mut self, {{ c }}: {{ scalar_t }}) -> &mut Self {
         self.{{ c }} = {{ c }};
-        self
+        *self
     }
 
     /// Returns a new version of this {{ dim }}D vector with the given `{{ c }}` value.

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -621,7 +621,7 @@ impl {{ self_t }} {
     #[must_use]
     pub fn set_{{ c }}(&mut self, {{ c }}: {{ scalar_t }}) -> &mut Self {
         self.{{ c }} = {{ c }};
-        *self
+        self
     }
 
     /// Returns a new version of this {{ dim }}D vector with the given `{{ c }}` value.

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -172,28 +172,55 @@ impl Vec3A {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        let mut new = *self;
+        new.x = x;
+        new
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f32) -> Self {
+    pub fn with_y(&self, y: f32) -> Self {
+        let mut new = *self;
+        new.y = y;
+        new
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f32) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: f32) -> Self {
+        let mut new = *self;
+        new.z = z;
+        new
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -172,7 +172,7 @@ impl Vec3A {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -180,7 +180,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
@@ -189,7 +189,7 @@ impl Vec3A {
         new
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -197,7 +197,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
@@ -206,7 +206,7 @@ impl Vec3A {
         new
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f32) -> Self {
@@ -214,7 +214,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -175,9 +175,9 @@ impl Vec3A {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -192,9 +192,9 @@ impl Vec3A {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -209,9 +209,9 @@ impl Vec3A {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -184,9 +184,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        let mut new = *self;
-        new.x = x;
-        new
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -201,9 +199,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        let mut new = *self;
-        new.y = y;
-        new
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -218,9 +214,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
-        let mut new = *self;
-        new.z = z;
-        new
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -175,9 +175,9 @@ impl Vec3A {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -192,9 +192,9 @@ impl Vec3A {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -209,9 +209,9 @@ impl Vec3A {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -160,36 +160,72 @@ impl Vec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        let mut new = *self;
+        new.x = x;
+        new
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f32) -> Self {
+    pub fn with_y(&self, y: f32) -> Self {
+        let mut new = *self;
+        new.y = y;
+        new
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f32) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: f32) -> Self {
+    pub fn with_z(&self, z: f32) -> Self {
+        let mut new = *self;
+        new.z = z;
+        new
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: f32) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: f32) -> Self {
+        let mut new = *self;
+        new.w = w;
+        new
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -172,9 +172,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        let mut new = *self;
-        new.x = x;
-        new
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -189,9 +187,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        let mut new = *self;
-        new.y = y;
-        new
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -206,9 +202,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
-        let mut new = *self;
-        new.z = z;
-        new
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -223,9 +217,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f32) -> Self {
-        let mut new = *self;
-        new.w = w;
-        new
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -160,7 +160,7 @@ impl Vec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -168,7 +168,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
@@ -177,7 +177,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -185,7 +185,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
@@ -194,7 +194,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f32) -> Self {
@@ -202,7 +202,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
@@ -211,7 +211,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: f32) -> Self {
@@ -219,7 +219,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f32) -> Self {

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -163,9 +163,9 @@ impl Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -180,9 +180,9 @@ impl Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -197,9 +197,9 @@ impl Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -214,9 +214,9 @@ impl Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: f32) -> Self {
+    pub fn set_w(&mut self, w: f32) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -163,9 +163,9 @@ impl Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -180,9 +180,9 @@ impl Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -197,9 +197,9 @@ impl Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -214,9 +214,9 @@ impl Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: f32) -> Self {
+    pub fn set_w(&mut self, w: f32) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -180,9 +180,9 @@ impl Vec3A {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -197,9 +197,9 @@ impl Vec3A {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -214,9 +214,9 @@ impl Vec3A {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -177,28 +177,55 @@ impl Vec3A {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        let mut new = *self;
+        new.x = x;
+        new
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f32) -> Self {
+    pub fn with_y(&self, y: f32) -> Self {
+        let mut new = *self;
+        new.y = y;
+        new
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f32) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: f32) -> Self {
+        let mut new = *self;
+        new.z = z;
+        new
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -180,9 +180,9 @@ impl Vec3A {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -197,9 +197,9 @@ impl Vec3A {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -214,9 +214,9 @@ impl Vec3A {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -189,9 +189,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        let mut new = *self;
-        new.x = x;
-        new
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -206,9 +204,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        let mut new = *self;
-        new.y = y;
-        new
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -223,9 +219,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
-        let mut new = *self;
-        new.z = z;
-        new
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -177,7 +177,7 @@ impl Vec3A {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -185,7 +185,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
@@ -194,7 +194,7 @@ impl Vec3A {
         new
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -202,7 +202,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
@@ -211,7 +211,7 @@ impl Vec3A {
         new
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f32) -> Self {
@@ -219,7 +219,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -171,9 +171,9 @@ impl Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -188,9 +188,9 @@ impl Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -205,9 +205,9 @@ impl Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -222,9 +222,9 @@ impl Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: f32) -> Self {
+    pub fn set_w(&mut self, w: f32) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -180,9 +180,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        let mut new = *self;
-        new.x = x;
-        new
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -197,9 +195,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        let mut new = *self;
-        new.y = y;
-        new
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -214,9 +210,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
-        let mut new = *self;
-        new.z = z;
-        new
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -231,9 +225,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f32) -> Self {
-        let mut new = *self;
-        new.w = w;
-        new
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -168,36 +168,72 @@ impl Vec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        let mut new = *self;
+        new.x = x;
+        new
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f32) -> Self {
+    pub fn with_y(&self, y: f32) -> Self {
+        let mut new = *self;
+        new.y = y;
+        new
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f32) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: f32) -> Self {
+    pub fn with_z(&self, z: f32) -> Self {
+        let mut new = *self;
+        new.z = z;
+        new
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: f32) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: f32) -> Self {
+        let mut new = *self;
+        new.w = w;
+        new
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -168,7 +168,7 @@ impl Vec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -176,7 +176,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
@@ -185,7 +185,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -193,7 +193,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
@@ -202,7 +202,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f32) -> Self {
@@ -210,7 +210,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
@@ -219,7 +219,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: f32) -> Self {
@@ -227,7 +227,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f32) -> Self {

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -171,9 +171,9 @@ impl Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -188,9 +188,9 @@ impl Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -205,9 +205,9 @@ impl Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -222,9 +222,9 @@ impl Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: f32) -> Self {
+    pub fn set_w(&mut self, w: f32) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -186,9 +186,9 @@ impl Vec3A {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -203,9 +203,9 @@ impl Vec3A {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -220,9 +220,9 @@ impl Vec3A {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -186,9 +186,9 @@ impl Vec3A {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -203,9 +203,9 @@ impl Vec3A {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -220,9 +220,9 @@ impl Vec3A {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -183,28 +183,55 @@ impl Vec3A {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        let mut new = *self;
+        new.x = x;
+        new
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f32) -> Self {
+    pub fn with_y(&self, y: f32) -> Self {
+        let mut new = *self;
+        new.y = y;
+        new
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f32) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: f32) -> Self {
+        let mut new = *self;
+        new.z = z;
+        new
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -183,7 +183,7 @@ impl Vec3A {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -191,7 +191,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
@@ -200,7 +200,7 @@ impl Vec3A {
         new
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -208,7 +208,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
@@ -217,7 +217,7 @@ impl Vec3A {
         new
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f32) -> Self {
@@ -225,7 +225,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -195,9 +195,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        let mut new = *self;
-        new.x = x;
-        new
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -212,9 +210,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        let mut new = *self;
-        new.y = y;
-        new
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -229,9 +225,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
-        let mut new = *self;
-        new.z = z;
-        new
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -184,36 +184,72 @@ impl Vec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        let mut new = *self;
+        new.x = x;
+        new
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f32) -> Self {
+    pub fn with_y(&self, y: f32) -> Self {
+        let mut new = *self;
+        new.y = y;
+        new
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f32) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: f32) -> Self {
+    pub fn with_z(&self, z: f32) -> Self {
+        let mut new = *self;
+        new.z = z;
+        new
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: f32) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: f32) -> Self {
+        let mut new = *self;
+        new.w = w;
+        new
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -187,9 +187,9 @@ impl Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -204,9 +204,9 @@ impl Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -221,9 +221,9 @@ impl Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -238,9 +238,9 @@ impl Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: f32) -> Self {
+    pub fn set_w(&mut self, w: f32) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -196,9 +196,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        let mut new = *self;
-        new.x = x;
-        new
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -213,9 +211,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        let mut new = *self;
-        new.y = y;
-        new
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -230,9 +226,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
-        let mut new = *self;
-        new.z = z;
-        new
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -247,9 +241,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f32) -> Self {
-        let mut new = *self;
-        new.w = w;
-        new
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -184,7 +184,7 @@ impl Vec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -192,7 +192,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
@@ -201,7 +201,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -209,7 +209,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
@@ -218,7 +218,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f32) -> Self {
@@ -226,7 +226,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
@@ -235,7 +235,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: f32) -> Self {
@@ -243,7 +243,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f32) -> Self {

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -187,9 +187,9 @@ impl Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -204,9 +204,9 @@ impl Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -221,9 +221,9 @@ impl Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -238,9 +238,9 @@ impl Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: f32) -> Self {
+    pub fn set_w(&mut self, w: f32) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -188,9 +188,9 @@ impl Vec3A {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -205,9 +205,9 @@ impl Vec3A {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -222,9 +222,9 @@ impl Vec3A {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -185,28 +185,55 @@ impl Vec3A {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        let mut new = *self;
+        new.x = x;
+        new
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f32) -> Self {
+    pub fn with_y(&self, y: f32) -> Self {
+        let mut new = *self;
+        new.y = y;
+        new
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f32) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: f32) -> Self {
+        let mut new = *self;
+        new.z = z;
+        new
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -185,7 +185,7 @@ impl Vec3A {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -193,7 +193,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
@@ -202,7 +202,7 @@ impl Vec3A {
         new
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -210,7 +210,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
@@ -219,7 +219,7 @@ impl Vec3A {
         new
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f32) -> Self {
@@ -227,7 +227,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -197,9 +197,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        let mut new = *self;
-        new.x = x;
-        new
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -214,9 +212,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        let mut new = *self;
-        new.y = y;
-        new
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -231,9 +227,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
-        let mut new = *self;
-        new.z = z;
-        new
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -188,9 +188,9 @@ impl Vec3A {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -205,9 +205,9 @@ impl Vec3A {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -222,9 +222,9 @@ impl Vec3A {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -179,9 +179,9 @@ impl Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -196,9 +196,9 @@ impl Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -213,9 +213,9 @@ impl Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -230,9 +230,9 @@ impl Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: f32) -> Self {
+    pub fn set_w(&mut self, w: f32) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -188,9 +188,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        let mut new = *self;
-        new.x = x;
-        new
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -205,9 +203,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        let mut new = *self;
-        new.y = y;
-        new
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -222,9 +218,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
-        let mut new = *self;
-        new.z = z;
-        new
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -239,9 +233,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f32) -> Self {
-        let mut new = *self;
-        new.w = w;
-        new
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -176,7 +176,7 @@ impl Vec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -184,7 +184,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
@@ -193,7 +193,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -201,7 +201,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
@@ -210,7 +210,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f32) -> Self {
@@ -218,7 +218,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
@@ -227,7 +227,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: f32) -> Self {
@@ -235,7 +235,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f32) -> Self {

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -179,9 +179,9 @@ impl Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -196,9 +196,9 @@ impl Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -213,9 +213,9 @@ impl Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -230,9 +230,9 @@ impl Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: f32) -> Self {
+    pub fn set_w(&mut self, w: f32) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -176,36 +176,72 @@ impl Vec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        let mut new = *self;
+        new.x = x;
+        new
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f32) -> Self {
+    pub fn with_y(&self, y: f32) -> Self {
+        let mut new = *self;
+        new.y = y;
+        new
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f32) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: f32) -> Self {
+    pub fn with_z(&self, z: f32) -> Self {
+        let mut new = *self;
+        new.z = z;
+        new
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: f32) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: f32) -> Self {
+        let mut new = *self;
+        new.w = w;
+        new
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -144,7 +144,7 @@ impl Vec2 {
         Vec3::new(self.x, self.y, z)
     }
 
-    /// Sets the x component of this 2D vector
+    /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -152,14 +152,14 @@ impl Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given x value.
+    /// Returns a new version of this 2D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 2D vector
+    /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -167,7 +167,7 @@ impl Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given y value.
+    /// Returns a new version of this 2D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -147,9 +147,9 @@ impl Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -162,9 +162,9 @@ impl Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -156,7 +156,7 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y)
     }
 
     /// Sets the `y` component of this 2D vector
@@ -171,7 +171,7 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -147,9 +147,9 @@ impl Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -162,9 +162,9 @@ impl Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -144,20 +144,34 @@ impl Vec2 {
         Vec3::new(self.x, self.y, z)
     }
 
-    /// Creates a 2D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 2D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 2D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 2D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
+    }
+
+    /// Returns a new version of this 2D vector with the given y value.
+    #[inline]
+    #[must_use]
+    pub fn with_y(&self, y: f32) -> Self {
+        Self { y, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -173,7 +173,7 @@ impl Vec3 {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -181,14 +181,14 @@ impl Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -196,14 +196,14 @@ impl Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f32) -> Self {
@@ -211,7 +211,7 @@ impl Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -173,28 +173,49 @@ impl Vec3 {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f32) -> Self {
+    pub fn with_y(&self, y: f32) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f32) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: f32) -> Self {
+        Self { z, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -185,7 +185,7 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -200,7 +200,7 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -215,7 +215,7 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -176,9 +176,9 @@ impl Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -191,9 +191,9 @@ impl Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -206,9 +206,9 @@ impl Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -176,9 +176,9 @@ impl Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -191,9 +191,9 @@ impl Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -206,9 +206,9 @@ impl Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -171,7 +171,7 @@ impl Vec3A {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -179,7 +179,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
@@ -188,7 +188,7 @@ impl Vec3A {
         new
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -196,7 +196,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
@@ -205,7 +205,7 @@ impl Vec3A {
         new
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f32) -> Self {
@@ -213,7 +213,7 @@ impl Vec3A {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -174,9 +174,9 @@ impl Vec3A {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -191,9 +191,9 @@ impl Vec3A {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -208,9 +208,9 @@ impl Vec3A {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -183,9 +183,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        let mut new = *self;
-        new.x = x;
-        new
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -200,9 +198,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        let mut new = *self;
-        new.y = y;
-        new
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -217,9 +213,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
-        let mut new = *self;
-        new.z = z;
-        new
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -174,9 +174,9 @@ impl Vec3A {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -191,9 +191,9 @@ impl Vec3A {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -208,9 +208,9 @@ impl Vec3A {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -171,28 +171,55 @@ impl Vec3A {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        let mut new = *self;
+        new.x = x;
+        new
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f32) -> Self {
+    pub fn with_y(&self, y: f32) -> Self {
+        let mut new = *self;
+        new.y = y;
+        new
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f32) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: f32) -> Self {
+        let mut new = *self;
+        new.z = z;
+        new
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -162,9 +162,9 @@ impl Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -179,9 +179,9 @@ impl Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -196,9 +196,9 @@ impl Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -213,9 +213,9 @@ impl Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: f32) -> Self {
+    pub fn set_w(&mut self, w: f32) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -162,9 +162,9 @@ impl Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f32) -> Self {
+    pub fn set_x(&mut self, x: f32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -179,9 +179,9 @@ impl Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f32) -> Self {
+    pub fn set_y(&mut self, y: f32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -196,9 +196,9 @@ impl Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f32) -> Self {
+    pub fn set_z(&mut self, z: f32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -213,9 +213,9 @@ impl Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: f32) -> Self {
+    pub fn set_w(&mut self, w: f32) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -171,9 +171,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
-        let mut new = *self;
-        new.x = x;
-        new
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -188,9 +186,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
-        let mut new = *self;
-        new.y = y;
-        new
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -205,9 +201,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
-        let mut new = *self;
-        new.z = z;
-        new
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -222,9 +216,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f32) -> Self {
-        let mut new = *self;
-        new.w = w;
-        new
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -159,7 +159,7 @@ impl Vec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f32) -> Self {
@@ -167,7 +167,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f32) -> Self {
@@ -176,7 +176,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f32) -> Self {
@@ -184,7 +184,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f32) -> Self {
@@ -193,7 +193,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f32) -> Self {
@@ -201,7 +201,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f32) -> Self {
@@ -210,7 +210,7 @@ impl Vec4 {
         new
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: f32) -> Self {
@@ -218,7 +218,7 @@ impl Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f32) -> Self {

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -159,36 +159,72 @@ impl Vec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f32) -> Self {
+    pub fn set_x(mut self, x: f32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f32) -> Self {
+    pub fn with_x(&self, x: f32) -> Self {
+        let mut new = *self;
+        new.x = x;
+        new
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f32) -> Self {
+    pub fn with_y(&self, y: f32) -> Self {
+        let mut new = *self;
+        new.y = y;
+        new
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f32) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: f32) -> Self {
+    pub fn with_z(&self, z: f32) -> Self {
+        let mut new = *self;
+        new.z = z;
+        new
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: f32) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: f32) -> Self {
+        let mut new = *self;
+        new.w = w;
+        new
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -144,7 +144,7 @@ impl DVec2 {
         DVec3::new(self.x, self.y, z)
     }
 
-    /// Sets the x component of this 2D vector
+    /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f64) -> Self {
@@ -152,14 +152,14 @@ impl DVec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given x value.
+    /// Returns a new version of this 2D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f64) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 2D vector
+    /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f64) -> Self {
@@ -167,7 +167,7 @@ impl DVec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given y value.
+    /// Returns a new version of this 2D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f64) -> Self {

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -156,7 +156,7 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f64) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y)
     }
 
     /// Sets the `y` component of this 2D vector
@@ -171,7 +171,7 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f64) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -144,20 +144,34 @@ impl DVec2 {
         DVec3::new(self.x, self.y, z)
     }
 
-    /// Creates a 2D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f64) -> Self {
+    pub fn set_x(mut self, x: f64) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 2D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 2D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f64) -> Self {
+    pub fn with_x(&self, x: f64) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 2D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f64) -> Self {
         self.y = y;
         self
+    }
+
+    /// Returns a new version of this 2D vector with the given y value.
+    #[inline]
+    #[must_use]
+    pub fn with_y(&self, y: f64) -> Self {
+        Self { y, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -147,9 +147,9 @@ impl DVec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f64) -> Self {
+    pub fn set_x(&mut self, x: f64) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -162,9 +162,9 @@ impl DVec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f64) -> Self {
+    pub fn set_y(&mut self, y: f64) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -147,9 +147,9 @@ impl DVec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f64) -> Self {
+    pub fn set_x(&mut self, x: f64) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -162,9 +162,9 @@ impl DVec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f64) -> Self {
+    pub fn set_y(&mut self, y: f64) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -176,9 +176,9 @@ impl DVec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f64) -> Self {
+    pub fn set_x(&mut self, x: f64) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -191,9 +191,9 @@ impl DVec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f64) -> Self {
+    pub fn set_y(&mut self, y: f64) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -206,9 +206,9 @@ impl DVec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f64) -> Self {
+    pub fn set_z(&mut self, z: f64) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -176,9 +176,9 @@ impl DVec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f64) -> Self {
+    pub fn set_x(&mut self, x: f64) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -191,9 +191,9 @@ impl DVec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f64) -> Self {
+    pub fn set_y(&mut self, y: f64) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -206,9 +206,9 @@ impl DVec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f64) -> Self {
+    pub fn set_z(&mut self, z: f64) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -173,7 +173,7 @@ impl DVec3 {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f64) -> Self {
@@ -181,14 +181,14 @@ impl DVec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f64) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f64) -> Self {
@@ -196,14 +196,14 @@ impl DVec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f64) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f64) -> Self {
@@ -211,7 +211,7 @@ impl DVec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f64) -> Self {

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -173,28 +173,49 @@ impl DVec3 {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f64) -> Self {
+    pub fn set_x(mut self, x: f64) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f64) -> Self {
+    pub fn with_x(&self, x: f64) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f64) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f64) -> Self {
+    pub fn with_y(&self, y: f64) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f64) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: f64) -> Self {
+        Self { z, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -185,7 +185,7 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f64) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -200,7 +200,7 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f64) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -215,7 +215,7 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f64) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -176,9 +176,9 @@ impl DVec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: f64) -> Self {
+    pub fn set_x(&mut self, x: f64) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -191,9 +191,9 @@ impl DVec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: f64) -> Self {
+    pub fn set_y(&mut self, y: f64) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -206,9 +206,9 @@ impl DVec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: f64) -> Self {
+    pub fn set_z(&mut self, z: f64) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -221,9 +221,9 @@ impl DVec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: f64) -> Self {
+    pub fn set_w(&mut self, w: f64) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -173,36 +173,64 @@ impl DVec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: f64) -> Self {
+    pub fn set_x(mut self, x: f64) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: f64) -> Self {
+    pub fn with_x(&self, x: f64) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: f64) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: f64) -> Self {
+    pub fn with_y(&self, y: f64) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: f64) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: f64) -> Self {
+    pub fn with_z(&self, z: f64) -> Self {
+        Self { z, ..*self }
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: f64) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: f64) -> Self {
+        Self { w, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -173,7 +173,7 @@ impl DVec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: f64) -> Self {
@@ -181,14 +181,14 @@ impl DVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f64) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: f64) -> Self {
@@ -196,14 +196,14 @@ impl DVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f64) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: f64) -> Self {
@@ -211,14 +211,14 @@ impl DVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f64) -> Self {
         Self { z, ..*self }
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: f64) -> Self {
@@ -226,7 +226,7 @@ impl DVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f64) -> Self {

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -185,7 +185,7 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: f64) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -200,7 +200,7 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: f64) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -215,7 +215,7 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: f64) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -230,7 +230,7 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: f64) -> Self {
-        Self { w, ..*self }
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -176,9 +176,9 @@ impl DVec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: f64) -> Self {
+    pub fn set_x(&mut self, x: f64) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -191,9 +191,9 @@ impl DVec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: f64) -> Self {
+    pub fn set_y(&mut self, y: f64) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -206,9 +206,9 @@ impl DVec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: f64) -> Self {
+    pub fn set_z(&mut self, z: f64) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -221,9 +221,9 @@ impl DVec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: f64) -> Self {
+    pub fn set_w(&mut self, w: f64) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -139,9 +139,9 @@ impl I16Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i16) -> Self {
+    pub fn set_x(&mut self, x: i16) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -154,9 +154,9 @@ impl I16Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i16) -> Self {
+    pub fn set_y(&mut self, y: i16) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -148,7 +148,7 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i16) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y)
     }
 
     /// Sets the `y` component of this 2D vector
@@ -163,7 +163,7 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i16) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -136,20 +136,34 @@ impl I16Vec2 {
         I16Vec3::new(self.x, self.y, z)
     }
 
-    /// Creates a 2D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i16) -> Self {
+    pub fn set_x(mut self, x: i16) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 2D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 2D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i16) -> Self {
+    pub fn with_x(&self, x: i16) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 2D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i16) -> Self {
         self.y = y;
         self
+    }
+
+    /// Returns a new version of this 2D vector with the given y value.
+    #[inline]
+    #[must_use]
+    pub fn with_y(&self, y: i16) -> Self {
+        Self { y, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -139,9 +139,9 @@ impl I16Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i16) -> Self {
+    pub fn set_x(&mut self, x: i16) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -154,9 +154,9 @@ impl I16Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i16) -> Self {
+    pub fn set_y(&mut self, y: i16) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -136,7 +136,7 @@ impl I16Vec2 {
         I16Vec3::new(self.x, self.y, z)
     }
 
-    /// Sets the x component of this 2D vector
+    /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i16) -> Self {
@@ -144,14 +144,14 @@ impl I16Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given x value.
+    /// Returns a new version of this 2D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i16) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 2D vector
+    /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i16) -> Self {
@@ -159,7 +159,7 @@ impl I16Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given y value.
+    /// Returns a new version of this 2D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i16) -> Self {

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -170,9 +170,9 @@ impl I16Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i16) -> Self {
+    pub fn set_x(&mut self, x: i16) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -185,9 +185,9 @@ impl I16Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i16) -> Self {
+    pub fn set_y(&mut self, y: i16) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -200,9 +200,9 @@ impl I16Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: i16) -> Self {
+    pub fn set_z(&mut self, z: i16) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -179,7 +179,7 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i16) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -194,7 +194,7 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i16) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -209,7 +209,7 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i16) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -170,9 +170,9 @@ impl I16Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i16) -> Self {
+    pub fn set_x(&mut self, x: i16) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -185,9 +185,9 @@ impl I16Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i16) -> Self {
+    pub fn set_y(&mut self, y: i16) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -200,9 +200,9 @@ impl I16Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: i16) -> Self {
+    pub fn set_z(&mut self, z: i16) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -167,7 +167,7 @@ impl I16Vec3 {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i16) -> Self {
@@ -175,14 +175,14 @@ impl I16Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i16) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i16) -> Self {
@@ -190,14 +190,14 @@ impl I16Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i16) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: i16) -> Self {
@@ -205,7 +205,7 @@ impl I16Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i16) -> Self {

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -167,28 +167,49 @@ impl I16Vec3 {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i16) -> Self {
+    pub fn set_x(mut self, x: i16) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i16) -> Self {
+    pub fn with_x(&self, x: i16) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i16) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: i16) -> Self {
+    pub fn with_y(&self, y: i16) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: i16) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: i16) -> Self {
+        Self { z, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -165,7 +165,7 @@ impl I16Vec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i16) -> Self {
@@ -173,14 +173,14 @@ impl I16Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i16) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i16) -> Self {
@@ -188,14 +188,14 @@ impl I16Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i16) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: i16) -> Self {
@@ -203,14 +203,14 @@ impl I16Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i16) -> Self {
         Self { z, ..*self }
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: i16) -> Self {
@@ -218,7 +218,7 @@ impl I16Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: i16) -> Self {

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -177,7 +177,7 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i16) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -192,7 +192,7 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i16) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -207,7 +207,7 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i16) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -222,7 +222,7 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: i16) -> Self {
-        Self { w, ..*self }
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -168,9 +168,9 @@ impl I16Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i16) -> Self {
+    pub fn set_x(&mut self, x: i16) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -183,9 +183,9 @@ impl I16Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i16) -> Self {
+    pub fn set_y(&mut self, y: i16) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -198,9 +198,9 @@ impl I16Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: i16) -> Self {
+    pub fn set_z(&mut self, z: i16) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -213,9 +213,9 @@ impl I16Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: i16) -> Self {
+    pub fn set_w(&mut self, w: i16) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -168,9 +168,9 @@ impl I16Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i16) -> Self {
+    pub fn set_x(&mut self, x: i16) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -183,9 +183,9 @@ impl I16Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i16) -> Self {
+    pub fn set_y(&mut self, y: i16) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -198,9 +198,9 @@ impl I16Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: i16) -> Self {
+    pub fn set_z(&mut self, z: i16) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -213,9 +213,9 @@ impl I16Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: i16) -> Self {
+    pub fn set_w(&mut self, w: i16) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -165,36 +165,64 @@ impl I16Vec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i16) -> Self {
+    pub fn set_x(mut self, x: i16) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i16) -> Self {
+    pub fn with_x(&self, x: i16) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i16) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: i16) -> Self {
+    pub fn with_y(&self, y: i16) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: i16) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: i16) -> Self {
+    pub fn with_z(&self, z: i16) -> Self {
+        Self { z, ..*self }
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: i16) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: i16) -> Self {
+        Self { w, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -136,7 +136,7 @@ impl IVec2 {
         IVec3::new(self.x, self.y, z)
     }
 
-    /// Sets the x component of this 2D vector
+    /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i32) -> Self {
@@ -144,14 +144,14 @@ impl IVec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given x value.
+    /// Returns a new version of this 2D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i32) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 2D vector
+    /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i32) -> Self {
@@ -159,7 +159,7 @@ impl IVec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given y value.
+    /// Returns a new version of this 2D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i32) -> Self {

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -148,7 +148,7 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i32) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y)
     }
 
     /// Sets the `y` component of this 2D vector
@@ -163,7 +163,7 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i32) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -139,9 +139,9 @@ impl IVec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i32) -> Self {
+    pub fn set_x(&mut self, x: i32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -154,9 +154,9 @@ impl IVec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i32) -> Self {
+    pub fn set_y(&mut self, y: i32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -139,9 +139,9 @@ impl IVec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i32) -> Self {
+    pub fn set_x(&mut self, x: i32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -154,9 +154,9 @@ impl IVec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i32) -> Self {
+    pub fn set_y(&mut self, y: i32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -136,20 +136,34 @@ impl IVec2 {
         IVec3::new(self.x, self.y, z)
     }
 
-    /// Creates a 2D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i32) -> Self {
+    pub fn set_x(mut self, x: i32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 2D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 2D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i32) -> Self {
+    pub fn with_x(&self, x: i32) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 2D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i32) -> Self {
         self.y = y;
         self
+    }
+
+    /// Returns a new version of this 2D vector with the given y value.
+    #[inline]
+    #[must_use]
+    pub fn with_y(&self, y: i32) -> Self {
+        Self { y, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -179,7 +179,7 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i32) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -194,7 +194,7 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i32) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -209,7 +209,7 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i32) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -167,7 +167,7 @@ impl IVec3 {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i32) -> Self {
@@ -175,14 +175,14 @@ impl IVec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i32) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i32) -> Self {
@@ -190,14 +190,14 @@ impl IVec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i32) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: i32) -> Self {
@@ -205,7 +205,7 @@ impl IVec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i32) -> Self {

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -167,28 +167,49 @@ impl IVec3 {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i32) -> Self {
+    pub fn set_x(mut self, x: i32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i32) -> Self {
+    pub fn with_x(&self, x: i32) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: i32) -> Self {
+    pub fn with_y(&self, y: i32) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: i32) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: i32) -> Self {
+        Self { z, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -170,9 +170,9 @@ impl IVec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i32) -> Self {
+    pub fn set_x(&mut self, x: i32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -185,9 +185,9 @@ impl IVec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i32) -> Self {
+    pub fn set_y(&mut self, y: i32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -200,9 +200,9 @@ impl IVec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: i32) -> Self {
+    pub fn set_z(&mut self, z: i32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -170,9 +170,9 @@ impl IVec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i32) -> Self {
+    pub fn set_x(&mut self, x: i32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -185,9 +185,9 @@ impl IVec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i32) -> Self {
+    pub fn set_y(&mut self, y: i32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -200,9 +200,9 @@ impl IVec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: i32) -> Self {
+    pub fn set_z(&mut self, z: i32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -165,36 +165,64 @@ impl IVec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i32) -> Self {
+    pub fn set_x(mut self, x: i32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i32) -> Self {
+    pub fn with_x(&self, x: i32) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: i32) -> Self {
+    pub fn with_y(&self, y: i32) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: i32) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: i32) -> Self {
+    pub fn with_z(&self, z: i32) -> Self {
+        Self { z, ..*self }
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: i32) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: i32) -> Self {
+        Self { w, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -168,9 +168,9 @@ impl IVec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i32) -> Self {
+    pub fn set_x(&mut self, x: i32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -183,9 +183,9 @@ impl IVec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i32) -> Self {
+    pub fn set_y(&mut self, y: i32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -198,9 +198,9 @@ impl IVec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: i32) -> Self {
+    pub fn set_z(&mut self, z: i32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -213,9 +213,9 @@ impl IVec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: i32) -> Self {
+    pub fn set_w(&mut self, w: i32) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -165,7 +165,7 @@ impl IVec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i32) -> Self {
@@ -173,14 +173,14 @@ impl IVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i32) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i32) -> Self {
@@ -188,14 +188,14 @@ impl IVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i32) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: i32) -> Self {
@@ -203,14 +203,14 @@ impl IVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i32) -> Self {
         Self { z, ..*self }
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: i32) -> Self {
@@ -218,7 +218,7 @@ impl IVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: i32) -> Self {

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -177,7 +177,7 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i32) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -192,7 +192,7 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i32) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -207,7 +207,7 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i32) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -222,7 +222,7 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: i32) -> Self {
-        Self { w, ..*self }
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -168,9 +168,9 @@ impl IVec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i32) -> Self {
+    pub fn set_x(&mut self, x: i32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -183,9 +183,9 @@ impl IVec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i32) -> Self {
+    pub fn set_y(&mut self, y: i32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -198,9 +198,9 @@ impl IVec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: i32) -> Self {
+    pub fn set_z(&mut self, z: i32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -213,9 +213,9 @@ impl IVec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: i32) -> Self {
+    pub fn set_w(&mut self, w: i32) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -139,9 +139,9 @@ impl I64Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i64) -> Self {
+    pub fn set_x(&mut self, x: i64) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -154,9 +154,9 @@ impl I64Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i64) -> Self {
+    pub fn set_y(&mut self, y: i64) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -136,20 +136,34 @@ impl I64Vec2 {
         I64Vec3::new(self.x, self.y, z)
     }
 
-    /// Creates a 2D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i64) -> Self {
+    pub fn set_x(mut self, x: i64) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 2D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 2D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i64) -> Self {
+    pub fn with_x(&self, x: i64) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 2D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i64) -> Self {
         self.y = y;
         self
+    }
+
+    /// Returns a new version of this 2D vector with the given y value.
+    #[inline]
+    #[must_use]
+    pub fn with_y(&self, y: i64) -> Self {
+        Self { y, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -139,9 +139,9 @@ impl I64Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i64) -> Self {
+    pub fn set_x(&mut self, x: i64) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -154,9 +154,9 @@ impl I64Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i64) -> Self {
+    pub fn set_y(&mut self, y: i64) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -136,7 +136,7 @@ impl I64Vec2 {
         I64Vec3::new(self.x, self.y, z)
     }
 
-    /// Sets the x component of this 2D vector
+    /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i64) -> Self {
@@ -144,14 +144,14 @@ impl I64Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given x value.
+    /// Returns a new version of this 2D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i64) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 2D vector
+    /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i64) -> Self {
@@ -159,7 +159,7 @@ impl I64Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given y value.
+    /// Returns a new version of this 2D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i64) -> Self {

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -148,7 +148,7 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i64) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y)
     }
 
     /// Sets the `y` component of this 2D vector
@@ -163,7 +163,7 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i64) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -170,9 +170,9 @@ impl I64Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i64) -> Self {
+    pub fn set_x(&mut self, x: i64) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -185,9 +185,9 @@ impl I64Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i64) -> Self {
+    pub fn set_y(&mut self, y: i64) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -200,9 +200,9 @@ impl I64Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: i64) -> Self {
+    pub fn set_z(&mut self, z: i64) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -170,9 +170,9 @@ impl I64Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i64) -> Self {
+    pub fn set_x(&mut self, x: i64) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -185,9 +185,9 @@ impl I64Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i64) -> Self {
+    pub fn set_y(&mut self, y: i64) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -200,9 +200,9 @@ impl I64Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: i64) -> Self {
+    pub fn set_z(&mut self, z: i64) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -167,28 +167,49 @@ impl I64Vec3 {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i64) -> Self {
+    pub fn set_x(mut self, x: i64) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i64) -> Self {
+    pub fn with_x(&self, x: i64) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i64) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: i64) -> Self {
+    pub fn with_y(&self, y: i64) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: i64) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: i64) -> Self {
+        Self { z, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -179,7 +179,7 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i64) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -194,7 +194,7 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i64) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -209,7 +209,7 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i64) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -167,7 +167,7 @@ impl I64Vec3 {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i64) -> Self {
@@ -175,14 +175,14 @@ impl I64Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i64) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i64) -> Self {
@@ -190,14 +190,14 @@ impl I64Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i64) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: i64) -> Self {
@@ -205,7 +205,7 @@ impl I64Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i64) -> Self {

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -168,9 +168,9 @@ impl I64Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i64) -> Self {
+    pub fn set_x(&mut self, x: i64) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -183,9 +183,9 @@ impl I64Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i64) -> Self {
+    pub fn set_y(&mut self, y: i64) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -198,9 +198,9 @@ impl I64Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: i64) -> Self {
+    pub fn set_z(&mut self, z: i64) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -213,9 +213,9 @@ impl I64Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: i64) -> Self {
+    pub fn set_w(&mut self, w: i64) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -165,36 +165,64 @@ impl I64Vec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i64) -> Self {
+    pub fn set_x(mut self, x: i64) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i64) -> Self {
+    pub fn with_x(&self, x: i64) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i64) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: i64) -> Self {
+    pub fn with_y(&self, y: i64) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: i64) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: i64) -> Self {
+    pub fn with_z(&self, z: i64) -> Self {
+        Self { z, ..*self }
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: i64) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: i64) -> Self {
+        Self { w, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -168,9 +168,9 @@ impl I64Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i64) -> Self {
+    pub fn set_x(&mut self, x: i64) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -183,9 +183,9 @@ impl I64Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i64) -> Self {
+    pub fn set_y(&mut self, y: i64) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -198,9 +198,9 @@ impl I64Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: i64) -> Self {
+    pub fn set_z(&mut self, z: i64) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -213,9 +213,9 @@ impl I64Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: i64) -> Self {
+    pub fn set_w(&mut self, w: i64) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -165,7 +165,7 @@ impl I64Vec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i64) -> Self {
@@ -173,14 +173,14 @@ impl I64Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i64) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i64) -> Self {
@@ -188,14 +188,14 @@ impl I64Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i64) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: i64) -> Self {
@@ -203,14 +203,14 @@ impl I64Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i64) -> Self {
         Self { z, ..*self }
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: i64) -> Self {
@@ -218,7 +218,7 @@ impl I64Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: i64) -> Self {

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -177,7 +177,7 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i64) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -192,7 +192,7 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i64) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -207,7 +207,7 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i64) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -222,7 +222,7 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: i64) -> Self {
-        Self { w, ..*self }
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -136,7 +136,7 @@ impl I8Vec2 {
         I8Vec3::new(self.x, self.y, z)
     }
 
-    /// Sets the x component of this 2D vector
+    /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i8) -> Self {
@@ -144,14 +144,14 @@ impl I8Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given x value.
+    /// Returns a new version of this 2D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i8) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 2D vector
+    /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i8) -> Self {
@@ -159,7 +159,7 @@ impl I8Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given y value.
+    /// Returns a new version of this 2D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i8) -> Self {

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -148,7 +148,7 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i8) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y)
     }
 
     /// Sets the `y` component of this 2D vector
@@ -163,7 +163,7 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i8) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -139,9 +139,9 @@ impl I8Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i8) -> Self {
+    pub fn set_x(&mut self, x: i8) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -154,9 +154,9 @@ impl I8Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i8) -> Self {
+    pub fn set_y(&mut self, y: i8) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -136,20 +136,34 @@ impl I8Vec2 {
         I8Vec3::new(self.x, self.y, z)
     }
 
-    /// Creates a 2D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i8) -> Self {
+    pub fn set_x(mut self, x: i8) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 2D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 2D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i8) -> Self {
+    pub fn with_x(&self, x: i8) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 2D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i8) -> Self {
         self.y = y;
         self
+    }
+
+    /// Returns a new version of this 2D vector with the given y value.
+    #[inline]
+    #[must_use]
+    pub fn with_y(&self, y: i8) -> Self {
+        Self { y, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -139,9 +139,9 @@ impl I8Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i8) -> Self {
+    pub fn set_x(&mut self, x: i8) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -154,9 +154,9 @@ impl I8Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i8) -> Self {
+    pub fn set_y(&mut self, y: i8) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -167,28 +167,49 @@ impl I8Vec3 {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i8) -> Self {
+    pub fn set_x(mut self, x: i8) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i8) -> Self {
+    pub fn with_x(&self, x: i8) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i8) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: i8) -> Self {
+    pub fn with_y(&self, y: i8) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: i8) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: i8) -> Self {
+        Self { z, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -170,9 +170,9 @@ impl I8Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i8) -> Self {
+    pub fn set_x(&mut self, x: i8) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -185,9 +185,9 @@ impl I8Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i8) -> Self {
+    pub fn set_y(&mut self, y: i8) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -200,9 +200,9 @@ impl I8Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: i8) -> Self {
+    pub fn set_z(&mut self, z: i8) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -179,7 +179,7 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i8) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -194,7 +194,7 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i8) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -209,7 +209,7 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i8) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -167,7 +167,7 @@ impl I8Vec3 {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i8) -> Self {
@@ -175,14 +175,14 @@ impl I8Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i8) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i8) -> Self {
@@ -190,14 +190,14 @@ impl I8Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i8) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: i8) -> Self {
@@ -205,7 +205,7 @@ impl I8Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i8) -> Self {

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -170,9 +170,9 @@ impl I8Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i8) -> Self {
+    pub fn set_x(&mut self, x: i8) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -185,9 +185,9 @@ impl I8Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i8) -> Self {
+    pub fn set_y(&mut self, y: i8) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -200,9 +200,9 @@ impl I8Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: i8) -> Self {
+    pub fn set_z(&mut self, z: i8) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -177,7 +177,7 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i8) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -192,7 +192,7 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i8) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -207,7 +207,7 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i8) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -222,7 +222,7 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: i8) -> Self {
-        Self { w, ..*self }
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -168,9 +168,9 @@ impl I8Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: i8) -> Self {
+    pub fn set_x(&mut self, x: i8) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -183,9 +183,9 @@ impl I8Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: i8) -> Self {
+    pub fn set_y(&mut self, y: i8) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -198,9 +198,9 @@ impl I8Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: i8) -> Self {
+    pub fn set_z(&mut self, z: i8) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -213,9 +213,9 @@ impl I8Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: i8) -> Self {
+    pub fn set_w(&mut self, w: i8) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -168,9 +168,9 @@ impl I8Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: i8) -> Self {
+    pub fn set_x(&mut self, x: i8) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -183,9 +183,9 @@ impl I8Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: i8) -> Self {
+    pub fn set_y(&mut self, y: i8) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -198,9 +198,9 @@ impl I8Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: i8) -> Self {
+    pub fn set_z(&mut self, z: i8) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -213,9 +213,9 @@ impl I8Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: i8) -> Self {
+    pub fn set_w(&mut self, w: i8) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -165,7 +165,7 @@ impl I8Vec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: i8) -> Self {
@@ -173,14 +173,14 @@ impl I8Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: i8) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: i8) -> Self {
@@ -188,14 +188,14 @@ impl I8Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: i8) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: i8) -> Self {
@@ -203,14 +203,14 @@ impl I8Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: i8) -> Self {
         Self { z, ..*self }
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: i8) -> Self {
@@ -218,7 +218,7 @@ impl I8Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: i8) -> Self {

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -165,36 +165,64 @@ impl I8Vec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: i8) -> Self {
+    pub fn set_x(mut self, x: i8) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: i8) -> Self {
+    pub fn with_x(&self, x: i8) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: i8) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: i8) -> Self {
+    pub fn with_y(&self, y: i8) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: i8) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: i8) -> Self {
+    pub fn with_z(&self, z: i8) -> Self {
+        Self { z, ..*self }
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: i8) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: i8) -> Self {
+        Self { w, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -139,7 +139,7 @@ impl U16Vec2 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u16) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y)
     }
 
     /// Sets the `y` component of this 2D vector
@@ -154,7 +154,7 @@ impl U16Vec2 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u16) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -127,20 +127,34 @@ impl U16Vec2 {
         U16Vec3::new(self.x, self.y, z)
     }
 
-    /// Creates a 2D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u16) -> Self {
+    pub fn set_x(mut self, x: u16) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 2D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 2D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u16) -> Self {
+    pub fn with_x(&self, x: u16) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 2D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u16) -> Self {
         self.y = y;
         self
+    }
+
+    /// Returns a new version of this 2D vector with the given y value.
+    #[inline]
+    #[must_use]
+    pub fn with_y(&self, y: u16) -> Self {
+        Self { y, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -130,9 +130,9 @@ impl U16Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u16) -> Self {
+    pub fn set_x(&mut self, x: u16) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -145,9 +145,9 @@ impl U16Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u16) -> Self {
+    pub fn set_y(&mut self, y: u16) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -130,9 +130,9 @@ impl U16Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u16) -> Self {
+    pub fn set_x(&mut self, x: u16) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -145,9 +145,9 @@ impl U16Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u16) -> Self {
+    pub fn set_y(&mut self, y: u16) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -127,7 +127,7 @@ impl U16Vec2 {
         U16Vec3::new(self.x, self.y, z)
     }
 
-    /// Sets the x component of this 2D vector
+    /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u16) -> Self {
@@ -135,14 +135,14 @@ impl U16Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given x value.
+    /// Returns a new version of this 2D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u16) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 2D vector
+    /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u16) -> Self {
@@ -150,7 +150,7 @@ impl U16Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given y value.
+    /// Returns a new version of this 2D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u16) -> Self {

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -155,28 +155,49 @@ impl U16Vec3 {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u16) -> Self {
+    pub fn set_x(mut self, x: u16) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u16) -> Self {
+    pub fn with_x(&self, x: u16) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u16) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: u16) -> Self {
+    pub fn with_y(&self, y: u16) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: u16) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: u16) -> Self {
+        Self { z, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -155,7 +155,7 @@ impl U16Vec3 {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u16) -> Self {
@@ -163,14 +163,14 @@ impl U16Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u16) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u16) -> Self {
@@ -178,14 +178,14 @@ impl U16Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u16) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: u16) -> Self {
@@ -193,7 +193,7 @@ impl U16Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u16) -> Self {

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -158,9 +158,9 @@ impl U16Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u16) -> Self {
+    pub fn set_x(&mut self, x: u16) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -173,9 +173,9 @@ impl U16Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u16) -> Self {
+    pub fn set_y(&mut self, y: u16) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -188,9 +188,9 @@ impl U16Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: u16) -> Self {
+    pub fn set_z(&mut self, z: u16) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -167,7 +167,7 @@ impl U16Vec3 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u16) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -182,7 +182,7 @@ impl U16Vec3 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u16) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -197,7 +197,7 @@ impl U16Vec3 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u16) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -158,9 +158,9 @@ impl U16Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u16) -> Self {
+    pub fn set_x(&mut self, x: u16) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -173,9 +173,9 @@ impl U16Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u16) -> Self {
+    pub fn set_y(&mut self, y: u16) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -188,9 +188,9 @@ impl U16Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: u16) -> Self {
+    pub fn set_z(&mut self, z: u16) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -150,7 +150,7 @@ impl U16Vec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u16) -> Self {
@@ -158,14 +158,14 @@ impl U16Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u16) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u16) -> Self {
@@ -173,14 +173,14 @@ impl U16Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u16) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: u16) -> Self {
@@ -188,14 +188,14 @@ impl U16Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u16) -> Self {
         Self { z, ..*self }
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: u16) -> Self {
@@ -203,7 +203,7 @@ impl U16Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: u16) -> Self {

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -162,7 +162,7 @@ impl U16Vec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u16) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -177,7 +177,7 @@ impl U16Vec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u16) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -192,7 +192,7 @@ impl U16Vec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u16) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -207,7 +207,7 @@ impl U16Vec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: u16) -> Self {
-        Self { w, ..*self }
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -153,9 +153,9 @@ impl U16Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u16) -> Self {
+    pub fn set_x(&mut self, x: u16) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -168,9 +168,9 @@ impl U16Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u16) -> Self {
+    pub fn set_y(&mut self, y: u16) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -183,9 +183,9 @@ impl U16Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: u16) -> Self {
+    pub fn set_z(&mut self, z: u16) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -198,9 +198,9 @@ impl U16Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: u16) -> Self {
+    pub fn set_w(&mut self, w: u16) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -153,9 +153,9 @@ impl U16Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u16) -> Self {
+    pub fn set_x(&mut self, x: u16) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -168,9 +168,9 @@ impl U16Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u16) -> Self {
+    pub fn set_y(&mut self, y: u16) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -183,9 +183,9 @@ impl U16Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: u16) -> Self {
+    pub fn set_z(&mut self, z: u16) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -198,9 +198,9 @@ impl U16Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: u16) -> Self {
+    pub fn set_w(&mut self, w: u16) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -150,36 +150,64 @@ impl U16Vec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u16) -> Self {
+    pub fn set_x(mut self, x: u16) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u16) -> Self {
+    pub fn with_x(&self, x: u16) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u16) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: u16) -> Self {
+    pub fn with_y(&self, y: u16) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: u16) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: u16) -> Self {
+    pub fn with_z(&self, z: u16) -> Self {
+        Self { z, ..*self }
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: u16) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: u16) -> Self {
+        Self { w, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -139,7 +139,7 @@ impl UVec2 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u32) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y)
     }
 
     /// Sets the `y` component of this 2D vector
@@ -154,7 +154,7 @@ impl UVec2 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u32) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -130,9 +130,9 @@ impl UVec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u32) -> Self {
+    pub fn set_x(&mut self, x: u32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -145,9 +145,9 @@ impl UVec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u32) -> Self {
+    pub fn set_y(&mut self, y: u32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -130,9 +130,9 @@ impl UVec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u32) -> Self {
+    pub fn set_x(&mut self, x: u32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -145,9 +145,9 @@ impl UVec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u32) -> Self {
+    pub fn set_y(&mut self, y: u32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -127,7 +127,7 @@ impl UVec2 {
         UVec3::new(self.x, self.y, z)
     }
 
-    /// Sets the x component of this 2D vector
+    /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u32) -> Self {
@@ -135,14 +135,14 @@ impl UVec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given x value.
+    /// Returns a new version of this 2D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u32) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 2D vector
+    /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u32) -> Self {
@@ -150,7 +150,7 @@ impl UVec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given y value.
+    /// Returns a new version of this 2D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u32) -> Self {

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -127,20 +127,34 @@ impl UVec2 {
         UVec3::new(self.x, self.y, z)
     }
 
-    /// Creates a 2D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u32) -> Self {
+    pub fn set_x(mut self, x: u32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 2D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 2D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u32) -> Self {
+    pub fn with_x(&self, x: u32) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 2D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u32) -> Self {
         self.y = y;
         self
+    }
+
+    /// Returns a new version of this 2D vector with the given y value.
+    #[inline]
+    #[must_use]
+    pub fn with_y(&self, y: u32) -> Self {
+        Self { y, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -158,9 +158,9 @@ impl UVec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u32) -> Self {
+    pub fn set_x(&mut self, x: u32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -173,9 +173,9 @@ impl UVec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u32) -> Self {
+    pub fn set_y(&mut self, y: u32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -188,9 +188,9 @@ impl UVec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: u32) -> Self {
+    pub fn set_z(&mut self, z: u32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -155,28 +155,49 @@ impl UVec3 {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u32) -> Self {
+    pub fn set_x(mut self, x: u32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u32) -> Self {
+    pub fn with_x(&self, x: u32) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: u32) -> Self {
+    pub fn with_y(&self, y: u32) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: u32) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: u32) -> Self {
+        Self { z, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -155,7 +155,7 @@ impl UVec3 {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u32) -> Self {
@@ -163,14 +163,14 @@ impl UVec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u32) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u32) -> Self {
@@ -178,14 +178,14 @@ impl UVec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u32) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: u32) -> Self {
@@ -193,7 +193,7 @@ impl UVec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u32) -> Self {

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -167,7 +167,7 @@ impl UVec3 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u32) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -182,7 +182,7 @@ impl UVec3 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u32) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -197,7 +197,7 @@ impl UVec3 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u32) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -158,9 +158,9 @@ impl UVec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u32) -> Self {
+    pub fn set_x(&mut self, x: u32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -173,9 +173,9 @@ impl UVec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u32) -> Self {
+    pub fn set_y(&mut self, y: u32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -188,9 +188,9 @@ impl UVec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: u32) -> Self {
+    pub fn set_z(&mut self, z: u32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -153,9 +153,9 @@ impl UVec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u32) -> Self {
+    pub fn set_x(&mut self, x: u32) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -168,9 +168,9 @@ impl UVec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u32) -> Self {
+    pub fn set_y(&mut self, y: u32) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -183,9 +183,9 @@ impl UVec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: u32) -> Self {
+    pub fn set_z(&mut self, z: u32) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -198,9 +198,9 @@ impl UVec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: u32) -> Self {
+    pub fn set_w(&mut self, w: u32) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -150,7 +150,7 @@ impl UVec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u32) -> Self {
@@ -158,14 +158,14 @@ impl UVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u32) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u32) -> Self {
@@ -173,14 +173,14 @@ impl UVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u32) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: u32) -> Self {
@@ -188,14 +188,14 @@ impl UVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u32) -> Self {
         Self { z, ..*self }
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: u32) -> Self {
@@ -203,7 +203,7 @@ impl UVec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: u32) -> Self {

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -150,36 +150,64 @@ impl UVec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u32) -> Self {
+    pub fn set_x(mut self, x: u32) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u32) -> Self {
+    pub fn with_x(&self, x: u32) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u32) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: u32) -> Self {
+    pub fn with_y(&self, y: u32) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: u32) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: u32) -> Self {
+    pub fn with_z(&self, z: u32) -> Self {
+        Self { z, ..*self }
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: u32) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: u32) -> Self {
+        Self { w, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -153,9 +153,9 @@ impl UVec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u32) -> Self {
+    pub fn set_x(&mut self, x: u32) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -168,9 +168,9 @@ impl UVec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u32) -> Self {
+    pub fn set_y(&mut self, y: u32) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -183,9 +183,9 @@ impl UVec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: u32) -> Self {
+    pub fn set_z(&mut self, z: u32) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -198,9 +198,9 @@ impl UVec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: u32) -> Self {
+    pub fn set_w(&mut self, w: u32) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -162,7 +162,7 @@ impl UVec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u32) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -177,7 +177,7 @@ impl UVec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u32) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -192,7 +192,7 @@ impl UVec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u32) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -207,7 +207,7 @@ impl UVec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: u32) -> Self {
-        Self { w, ..*self }
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -127,20 +127,34 @@ impl U64Vec2 {
         U64Vec3::new(self.x, self.y, z)
     }
 
-    /// Creates a 2D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u64) -> Self {
+    pub fn set_x(mut self, x: u64) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 2D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 2D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u64) -> Self {
+    pub fn with_x(&self, x: u64) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 2D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u64) -> Self {
         self.y = y;
         self
+    }
+
+    /// Returns a new version of this 2D vector with the given y value.
+    #[inline]
+    #[must_use]
+    pub fn with_y(&self, y: u64) -> Self {
+        Self { y, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -130,9 +130,9 @@ impl U64Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u64) -> Self {
+    pub fn set_x(&mut self, x: u64) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -145,9 +145,9 @@ impl U64Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u64) -> Self {
+    pub fn set_y(&mut self, y: u64) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -130,9 +130,9 @@ impl U64Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u64) -> Self {
+    pub fn set_x(&mut self, x: u64) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -145,9 +145,9 @@ impl U64Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u64) -> Self {
+    pub fn set_y(&mut self, y: u64) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -127,7 +127,7 @@ impl U64Vec2 {
         U64Vec3::new(self.x, self.y, z)
     }
 
-    /// Sets the x component of this 2D vector
+    /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u64) -> Self {
@@ -135,14 +135,14 @@ impl U64Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given x value.
+    /// Returns a new version of this 2D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u64) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 2D vector
+    /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u64) -> Self {
@@ -150,7 +150,7 @@ impl U64Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given y value.
+    /// Returns a new version of this 2D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u64) -> Self {

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -139,7 +139,7 @@ impl U64Vec2 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u64) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y)
     }
 
     /// Sets the `y` component of this 2D vector
@@ -154,7 +154,7 @@ impl U64Vec2 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u64) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -155,7 +155,7 @@ impl U64Vec3 {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u64) -> Self {
@@ -163,14 +163,14 @@ impl U64Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u64) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u64) -> Self {
@@ -178,14 +178,14 @@ impl U64Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u64) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: u64) -> Self {
@@ -193,7 +193,7 @@ impl U64Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u64) -> Self {

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -155,28 +155,49 @@ impl U64Vec3 {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u64) -> Self {
+    pub fn set_x(mut self, x: u64) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u64) -> Self {
+    pub fn with_x(&self, x: u64) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u64) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: u64) -> Self {
+    pub fn with_y(&self, y: u64) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: u64) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: u64) -> Self {
+        Self { z, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -158,9 +158,9 @@ impl U64Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u64) -> Self {
+    pub fn set_x(&mut self, x: u64) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -173,9 +173,9 @@ impl U64Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u64) -> Self {
+    pub fn set_y(&mut self, y: u64) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -188,9 +188,9 @@ impl U64Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: u64) -> Self {
+    pub fn set_z(&mut self, z: u64) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -158,9 +158,9 @@ impl U64Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u64) -> Self {
+    pub fn set_x(&mut self, x: u64) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -173,9 +173,9 @@ impl U64Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u64) -> Self {
+    pub fn set_y(&mut self, y: u64) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -188,9 +188,9 @@ impl U64Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: u64) -> Self {
+    pub fn set_z(&mut self, z: u64) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -167,7 +167,7 @@ impl U64Vec3 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u64) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -182,7 +182,7 @@ impl U64Vec3 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u64) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -197,7 +197,7 @@ impl U64Vec3 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u64) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -150,36 +150,64 @@ impl U64Vec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u64) -> Self {
+    pub fn set_x(mut self, x: u64) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u64) -> Self {
+    pub fn with_x(&self, x: u64) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u64) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: u64) -> Self {
+    pub fn with_y(&self, y: u64) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: u64) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: u64) -> Self {
+    pub fn with_z(&self, z: u64) -> Self {
+        Self { z, ..*self }
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: u64) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: u64) -> Self {
+        Self { w, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -153,9 +153,9 @@ impl U64Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u64) -> Self {
+    pub fn set_x(&mut self, x: u64) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -168,9 +168,9 @@ impl U64Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u64) -> Self {
+    pub fn set_y(&mut self, y: u64) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -183,9 +183,9 @@ impl U64Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: u64) -> Self {
+    pub fn set_z(&mut self, z: u64) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -198,9 +198,9 @@ impl U64Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: u64) -> Self {
+    pub fn set_w(&mut self, w: u64) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -150,7 +150,7 @@ impl U64Vec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u64) -> Self {
@@ -158,14 +158,14 @@ impl U64Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u64) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u64) -> Self {
@@ -173,14 +173,14 @@ impl U64Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u64) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: u64) -> Self {
@@ -188,14 +188,14 @@ impl U64Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u64) -> Self {
         Self { z, ..*self }
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: u64) -> Self {
@@ -203,7 +203,7 @@ impl U64Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: u64) -> Self {

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -162,7 +162,7 @@ impl U64Vec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u64) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -177,7 +177,7 @@ impl U64Vec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u64) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -192,7 +192,7 @@ impl U64Vec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u64) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -207,7 +207,7 @@ impl U64Vec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: u64) -> Self {
-        Self { w, ..*self }
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -153,9 +153,9 @@ impl U64Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u64) -> Self {
+    pub fn set_x(&mut self, x: u64) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -168,9 +168,9 @@ impl U64Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u64) -> Self {
+    pub fn set_y(&mut self, y: u64) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -183,9 +183,9 @@ impl U64Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: u64) -> Self {
+    pub fn set_z(&mut self, z: u64) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -198,9 +198,9 @@ impl U64Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: u64) -> Self {
+    pub fn set_w(&mut self, w: u64) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -130,9 +130,9 @@ impl U8Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u8) -> Self {
+    pub fn set_x(&mut self, x: u8) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -145,9 +145,9 @@ impl U8Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u8) -> Self {
+    pub fn set_y(&mut self, y: u8) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -127,20 +127,34 @@ impl U8Vec2 {
         U8Vec3::new(self.x, self.y, z)
     }
 
-    /// Creates a 2D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u8) -> Self {
+    pub fn set_x(mut self, x: u8) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 2D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 2D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u8) -> Self {
+    pub fn with_x(&self, x: u8) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 2D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u8) -> Self {
         self.y = y;
         self
+    }
+
+    /// Returns a new version of this 2D vector with the given y value.
+    #[inline]
+    #[must_use]
+    pub fn with_y(&self, y: u8) -> Self {
+        Self { y, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -127,7 +127,7 @@ impl U8Vec2 {
         U8Vec3::new(self.x, self.y, z)
     }
 
-    /// Sets the x component of this 2D vector
+    /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u8) -> Self {
@@ -135,14 +135,14 @@ impl U8Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given x value.
+    /// Returns a new version of this 2D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u8) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 2D vector
+    /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u8) -> Self {
@@ -150,7 +150,7 @@ impl U8Vec2 {
         self
     }
 
-    /// Returns a new version of this 2D vector with the given y value.
+    /// Returns a new version of this 2D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u8) -> Self {

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -139,7 +139,7 @@ impl U8Vec2 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u8) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y)
     }
 
     /// Sets the `y` component of this 2D vector
@@ -154,7 +154,7 @@ impl U8Vec2 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u8) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -130,9 +130,9 @@ impl U8Vec2 {
     /// Sets the `x` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u8) -> Self {
+    pub fn set_x(&mut self, x: u8) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `x` value.
@@ -145,9 +145,9 @@ impl U8Vec2 {
     /// Sets the `y` component of this 2D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u8) -> Self {
+    pub fn set_y(&mut self, y: u8) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 2D vector with the given `y` value.

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -155,7 +155,7 @@ impl U8Vec3 {
         self.xy()
     }
 
-    /// Sets the x component of this 3D vector
+    /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u8) -> Self {
@@ -163,14 +163,14 @@ impl U8Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given x value.
+    /// Returns a new version of this 3D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u8) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 3D vector
+    /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u8) -> Self {
@@ -178,14 +178,14 @@ impl U8Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given y value.
+    /// Returns a new version of this 3D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u8) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 3D vector
+    /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: u8) -> Self {
@@ -193,7 +193,7 @@ impl U8Vec3 {
         self
     }
 
-    /// Returns a new version of this 3D vector with the given z value.
+    /// Returns a new version of this 3D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u8) -> Self {

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -155,28 +155,49 @@ impl U8Vec3 {
         self.xy()
     }
 
-    /// Creates a 3D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u8) -> Self {
+    pub fn set_x(mut self, x: u8) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 3D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u8) -> Self {
+    pub fn with_x(&self, x: u8) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u8) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 3D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 3D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: u8) -> Self {
+    pub fn with_y(&self, y: u8) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 3D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: u8) -> Self {
         self.z = z;
         self
+    }
+
+    /// Returns a new version of this 3D vector with the given z value.
+    #[inline]
+    #[must_use]
+    pub fn with_z(&self, z: u8) -> Self {
+        Self { z, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -158,9 +158,9 @@ impl U8Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u8) -> Self {
+    pub fn set_x(&mut self, x: u8) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -173,9 +173,9 @@ impl U8Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u8) -> Self {
+    pub fn set_y(&mut self, y: u8) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -188,9 +188,9 @@ impl U8Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: u8) -> Self {
+    pub fn set_z(&mut self, z: u8) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -167,7 +167,7 @@ impl U8Vec3 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u8) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z)
     }
 
     /// Sets the `y` component of this 3D vector
@@ -182,7 +182,7 @@ impl U8Vec3 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u8) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z)
     }
 
     /// Sets the `z` component of this 3D vector
@@ -197,7 +197,7 @@ impl U8Vec3 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u8) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -158,9 +158,9 @@ impl U8Vec3 {
     /// Sets the `x` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u8) -> Self {
+    pub fn set_x(&mut self, x: u8) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `x` value.
@@ -173,9 +173,9 @@ impl U8Vec3 {
     /// Sets the `y` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u8) -> Self {
+    pub fn set_y(&mut self, y: u8) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `y` value.
@@ -188,9 +188,9 @@ impl U8Vec3 {
     /// Sets the `z` component of this 3D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: u8) -> Self {
+    pub fn set_z(&mut self, z: u8) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 3D vector with the given `z` value.

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -153,9 +153,9 @@ impl U8Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(&mut self, x: u8) -> Self {
+    pub fn set_x(&mut self, x: u8) -> &mut Self {
         self.x = x;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -168,9 +168,9 @@ impl U8Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(&mut self, y: u8) -> Self {
+    pub fn set_y(&mut self, y: u8) -> &mut Self {
         self.y = y;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -183,9 +183,9 @@ impl U8Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(&mut self, z: u8) -> Self {
+    pub fn set_z(&mut self, z: u8) -> &mut Self {
         self.z = z;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -198,9 +198,9 @@ impl U8Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(&mut self, w: u8) -> Self {
+    pub fn set_w(&mut self, w: u8) -> &mut Self {
         self.w = w;
-        *self
+        self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -153,9 +153,9 @@ impl U8Vec4 {
     /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_x(mut self, x: u8) -> Self {
+    pub fn set_x(&mut self, x: u8) -> Self {
         self.x = x;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `x` value.
@@ -168,9 +168,9 @@ impl U8Vec4 {
     /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_y(mut self, y: u8) -> Self {
+    pub fn set_y(&mut self, y: u8) -> Self {
         self.y = y;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `y` value.
@@ -183,9 +183,9 @@ impl U8Vec4 {
     /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_z(mut self, z: u8) -> Self {
+    pub fn set_z(&mut self, z: u8) -> Self {
         self.z = z;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `z` value.
@@ -198,9 +198,9 @@ impl U8Vec4 {
     /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn set_w(mut self, w: u8) -> Self {
+    pub fn set_w(&mut self, w: u8) -> Self {
         self.w = w;
-        self
+        *self
     }
 
     /// Returns a new version of this 4D vector with the given `w` value.

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -150,7 +150,7 @@ impl U8Vec4 {
         self.xyz()
     }
 
-    /// Sets the x component of this 4D vector
+    /// Sets the `x` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_x(mut self, x: u8) -> Self {
@@ -158,14 +158,14 @@ impl U8Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given x value.
+    /// Returns a new version of this 4D vector with the given `x` value.
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u8) -> Self {
         Self { x, ..*self }
     }
 
-    /// Sets the y component of this 4D vector
+    /// Sets the `y` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_y(mut self, y: u8) -> Self {
@@ -173,14 +173,14 @@ impl U8Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given y value.
+    /// Returns a new version of this 4D vector with the given `y` value.
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u8) -> Self {
         Self { y, ..*self }
     }
 
-    /// Sets the z component of this 4D vector
+    /// Sets the `z` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_z(mut self, z: u8) -> Self {
@@ -188,14 +188,14 @@ impl U8Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given z value.
+    /// Returns a new version of this 4D vector with the given `z` value.
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u8) -> Self {
         Self { z, ..*self }
     }
 
-    /// Sets the w component of this 4D vector
+    /// Sets the `w` component of this 4D vector
     #[inline]
     #[must_use]
     pub fn set_w(mut self, w: u8) -> Self {
@@ -203,7 +203,7 @@ impl U8Vec4 {
         self
     }
 
-    /// Returns a new version of this 4D vector with the given w value.
+    /// Returns a new version of this 4D vector with the given `w` value.
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: u8) -> Self {

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -162,7 +162,7 @@ impl U8Vec4 {
     #[inline]
     #[must_use]
     pub fn with_x(&self, x: u8) -> Self {
-        Self { x, ..*self }
+        Self::new(x, self.y, self.z, self.w)
     }
 
     /// Sets the `y` component of this 4D vector
@@ -177,7 +177,7 @@ impl U8Vec4 {
     #[inline]
     #[must_use]
     pub fn with_y(&self, y: u8) -> Self {
-        Self { y, ..*self }
+        Self::new(self.x, y, self.z, self.w)
     }
 
     /// Sets the `z` component of this 4D vector
@@ -192,7 +192,7 @@ impl U8Vec4 {
     #[inline]
     #[must_use]
     pub fn with_z(&self, z: u8) -> Self {
-        Self { z, ..*self }
+        Self::new(self.x, self.y, z, self.w)
     }
 
     /// Sets the `w` component of this 4D vector
@@ -207,7 +207,7 @@ impl U8Vec4 {
     #[inline]
     #[must_use]
     pub fn with_w(&self, w: u8) -> Self {
-        Self { w, ..*self }
+        Self::new(self.x, self.y, self.z, w)
     }
 
     /// Computes the dot product of `self` and `rhs`.

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -150,36 +150,64 @@ impl U8Vec4 {
         self.xyz()
     }
 
-    /// Creates a 4D vector from `self` with the given value of `x`.
+    /// Sets the x component of this 4D vector
     #[inline]
     #[must_use]
-    pub fn with_x(mut self, x: u8) -> Self {
+    pub fn set_x(mut self, x: u8) -> Self {
         self.x = x;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `y`.
+    /// Returns a new version of this 4D vector with the given x value.
     #[inline]
     #[must_use]
-    pub fn with_y(mut self, y: u8) -> Self {
+    pub fn with_x(&self, x: u8) -> Self {
+        Self { x, ..*self }
+    }
+
+    /// Sets the y component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_y(mut self, y: u8) -> Self {
         self.y = y;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `z`.
+    /// Returns a new version of this 4D vector with the given y value.
     #[inline]
     #[must_use]
-    pub fn with_z(mut self, z: u8) -> Self {
+    pub fn with_y(&self, y: u8) -> Self {
+        Self { y, ..*self }
+    }
+
+    /// Sets the z component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_z(mut self, z: u8) -> Self {
         self.z = z;
         self
     }
 
-    /// Creates a 4D vector from `self` with the given value of `w`.
+    /// Returns a new version of this 4D vector with the given z value.
     #[inline]
     #[must_use]
-    pub fn with_w(mut self, w: u8) -> Self {
+    pub fn with_z(&self, z: u8) -> Self {
+        Self { z, ..*self }
+    }
+
+    /// Sets the w component of this 4D vector
+    #[inline]
+    #[must_use]
+    pub fn set_w(mut self, w: u8) -> Self {
         self.w = w;
         self
+    }
+
+    /// Returns a new version of this 4D vector with the given w value.
+    #[inline]
+    #[must_use]
+    pub fn with_w(&self, w: u8) -> Self {
+        Self { w, ..*self }
     }
 
     /// Computes the dot product of `self` and `rhs`.


### PR DESCRIPTION
## Objective:
The current behavior of the `with_` methods for vector types is using `mut self` type, which can be confusing since it relies on the `Copy` trait for implicit copy.

There are also no convenient `set_` method for method chaining pattern.

## Solution:
- Refactor the `with_` method of vector types to use `self` and create an explicit copy instead.
- Add a new `set_` method to allow for method chaining when mutating vector types.
