### PR TITLE
Add `within` method for Vec2

### DIFF
--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -2333,6 +2333,20 @@ impl {{ self_t }} {
     }
 {% endif %}
 
+{% if dim == 2 %}
+    /// Checks if the point is inside the area of a
+    /// rectangle delimited by `a` and `b`.
+    ///
+    /// Where:
+    /// - `a` is the top-left corner
+    /// - `b` is the bottom-right corner
+    #[inline]
+    #[must_use]
+    pub fn within(&self, a: &Self, b: &Self) -> bool {
+        self.x >= a.x && self.x <= b.x && self.y >= a.y && self.y <= b.y
+    }
+{% endif %}
+
 {% if scalar_t != "f32" %}
     {% if dim == 2 %}
     /// Casts all elements of `self` to `f32`.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -936,6 +936,18 @@ impl Vec2 {
         Self::from_angle(angle).rotate(*self)
     }
 
+    /// Checks if the point is inside the area of a
+    /// rectangle delimited by `a` and `b`.
+    ///
+    /// Where:
+    /// - `a` is the top-left corner
+    /// - `b` is the bottom-right corner
+    #[inline]
+    #[must_use]
+    pub fn within(&self, a: &Self, b: &Self) -> bool {
+        self.x >= a.x && self.x <= b.x && self.y >= a.y && self.y <= b.y
+    }
+
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -936,6 +936,18 @@ impl DVec2 {
         Self::from_angle(angle).rotate(*self)
     }
 
+    /// Checks if the point is inside the area of a
+    /// rectangle delimited by `a` and `b`.
+    ///
+    /// Where:
+    /// - `a` is the top-left corner
+    /// - `b` is the bottom-right corner
+    #[inline]
+    #[must_use]
+    pub fn within(&self, a: &Self, b: &Self) -> bool {
+        self.x >= a.x && self.x <= b.x && self.y >= a.y && self.y <= b.y
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -449,6 +449,18 @@ impl I16Vec2 {
         }
     }
 
+    /// Checks if the point is inside the area of a
+    /// rectangle delimited by `a` and `b`.
+    ///
+    /// Where:
+    /// - `a` is the top-left corner
+    /// - `b` is the bottom-right corner
+    #[inline]
+    #[must_use]
+    pub fn within(&self, a: &Self, b: &Self) -> bool {
+        self.x >= a.x && self.x <= b.x && self.y >= a.y && self.y <= b.y
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -449,6 +449,18 @@ impl IVec2 {
         }
     }
 
+    /// Checks if the point is inside the area of a
+    /// rectangle delimited by `a` and `b`.
+    ///
+    /// Where:
+    /// - `a` is the top-left corner
+    /// - `b` is the bottom-right corner
+    #[inline]
+    #[must_use]
+    pub fn within(&self, a: &Self, b: &Self) -> bool {
+        self.x >= a.x && self.x <= b.x && self.y >= a.y && self.y <= b.y
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -449,6 +449,18 @@ impl I64Vec2 {
         }
     }
 
+    /// Checks if the point is inside the area of a
+    /// rectangle delimited by `a` and `b`.
+    ///
+    /// Where:
+    /// - `a` is the top-left corner
+    /// - `b` is the bottom-right corner
+    #[inline]
+    #[must_use]
+    pub fn within(&self, a: &Self, b: &Self) -> bool {
+        self.x >= a.x && self.x <= b.x && self.y >= a.y && self.y <= b.y
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -449,6 +449,18 @@ impl I8Vec2 {
         }
     }
 
