### PR TITLE
Update `rand` to latest v0.9 version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ core-simd = []
 approx = { version = "0.5", optional = true, default-features = false }
 bytemuck = { version = "1.9", optional = true, default-features = false }
 mint = { version = "0.5.8", optional = true, default-features = false }
-rand = { version = "0.8", optional = true, default-features = false }
+rand = { version = "0.9", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 rkyv = { version = "0.7", optional = true, default-features = false }
 bytecheck = { version = "0.7", optional = true, default-features = false }
@@ -53,7 +53,7 @@ libm = { version = "0.2", optional = true, default-features = false}
 
 [dev-dependencies]
 # rand_xoshiro is required for tests if rand is enabled
-rand_xoshiro = "0.6"
+rand_xoshiro = "0.7"
 # Set a size_xx feature so that this crate compiles properly with --all-targets --all-features
 rkyv = { version = "0.7", default-features = false, features = ["size_32"] }
 serde_json = "1.0"


### PR DESCRIPTION
# Objective

Since `rand` version 0.9 is out with breaking changes to various traits, it means that some of the old assertions no longer apply and instead are now passed to the consumer on how to deal with them via `Result` with regards to the distributions and sampling. Some traits have been renamed, but otherwise it is a straightforward migration to the new version.

## Solution

- Update the `impl_rand` macros with the new updated traits. Also, various deprecated methods were renamed to their recommended versions so to better support Rust 2024 edition as `gen` is now a reserved keyword.

## Code generation

- The codegen templates are unmodified, and only the `impl_rand` module and macros have been updated

## Testing and linting

- No new features have been added, only a migration from `rand` v0.8 -> v0.9. Therefore no new tests are added, but everything must pass to ensure no regressions.

## Breaking changes

- The new version of `rand` is a breaking change to the trait implementations, so users making use of the `UniformSampler` will need to account for a `Result<T, UniformError>` instead of just `T`. This will require a new major version of this crate to be published.