+    /// Checks if the point is inside the area of a
+    /// rectangle delimited by `a` and `b`.
+    ///
+    /// Where:
+    /// - `a` is the top-left corner
+    /// - `b` is the bottom-right corner
+    #[inline]
+    #[must_use]
+    pub fn within(&self, a: &Self, b: &Self) -> bool {
+        self.x >= a.x && self.x <= b.x && self.y >= a.y && self.y <= b.y
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -344,6 +344,18 @@ impl U16Vec2 {
             .unwrap()
     }
 
+    /// Checks if the point is inside the area of a
+    /// rectangle delimited by `a` and `b`.
+    ///
+    /// Where:
+    /// - `a` is the top-left corner
+    /// - `b` is the bottom-right corner
+    #[inline]
+    #[must_use]
+    pub fn within(&self, a: &Self, b: &Self) -> bool {
+        self.x >= a.x && self.x <= b.x && self.y >= a.y && self.y <= b.y
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -344,6 +344,18 @@ impl UVec2 {
             .unwrap()
     }
 
+    /// Checks if the point is inside the area of a
+    /// rectangle delimited by `a` and `b`.
+    ///
+    /// Where:
+    /// - `a` is the top-left corner
+    /// - `b` is the bottom-right corner
+    #[inline]
+    #[must_use]
+    pub fn within(&self, a: &Self, b: &Self) -> bool {
+        self.x >= a.x && self.x <= b.x && self.y >= a.y && self.y <= b.y
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -344,6 +344,18 @@ impl U64Vec2 {
             .unwrap()
     }
 
+    /// Checks if the point is inside the area of a
+    /// rectangle delimited by `a` and `b`.
+    ///
+    /// Where:
+    /// - `a` is the top-left corner
+    /// - `b` is the bottom-right corner
+    #[inline]
+    #[must_use]
+    pub fn within(&self, a: &Self, b: &Self) -> bool {
+        self.x >= a.x && self.x <= b.x && self.y >= a.y && self.y <= b.y
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -344,6 +344,18 @@ impl U8Vec2 {
             .unwrap()
     }
 
+    /// Checks if the point is inside the area of a
+    /// rectangle delimited by `a` and `b`.
+    ///
+    /// Where:
+    /// - `a` is the top-left corner
+    /// - `b` is the bottom-right corner
+    #[inline]
+    #[must_use]
+    pub fn within(&self, a: &Self, b: &Self) -> bool {
+        self.x >= a.x && self.x <= b.x && self.y >= a.y && self.y <= b.y
+    }
+
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -633,6 +633,14 @@ macro_rules! impl_vec2_tests {
             assert_eq!([two, two].iter().product::<$vec2>(), two * two);
             assert_eq!([two, two].into_iter().product::<$vec2>(), two * two);
         });
+        glam_test!(test_within, {
+            let top_left = $vec2::new(0 as $t, 0 as $t);
+            let bottom_right = $vec2::new(2 as $t, 2 as $t);
+            let point = $vec2::new(1 as $t, 1 as $t);
+            assert!(point.within(&top_left, &bottom_right));
+            let point = $vec2::new(4 as $t, 1 as $t);
+            assert!(!point.within(&top_left, &bottom_right));
+        });
     };
 }
 
@@ -721,6 +729,14 @@ macro_rules! impl_vec2_signed_tests {
             assert_eq!((-four).rem_euclid(three), two);
             assert_eq!(four.rem_euclid(-three), one);
             assert_eq!((-four).rem_euclid(-three), two);
+        });
+        glam_test!(test_within_signed, {
+            let top_left = $vec2::new(-2 as $t, -2 as $t);
+            let bottom_right = $vec2::new(2 as $t, 2 as $t);
+            let point = $vec2::new(-1 as $t, 1 as $t);
+            assert!(point.within(&top_left, &bottom_right));
+            let point = $vec2::new(-12 as $t, 0 as $t);
+            assert!(!point.within(&top_left, &bottom_right));
         });
     };
 }
@@ -1278,6 +1294,15 @@ macro_rules! impl_vec2_float_tests {
             let incident = $vec2::new(1.0, -1.0).normalize();
             let normal = $vec2::Y;
             assert_approx_eq!(incident.refract(normal, 1.5), $vec2::ZERO);
+        });
+
+        glam_test!(test_within_float, {
+            let top_left = $vec2::new(-1.5 as $t, -2.5 as $t);
+            let bottom_right = $vec2::new(3 as $t, 3 as $t);
+            let point = $vec2::new(0.3 as $t, -1.5 as $t);
+            assert!(point.within(&top_left, &bottom_right));
+            let point = $vec2::new(9.0 as $t, -12.0 as $t);
+            assert!(!point.within(&top_left, &bottom_right));
         });
     };
 }


### PR DESCRIPTION
Add a new `within`  method for Vec2 that returns true if the point is inside the area of a rectagle.

# Objective
Implement a `within` method to check if the a coordinate - represented by a Vec2 - is contained inside a rectangle.
This was suggested on #594 

## Solution
Implement a within method, that receives two Vec2. The first one (a) is the top-left corner of the rectangle, and the second one (b) is the bottom right.  
To check if the point is inside the rectangle, check that x is inside [a.x,b.x] and that y in inside [a.y,b.y] 

## Code generation

I've modified the vec.rs.tera template.
I've run the code generator, and it succeeds

## Testing and linting
I've added some basic test cases for the new within method.
