### PR TITLE
Bvec test refactor

### DIFF
--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -3,8 +3,227 @@
 #[macro_use]
 mod support;
 
+macro_rules! impl_bvec2_tests {
+    ($mask:ident, $masknew:ident) => {
+        glam_test!(test_mask_new, {
+            assert_eq!($mask::new(false, false), $masknew(false, false));
+            assert_eq!($mask::new(true, false), $masknew(true, false));
+            assert_eq!($mask::new(false, true), $masknew(false, true));
+            assert_eq!($mask::new(true, true), $masknew(true, true));
+        });
+
+        glam_test!(test_mask_from_array_bool, {
+            assert_eq!($mask::new(false, false), $mask::from([false, false]));
+            assert_eq!($mask::new(true, false), $mask::from([true, false]));
+            assert_eq!($mask::new(false, true), $mask::from([false, true]));
+            assert_eq!($mask::new(true, true), $mask::from([true, true]));
+        });
+
+        glam_test!(test_mask_into_array_u32, {
+            assert_eq!(Into::<[u32; 2]>::into($mask::new(false, false)), [0, 0]);
+            assert_eq!(Into::<[u32; 2]>::into($mask::new(true, false)), [!0, 0]);
+            assert_eq!(Into::<[u32; 2]>::into($mask::new(false, true)), [0, !0]);
+            assert_eq!(Into::<[u32; 2]>::into($mask::new(true, true)), [!0, !0]);
+        });
+
+        glam_test!(test_mask_into_array_bool, {
+            assert_eq!(
+                Into::<[bool; 2]>::into($mask::new(false, false)),
+                [false, false]
+            );
+            assert_eq!(
+                Into::<[bool; 2]>::into($mask::new(true, false)),
+                [true, false]
+            );
+            assert_eq!(
+                Into::<[bool; 2]>::into($mask::new(false, true)),
+                [false, true]
+            );
+            assert_eq!(
+                Into::<[bool; 2]>::into($mask::new(true, true)),
+                [true, true]
+            );
+        });
+
+        glam_test!(test_mask_splat, {
+            assert_eq!($mask::splat(false), $mask::new(false, false));
+            assert_eq!($mask::splat(true), $mask::new(true, true));
+        });
+
+        glam_test!(test_mask_bitmask, {
+            assert_eq!($mask::new(false, false).bitmask(), 0b00);
+            assert_eq!($mask::new(true, false).bitmask(), 0b01);
+            assert_eq!($mask::new(false, true).bitmask(), 0b10);
+            assert_eq!($mask::new(true, true).bitmask(), 0b11);
+        });
+
+        glam_test!(test_mask_any, {
+            assert_eq!($mask::new(false, false).any(), false);
+            assert_eq!($mask::new(true, false).any(), true);
+            assert_eq!($mask::new(false, true).any(), true);
+            assert_eq!($mask::new(true, true).any(), true);
+        });
+
+        glam_test!(test_mask_all, {
+            assert_eq!($mask::new(false, false).all(), false);
+            assert_eq!($mask::new(true, false).all(), false);
+            assert_eq!($mask::new(false, true).all(), false);
+            assert_eq!($mask::new(true, true).all(), true);
+        });
+
+        glam_test!(test_mask_and, {
+            assert_eq!(
+                ($mask::new(false, false) & $mask::new(false, false)).bitmask(),
+                0b00,
+            );
+            assert_eq!(
+                ($mask::new(true, true) & $mask::new(true, false)).bitmask(),
+                0b01,
+            );
+            assert_eq!(
+                ($mask::new(true, false) & $mask::new(false, true)).bitmask(),
+                0b00,
+            );
+            assert_eq!(
+                ($mask::new(true, true) & $mask::new(true, true)).bitmask(),
+                0b11,
+            );
+
+            let mut mask = $mask::new(true, true);
+            mask &= $mask::new(true, false);
+            assert_eq!(mask.bitmask(), 0b01);
+        });
+
+        glam_test!(test_mask_or, {
+            assert_eq!(
+                ($mask::new(false, false) | $mask::new(false, false)).bitmask(),
+                0b00,
+            );
+            assert_eq!(
+                ($mask::new(false, false) | $mask::new(false, true)).bitmask(),
+                0b10,
+            );
+            assert_eq!(
+                ($mask::new(true, false) | $mask::new(false, true)).bitmask(),
+                0b11,
+            );
+            assert_eq!(
+                ($mask::new(true, true) | $mask::new(true, true)).bitmask(),
+                0b11,
+            );
+
+            let mut mask = $mask::new(true, true);
+            mask |= $mask::new(true, false);
+            assert_eq!(mask.bitmask(), 0b11);
+        });
+
+        glam_test!(test_mask_xor, {
+            assert_eq!(
+                ($mask::new(false, false) ^ $mask::new(false, false)).bitmask(),
+                0b00,
+            );
+            assert_eq!(
+                ($mask::new(false, false) ^ $mask::new(false, true)).bitmask(),
+                0b10,
+            );
+            assert_eq!(
+                ($mask::new(true, false) ^ $mask::new(false, true)).bitmask(),
+                0b11,
+            );
+            assert_eq!(
+                ($mask::new(true, true) ^ $mask::new(true, true)).bitmask(),
+                0b00,
+            );
+
+            let mut mask = $mask::new(false, true);
+            mask ^= $mask::new(true, false);
+            assert_eq!(mask.bitmask(), 0b11);
+        });
+
+        glam_test!(test_mask_not, {
+            assert_eq!((!$mask::new(false, false)).bitmask(), 0b11);
+            assert_eq!((!$mask::new(true, false)).bitmask(), 0b10);
+            assert_eq!((!$mask::new(false, true)).bitmask(), 0b01);
+            assert_eq!((!$mask::new(true, true)).bitmask(), 0b00);
+        });
+
+        glam_test!(test_mask_fmt, {
+            let a = $mask::new(true, false);
+
+            assert_eq!(
+                format!("{:?}", a),
+                format!("{}(0xffffffff, 0x0)", stringify!($mask))
+            );
+            assert_eq!(format!("{}", a), "[true, false]");
+        });
+
+        glam_test!(test_mask_eq, {
+            let a = $mask::new(true, false);
+            let b = $mask::new(true, false);
+            let c = $mask::new(false, true);
+
+            assert_eq!(a, b);
+            assert_eq!(b, a);
+            assert_ne!(a, c);
+            assert_ne!(b, c);
+        });
+
+        glam_test!(test_mask_test, {
+            let a = $mask::new(true, false);
+            assert_eq!(a.test(0), true);
+            assert_eq!(a.test(1), false);
+
+            let b = $mask::new(false, true);
+            assert_eq!(b.test(0), false);
+            assert_eq!(b.test(1), true);
+        });
+
+        glam_test!(test_mask_set, {
+            let mut a = $mask::new(false, true);
+            a.set(0, true);
+            assert_eq!(a.test(0), true);
+            a.set(1, false);
+            assert_eq!(a.test(1), false);
+
+            let mut b = $mask::new(true, false);
+            b.set(0, false);
+            assert_eq!(b.test(0), false);
+            b.set(1, true);
+            assert_eq!(b.test(1), true);
+        });
+
+        glam_test!(test_mask_hash, {
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::Hash;
+            use std::hash::Hasher;
+
+            let a = $mask::new(true, false);
+            let b = $mask::new(true, false);
+            let c = $mask::new(false, true);
+
+            let mut hasher = DefaultHasher::new();
+            a.hash(&mut hasher);
+            let a_hashed = hasher.finish();
+
+            let mut hasher = DefaultHasher::new();
+            b.hash(&mut hasher);
+            let b_hashed = hasher.finish();
+
+            let mut hasher = DefaultHasher::new();
+            c.hash(&mut hasher);
+            let c_hashed = hasher.finish();
+
+            assert_eq!(a, b);
+            assert_eq!(a_hashed, b_hashed);
+            assert_ne!(a, c);
+            assert_ne!(a_hashed, c_hashed);
+        });
+
+    }
+}
+
 macro_rules! impl_vec2_tests {
-    ($t:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
+    ($t:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident) => {
         glam_test!(test_const, {
             const V0: $vec2 = $vec2::splat(1 as $t);
             const V1: $vec2 = $vec2::new(1 as $t, 2 as $t);
@@ -356,89 +575,7 @@ macro_rules! impl_vec2_tests {
             assert!(a == a);
         });
 
-        glam_test!(test_extend_truncate, {
-            let a = $new(1 as $t, 2 as $t);
-            let b = a.extend(3 as $t);
-            assert_eq!($vec3::new(1 as $t, 2 as $t, 3 as $t), b);
-        });
-
-        glam_test!(test_vec2mask, {
-            // make sure the unused 'z' value doesn't break $vec2 behaviour
-            let a = $vec3::ZERO;
-            let mut b = a.truncate();
-            b.x = 1 as $t;
-            b.y = 1 as $t;
-            assert!(!b.cmpeq($vec2::ZERO).any());
-            assert!(b.cmpeq($vec2::splat(1 as $t)).all());
-        });
-
-        glam_test!(test_mask_new, {
-            assert_eq!($mask::new(false, false), $masknew(false, false));
-            assert_eq!($mask::new(true, false), $masknew(true, false));
-            assert_eq!($mask::new(false, true), $masknew(false, true));
-            assert_eq!($mask::new(true, true), $masknew(true, true));
-        });
-
-        glam_test!(test_mask_from_array_bool, {
-            assert_eq!($mask::new(false, false), $mask::from([false, false]));
-            assert_eq!($mask::new(true, false), $mask::from([true, false]));
-            assert_eq!($mask::new(false, true), $mask::from([false, true]));
-            assert_eq!($mask::new(true, true), $mask::from([true, true]));
-        });
-
-        glam_test!(test_mask_into_array_u32, {
-            assert_eq!(Into::<[u32; 2]>::into($mask::new(false, false)), [0, 0]);
-            assert_eq!(Into::<[u32; 2]>::into($mask::new(true, false)), [!0, 0]);
-            assert_eq!(Into::<[u32; 2]>::into($mask::new(false, true)), [0, !0]);
-            assert_eq!(Into::<[u32; 2]>::into($mask::new(true, true)), [!0, !0]);
-        });
-
-        glam_test!(test_mask_into_array_bool, {
-            assert_eq!(
-                Into::<[bool; 2]>::into($mask::new(false, false)),
-                [false, false]
-            );
-            assert_eq!(
-                Into::<[bool; 2]>::into($mask::new(true, false)),
-                [true, false]
-            );
-            assert_eq!(
-                Into::<[bool; 2]>::into($mask::new(false, true)),
-                [false, true]
-            );
-            assert_eq!(
-                Into::<[bool; 2]>::into($mask::new(true, true)),
-                [true, true]
-            );
-        });
-
-        glam_test!(test_mask_splat, {
-            assert_eq!($mask::splat(false), $mask::new(false, false));
-            assert_eq!($mask::splat(true), $mask::new(true, true));
-        });
-
-        glam_test!(test_mask_bitmask, {
-            assert_eq!($mask::new(false, false).bitmask(), 0b00);
-            assert_eq!($mask::new(true, false).bitmask(), 0b01);
-            assert_eq!($mask::new(false, true).bitmask(), 0b10);
-            assert_eq!($mask::new(true, true).bitmask(), 0b11);
-        });
-
-        glam_test!(test_mask_any, {
-            assert_eq!($mask::new(false, false).any(), false);
-            assert_eq!($mask::new(true, false).any(), true);
-            assert_eq!($mask::new(false, true).any(), true);
-            assert_eq!($mask::new(true, true).any(), true);
-        });
-
-        glam_test!(test_mask_all, {
-            assert_eq!($mask::new(false, false).all(), false);
-            assert_eq!($mask::new(true, false).all(), false);
-            assert_eq!($mask::new(false, true).all(), false);
-            assert_eq!($mask::new(true, true).all(), true);
-        });
-
-        glam_test!(test_mask_select, {
+        glam_test!(test_select, {
             let a = $vec2::new(1 as $t, 2 as $t);
             let b = $vec2::new(3 as $t, 4 as $t);
             assert_eq!(
@@ -459,152 +596,10 @@ macro_rules! impl_vec2_tests {
             );
         });
 
-        glam_test!(test_mask_and, {
-            assert_eq!(
-                ($mask::new(false, false) & $mask::new(false, false)).bitmask(),
-                0b00,
-            );
-            assert_eq!(
-                ($mask::new(true, true) & $mask::new(true, false)).bitmask(),
-                0b01,
-            );
-            assert_eq!(
-                ($mask::new(true, false) & $mask::new(false, true)).bitmask(),
-                0b00,
-            );
-            assert_eq!(
-                ($mask::new(true, true) & $mask::new(true, true)).bitmask(),
-                0b11,
-            );
-
-            let mut mask = $mask::new(true, true);
-            mask &= $mask::new(true, false);
-            assert_eq!(mask.bitmask(), 0b01);
-        });
-
-        glam_test!(test_mask_or, {
-            assert_eq!(
-                ($mask::new(false, false) | $mask::new(false, false)).bitmask(),
-                0b00,
-            );
-            assert_eq!(
-                ($mask::new(false, false) | $mask::new(false, true)).bitmask(),
-                0b10,
-            );
-            assert_eq!(
-                ($mask::new(true, false) | $mask::new(false, true)).bitmask(),
-                0b11,
-            );
-            assert_eq!(
-                ($mask::new(true, true) | $mask::new(true, true)).bitmask(),
-                0b11,
-            );
-
-            let mut mask = $mask::new(true, true);
-            mask |= $mask::new(true, false);
-            assert_eq!(mask.bitmask(), 0b11);
-        });
-
-        glam_test!(test_mask_xor, {
-            assert_eq!(
-                ($mask::new(false, false) ^ $mask::new(false, false)).bitmask(),
-                0b00,
-            );
-            assert_eq!(
-                ($mask::new(false, false) ^ $mask::new(false, true)).bitmask(),
-                0b10,
-            );
-            assert_eq!(
-                ($mask::new(true, false) ^ $mask::new(false, true)).bitmask(),
-                0b11,
-            );
-            assert_eq!(
-                ($mask::new(true, true) ^ $mask::new(true, true)).bitmask(),
-                0b00,
-            );
-
-            let mut mask = $mask::new(false, true);
-            mask ^= $mask::new(true, false);
-            assert_eq!(mask.bitmask(), 0b11);
-        });
-
-        glam_test!(test_mask_not, {
-            assert_eq!((!$mask::new(false, false)).bitmask(), 0b11);
-            assert_eq!((!$mask::new(true, false)).bitmask(), 0b10);
-            assert_eq!((!$mask::new(false, true)).bitmask(), 0b01);
-            assert_eq!((!$mask::new(true, true)).bitmask(), 0b00);
-        });
-
-        glam_test!(test_mask_fmt, {
-            let a = $mask::new(true, false);
-
-            assert_eq!(
-                format!("{:?}", a),
-                format!("{}(0xffffffff, 0x0)", stringify!($mask))
-            );
-            assert_eq!(format!("{}", a), "[true, false]");
-        });
-
-        glam_test!(test_mask_eq, {
-            let a = $mask::new(true, false);
-            let b = $mask::new(true, false);
-            let c = $mask::new(false, true);
-
-            assert_eq!(a, b);
-            assert_eq!(b, a);
-            assert_ne!(a, c);
-            assert_ne!(b, c);
-        });
-
-        glam_test!(test_mask_test, {
-            let a = $mask::new(true, false);
-            assert_eq!(a.test(0), true);
-            assert_eq!(a.test(1), false);
-
-            let b = $mask::new(false, true);
-            assert_eq!(b.test(0), false);
-            assert_eq!(b.test(1), true);
-        });
-
-        glam_test!(test_mask_set, {
-            let mut a = $mask::new(false, true);
-            a.set(0, true);
-            assert_eq!(a.test(0), true);
-            a.set(1, false);
-            assert_eq!(a.test(1), false);
-
-            let mut b = $mask::new(true, false);
-            b.set(0, false);
-            assert_eq!(b.test(0), false);
-            b.set(1, true);
-            assert_eq!(b.test(1), true);
-        });
-
-        glam_test!(test_mask_hash, {
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::Hash;
-            use std::hash::Hasher;
-
-            let a = $mask::new(true, false);
-            let b = $mask::new(true, false);
-            let c = $mask::new(false, true);
-
-            let mut hasher = DefaultHasher::new();
-            a.hash(&mut hasher);
-            let a_hashed = hasher.finish();
-
-            let mut hasher = DefaultHasher::new();
-            b.hash(&mut hasher);
-            let b_hashed = hasher.finish();
-
-            let mut hasher = DefaultHasher::new();
-            c.hash(&mut hasher);
-            let c_hashed = hasher.finish();
-
-            assert_eq!(a, b);
-            assert_eq!(a_hashed, b_hashed);
-            assert_ne!(a, c);
-            assert_ne!(a_hashed, c_hashed);
+        glam_test!(test_extend_truncate, {
+            let a = $new(1 as $t, 2 as $t);
+            let b = a.extend(3 as $t);
+            assert_eq!($vec3::new(1 as $t, 2 as $t, 3 as $t), b);
         });
 
         glam_test!(test_to_from_slice, {
@@ -637,8 +632,8 @@ macro_rules! impl_vec2_tests {
 }
 
 macro_rules! impl_vec2_signed_tests {
-    ($t:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
-        impl_vec2_tests!($t, $new, $vec2, $vec3, $mask, $masknew);
+    ($t:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident) => {
+        impl_vec2_tests!($t, $new, $vec2, $vec3, $mask);
 
         glam_test!(test_is_negative_bitmask, {
             assert_eq!($vec2::ZERO.is_negative_bitmask(), 0b00);
@@ -726,8 +721,8 @@ macro_rules! impl_vec2_signed_tests {
 }
 
 macro_rules! impl_vec2_signed_integer_tests {
-    ($t:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
-        impl_vec2_signed_tests!($t, $new, $vec2, $vec3, $mask, $masknew);
+    ($t:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident) => {
+        impl_vec2_signed_tests!($t, $new, $vec2, $vec3, $mask);
 
         glam_test!(test_signum, {
             assert_eq!($vec2::ZERO.signum(), $vec2::ZERO);
@@ -812,8 +807,8 @@ macro_rules! impl_vec2_signed_integer_tests {
 }
 
 macro_rules! impl_vec2_unsigned_integer_tests {
-    ($t:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
-        impl_vec2_tests!($t, $new, $vec2, $vec3, $mask, $masknew);
+    ($t:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident) => {
+        impl_vec2_tests!($t, $new, $vec2, $vec3, $mask);
 
         glam_test!(test_checked_add, {
             assert_eq!($vec2::MAX.checked_add($vec2::ONE), None);
@@ -904,8 +899,8 @@ macro_rules! impl_vec2_eq_hash_tests {
 }
 
 macro_rules! impl_vec2_float_tests {
-    ($t:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
-        impl_vec2_signed_tests!($t, $new, $vec2, $vec3, $mask, $masknew);
+    ($t:ident, $new:ident, $vec2:ident, $vec3:ident, $mask:ident) => {
+        impl_vec2_signed_tests!($t, $new, $vec2, $vec3, $mask);
         impl_vec_float_normalize_tests!($t, $vec2);
 
         glam_test!(test_vec2_nan, {
@@ -1415,8 +1410,20 @@ macro_rules! impl_vec2_bit_op_tests {
     };
 }
 
+mod bvec2 {
+    use glam::{bvec2, BVec2};
+
+    glam_test!(test_mask_align, {
+        use core::mem;
+        assert_eq!(2, mem::size_of::<BVec2>());
+        assert_eq!(1, mem::align_of::<BVec2>());
+    });
+
+    impl_bvec2_tests!(BVec2, bvec2);
+}
+
 mod vec2 {
-    use glam::{bvec2, vec2, BVec2, Vec2, Vec3};
+    use glam::{vec2, BVec2, Vec2, Vec3};
 
     glam_test!(test_align, {
         use core::mem;
@@ -1425,8 +1432,6 @@ mod vec2 {
         assert_eq!(4, mem::align_of::<Vec2>());
         #[cfg(feature = "cuda")]
         assert_eq!(8, mem::align_of::<Vec2>());
-        assert_eq!(2, mem::size_of::<BVec2>());
-        assert_eq!(1, mem::align_of::<BVec2>());
     });
 
     glam_test!(test_as, {
@@ -1532,11 +1537,11 @@ mod vec2 {
         assert_eq!(I64Vec2::new(1, 2), U64Vec2::new(1, 2).as_i64vec2());
     });
 
-    impl_vec2_float_tests!(f32, vec2, Vec2, Vec3, BVec2, bvec2);
+    impl_vec2_float_tests!(f32, vec2, Vec2, Vec3, BVec2);
 }
 
 mod dvec2 {
-    use glam::{bvec2, dvec2, BVec2, DVec2, DVec3, IVec2, UVec2, Vec2};
+    use glam::{dvec2, BVec2, DVec2, DVec3, IVec2, UVec2, Vec2};
 
     glam_test!(test_align, {
         use core::mem;
@@ -1545,8 +1550,6 @@ mod dvec2 {
         assert_eq!(mem::align_of::<f64>(), mem::align_of::<DVec2>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<DVec2>());
-        assert_eq!(2, mem::size_of::<BVec2>());
-        assert_eq!(1, mem::align_of::<BVec2>());
     });
 
     glam_test!(test_try_from, {
@@ -1555,12 +1558,12 @@ mod dvec2 {
         assert_eq!(DVec2::new(1.0, 2.0), DVec2::from(UVec2::new(1, 2)));
     });
 
-    impl_vec2_float_tests!(f64, dvec2, DVec2, DVec3, BVec2, bvec2);
+    impl_vec2_float_tests!(f64, dvec2, DVec2, DVec3, BVec2);
 }
 
 mod i8vec2 {
     use glam::{
-        bvec2, i8vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, I8Vec3, IVec2, U16Vec2, U64Vec2, U8Vec2,
+        i8vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, I8Vec3, IVec2, U16Vec2, U64Vec2, U8Vec2,
         UVec2,
     };
 
@@ -1724,7 +1727,7 @@ mod i8vec2 {
         );
     });
 
-    impl_vec2_signed_integer_tests!(i8, i8vec2, I8Vec2, I8Vec3, BVec2, bvec2);
+    impl_vec2_signed_integer_tests!(i8, i8vec2, I8Vec2, I8Vec3, BVec2);
     impl_vec2_eq_hash_tests!(i8, i8vec2);
 
     impl_vec2_scalar_shift_op_tests!(I8Vec2, -2, 2);
@@ -1736,7 +1739,7 @@ mod i8vec2 {
 
 mod u8vec2 {
     use glam::{
-        bvec2, u8vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2, U8Vec3,
+        u8vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2, U8Vec3,
         UVec2,
     };
 
@@ -1878,7 +1881,7 @@ mod u8vec2 {
         );
     });
 
-    impl_vec2_unsigned_integer_tests!(u8, u8vec2, U8Vec2, U8Vec3, BVec2, bvec2);
+    impl_vec2_unsigned_integer_tests!(u8, u8vec2, U8Vec2, U8Vec3, BVec2);
     impl_vec2_eq_hash_tests!(u8, u8vec2);
 
     impl_vec2_scalar_shift_op_tests!(U8Vec2, 0, 2);
@@ -1890,7 +1893,7 @@ mod u8vec2 {
 
 mod i16vec2 {
     use glam::{
-        bvec2, i16vec2, BVec2, I16Vec2, I16Vec3, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2,
+        i16vec2, BVec2, I16Vec2, I16Vec3, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2,
         UVec2,
     };
 
@@ -2043,7 +2046,7 @@ mod i16vec2 {
         );
     });
 
-    impl_vec2_signed_integer_tests!(i16, i16vec2, I16Vec2, I16Vec3, BVec2, bvec2);
+    impl_vec2_signed_integer_tests!(i16, i16vec2, I16Vec2, I16Vec3, BVec2);
     impl_vec2_eq_hash_tests!(i16, i16vec2);
 
     impl_vec2_scalar_shift_op_tests!(I16Vec2, -2, 2);
@@ -2055,7 +2058,7 @@ mod i16vec2 {
 
 mod u16vec2 {
     use glam::{
-        bvec2, u16vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U16Vec3, U64Vec2, UVec2,
+        u16vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U16Vec3, U64Vec2, UVec2,
     };
 
     glam_test!(test_align, {
@@ -2187,7 +2190,7 @@ mod u16vec2 {
         );
     });
 
-    impl_vec2_unsigned_integer_tests!(u16, u16vec2, U16Vec2, U16Vec3, BVec2, bvec2);
+    impl_vec2_unsigned_integer_tests!(u16, u16vec2, U16Vec2, U16Vec3, BVec2);
     impl_vec2_eq_hash_tests!(u16, u16vec2);
 
     impl_vec2_scalar_shift_op_tests!(U16Vec2, 0, 2);
@@ -2199,7 +2202,7 @@ mod u16vec2 {
 
 mod ivec2 {
     use glam::{
-        bvec2, ivec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, IVec3, U16Vec2, U64Vec2, U8Vec2,
+        ivec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, IVec3, U16Vec2, U64Vec2, U8Vec2,
         UVec2,
     };
 
@@ -2210,8 +2213,6 @@ mod ivec2 {
         assert_eq!(4, mem::align_of::<IVec2>());
         #[cfg(feature = "cuda")]
         assert_eq!(8, mem::align_of::<IVec2>());
-        assert_eq!(2, mem::size_of::<BVec2>());
-        assert_eq!(1, mem::align_of::<BVec2>());
     });
 
     glam_test!(test_try_from, {
@@ -2340,7 +2341,7 @@ mod ivec2 {
         );
     });
 
-    impl_vec2_signed_integer_tests!(i32, ivec2, IVec2, IVec3, BVec2, bvec2);
+    impl_vec2_signed_integer_tests!(i32, ivec2, IVec2, IVec3, BVec2);
     impl_vec2_eq_hash_tests!(i32, ivec2);
 
     impl_vec2_scalar_shift_op_tests!(IVec2, -2, 2);
@@ -2352,7 +2353,7 @@ mod ivec2 {
 
 mod uvec2 {
     use glam::{
-        bvec2, uvec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2, UVec2,
+        uvec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2, UVec2,
         UVec3,
     };
 
@@ -2363,8 +2364,6 @@ mod uvec2 {
         assert_eq!(4, mem::align_of::<UVec2>());
         #[cfg(feature = "cuda")]
         assert_eq!(8, mem::align_of::<UVec2>());
-        assert_eq!(2, mem::size_of::<BVec2>());
-        assert_eq!(1, mem::align_of::<BVec2>());
     });
 
     glam_test!(test_try_from, {
@@ -2478,7 +2477,7 @@ mod uvec2 {
         );
     });
 
-    impl_vec2_unsigned_integer_tests!(u32, uvec2, UVec2, UVec3, BVec2, bvec2);
+    impl_vec2_unsigned_integer_tests!(u32, uvec2, UVec2, UVec3, BVec2);
     impl_vec2_eq_hash_tests!(u32, uvec2);
 
     impl_vec2_scalar_shift_op_tests!(UVec2, 0, 2);
@@ -2490,7 +2489,7 @@ mod uvec2 {
 
 mod i64vec2 {
     use glam::{
-        bvec2, i64vec2, BVec2, I16Vec2, I64Vec2, I64Vec3, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2,
+        i64vec2, BVec2, I16Vec2, I64Vec2, I64Vec3, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2,
         UVec2,
     };
 
@@ -2501,8 +2500,6 @@ mod i64vec2 {
         assert_eq!(8, mem::align_of::<I64Vec2>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<I64Vec2>());
-        assert_eq!(2, mem::size_of::<BVec2>());
-        assert_eq!(1, mem::align_of::<BVec2>());
     });
 
     glam_test!(test_try_from, {
@@ -2565,7 +2562,7 @@ mod i64vec2 {
         );
     });
 
-    impl_vec2_signed_integer_tests!(i64, i64vec2, I64Vec2, I64Vec3, BVec2, bvec2);
+    impl_vec2_signed_integer_tests!(i64, i64vec2, I64Vec2, I64Vec3, BVec2);
     impl_vec2_eq_hash_tests!(i64, i64vec2);
 
     impl_vec2_scalar_shift_op_tests!(I64Vec2, -2, 2);
@@ -2577,7 +2574,7 @@ mod i64vec2 {
 
 mod u64vec2 {
     use glam::{
-        bvec2, u64vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U64Vec3, U8Vec2,
+        u64vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U64Vec3, U8Vec2,
         UVec2,
     };
 
@@ -2588,8 +2585,6 @@ mod u64vec2 {
         assert_eq!(8, mem::align_of::<U64Vec2>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<U64Vec2>());
-        assert_eq!(2, mem::size_of::<BVec2>());
-        assert_eq!(1, mem::align_of::<BVec2>());
     });
 
     glam_test!(test_try_from, {
@@ -2642,7 +2637,7 @@ mod u64vec2 {
         );
     });
 
-    impl_vec2_unsigned_integer_tests!(u64, u64vec2, U64Vec2, U64Vec3, BVec2, bvec2);
+    impl_vec2_unsigned_integer_tests!(u64, u64vec2, U64Vec2, U64Vec3, BVec2);
     impl_vec2_eq_hash_tests!(u64, u64vec2);
 
     impl_vec2_scalar_shift_op_tests!(U64Vec2, 0, 2);

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -218,8 +218,7 @@ macro_rules! impl_bvec2_tests {
             assert_ne!(a, c);
             assert_ne!(a_hashed, c_hashed);
         });
-
-    }
+    };
 }
 
 macro_rules! impl_vec2_tests {
@@ -1563,8 +1562,7 @@ mod dvec2 {
 
 mod i8vec2 {
     use glam::{
-        i8vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, I8Vec3, IVec2, U16Vec2, U64Vec2, U8Vec2,
-        UVec2,
+        i8vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, I8Vec3, IVec2, U16Vec2, U64Vec2, U8Vec2, UVec2,
     };
 
     glam_test!(test_align, {
@@ -1739,8 +1737,7 @@ mod i8vec2 {
 
 mod u8vec2 {
     use glam::{
-        u8vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2, U8Vec3,
-        UVec2,
+        u8vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2, U8Vec3, UVec2,
     };
 
     glam_test!(test_align, {
@@ -1893,8 +1890,7 @@ mod u8vec2 {
 
 mod i16vec2 {
     use glam::{
-        i16vec2, BVec2, I16Vec2, I16Vec3, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2,
-        UVec2,
+        i16vec2, BVec2, I16Vec2, I16Vec3, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2, UVec2,
     };
 
     glam_test!(test_align, {
@@ -2057,9 +2053,7 @@ mod i16vec2 {
 }
 
 mod u16vec2 {
-    use glam::{
-        u16vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U16Vec3, U64Vec2, UVec2,
-    };
+    use glam::{u16vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U16Vec3, U64Vec2, UVec2};
 
     glam_test!(test_align, {
         use core::mem;
@@ -2202,8 +2196,7 @@ mod u16vec2 {
 
 mod ivec2 {
     use glam::{
-        ivec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, IVec3, U16Vec2, U64Vec2, U8Vec2,
-        UVec2,
+        ivec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, IVec3, U16Vec2, U64Vec2, U8Vec2, UVec2,
     };
 
     glam_test!(test_align, {
@@ -2353,8 +2346,7 @@ mod ivec2 {
 
 mod uvec2 {
     use glam::{
-        uvec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2, UVec2,
-        UVec3,
+        uvec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2, UVec2, UVec3,
     };
 
     glam_test!(test_align, {
@@ -2489,8 +2481,7 @@ mod uvec2 {
 
 mod i64vec2 {
     use glam::{
-        i64vec2, BVec2, I16Vec2, I64Vec2, I64Vec3, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2,
-        UVec2,
+        i64vec2, BVec2, I16Vec2, I64Vec2, I64Vec3, I8Vec2, IVec2, U16Vec2, U64Vec2, U8Vec2, UVec2,
     };
 
     glam_test!(test_align, {
@@ -2574,8 +2565,7 @@ mod i64vec2 {
 
 mod u64vec2 {
     use glam::{
-        u64vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U64Vec3, U8Vec2,
-        UVec2,
+        u64vec2, BVec2, I16Vec2, I64Vec2, I8Vec2, IVec2, U16Vec2, U64Vec2, U64Vec3, U8Vec2, UVec2,
     };
 
     glam_test!(test_align, {

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -3,8 +3,290 @@
 #[macro_use]
 mod support;
 
+macro_rules! impl_bvec3_tests {
+    ($mask:ident, $masknew:ident) => {
+        glam_test!(test_mask_new, {
+            assert_eq!(
+                $mask::new(false, false, false),
+                $masknew(false, false, false)
+            );
+            assert_eq!($mask::new(true, false, false), $masknew(true, false, false));
+            assert_eq!($mask::new(false, true, true), $masknew(false, true, true));
+            assert_eq!($mask::new(false, true, false), $masknew(false, true, false));
+            assert_eq!($mask::new(true, false, true), $masknew(true, false, true));
+            assert_eq!($mask::new(true, true, true), $masknew(true, true, true));
+        });
+
+        glam_test!(test_mask_from_array_bool, {
+            assert_eq!(
+                $mask::new(false, false, false),
+                $mask::from([false, false, false])
+            );
+            assert_eq!(
+                $mask::new(true, false, false),
+                $mask::from([true, false, false])
+            );
+            assert_eq!(
+                $mask::new(false, true, true),
+                $mask::from([false, true, true])
+            );
+            assert_eq!(
+                $mask::new(false, true, false),
+                $mask::from([false, true, false])
+            );
+            assert_eq!(
+                $mask::new(true, false, true),
+                $mask::from([true, false, true])
+            );
+            assert_eq!(
+                $mask::new(true, true, true),
+                $mask::from([true, true, true])
+            );
+        });
+
+        glam_test!(test_mask_into_array_u32, {
+            assert_eq!(
+                Into::<[u32; 3]>::into($mask::new(false, false, false)),
+                [0, 0, 0]
+            );
+            assert_eq!(
+                Into::<[u32; 3]>::into($mask::new(true, false, false)),
+                [!0, 0, 0]
+            );
+            assert_eq!(
+                Into::<[u32; 3]>::into($mask::new(false, true, true)),
+                [0, !0, !0]
+            );
+            assert_eq!(
+                Into::<[u32; 3]>::into($mask::new(false, true, false)),
+                [0, !0, 0]
+            );
+            assert_eq!(
+                Into::<[u32; 3]>::into($mask::new(true, false, true)),
+                [!0, 0, !0]
+            );
+            assert_eq!(
+                Into::<[u32; 3]>::into($mask::new(true, true, true)),
+                [!0, !0, !0]
+            );
+        });
+
+        glam_test!(test_mask_into_array_bool, {
+            assert_eq!(
+                Into::<[bool; 3]>::into($mask::new(false, false, false)),
+                [false, false, false]
+            );
+            assert_eq!(
+                Into::<[bool; 3]>::into($mask::new(true, false, false)),
+                [true, false, false]
+            );
+            assert_eq!(
+                Into::<[bool; 3]>::into($mask::new(false, true, true)),
+                [false, true, true]
+            );
+            assert_eq!(
+                Into::<[bool; 3]>::into($mask::new(false, true, false)),
+                [false, true, false]
+            );
+            assert_eq!(
+                Into::<[bool; 3]>::into($mask::new(true, false, true)),
+                [true, false, true]
+            );
+            assert_eq!(
+                Into::<[bool; 3]>::into($mask::new(true, true, true)),
+                [true, true, true]
+            );
+        });
+
+        glam_test!(test_mask_splat, {
+            assert_eq!($mask::splat(false), $mask::new(false, false, false));
+            assert_eq!($mask::splat(true), $mask::new(true, true, true));
+        });
+
+        glam_test!(test_mask_bitmask, {
+            assert_eq!($mask::new(false, false, false).bitmask(), 0b000);
+            assert_eq!($mask::new(true, false, false).bitmask(), 0b001);
+            assert_eq!($mask::new(false, true, true).bitmask(), 0b110);
+            assert_eq!($mask::new(false, true, false).bitmask(), 0b010);
+            assert_eq!($mask::new(true, false, true).bitmask(), 0b101);
+            assert_eq!($mask::new(true, true, true).bitmask(), 0b111);
+        });
+
+        glam_test!(test_mask_any, {
+            assert_eq!($mask::new(false, false, false).any(), false);
+            assert_eq!($mask::new(true, false, false).any(), true);
+            assert_eq!($mask::new(false, true, false).any(), true);
+            assert_eq!($mask::new(false, false, true).any(), true);
+        });
+
+        glam_test!(test_mask_all, {
+            assert_eq!($mask::new(true, true, true).all(), true);
+            assert_eq!($mask::new(false, true, true).all(), false);
+            assert_eq!($mask::new(true, false, true).all(), false);
+            assert_eq!($mask::new(true, true, false).all(), false);
+        });
+
+        glam_test!(test_mask_and, {
+            assert_eq!(
+                ($mask::new(false, false, false) & $mask::new(false, false, false)).bitmask(),
+                0b000,
+            );
+            assert_eq!(
+                ($mask::new(true, true, true) & $mask::new(true, true, true)).bitmask(),
+                0b111,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true) & $mask::new(false, true, false)).bitmask(),
+                0b000,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true) & $mask::new(true, true, true)).bitmask(),
+                0b101,
+            );
+
+            let mut mask = $mask::new(true, true, false);
+            mask &= $mask::new(true, false, false);
+            assert_eq!(mask.bitmask(), 0b001);
+        });
+
+        glam_test!(test_mask_or, {
+            assert_eq!(
+                ($mask::new(false, false, false) | $mask::new(false, false, false)).bitmask(),
+                0b000,
+            );
+            assert_eq!(
+                ($mask::new(true, true, true) | $mask::new(true, true, true)).bitmask(),
+                0b111,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true) | $mask::new(false, true, false)).bitmask(),
+                0b111,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true) | $mask::new(true, false, true)).bitmask(),
+                0b101,
+            );
+
+            let mut mask = $mask::new(true, true, false);
+            mask |= $mask::new(true, false, false);
+            assert_eq!(mask.bitmask(), 0b011);
+        });
+
+        glam_test!(test_mask_xor, {
+            assert_eq!(
+                ($mask::new(false, false, false) ^ $mask::new(false, false, false)).bitmask(),
+                0b000,
+            );
+            assert_eq!(
+                ($mask::new(true, true, true) ^ $mask::new(true, true, true)).bitmask(),
+                0b000,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true) ^ $mask::new(false, true, false)).bitmask(),
+                0b111,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true) ^ $mask::new(true, false, true)).bitmask(),
+                0b000,
+            );
+
+            let mut mask = $mask::new(true, true, false);
+            mask ^= $mask::new(true, false, false);
+            assert_eq!(mask.bitmask(), 0b010);
+        });
+
+        glam_test!(test_mask_not, {
+            assert_eq!((!$mask::new(false, false, false)).bitmask(), 0b111);
+            assert_eq!((!$mask::new(true, true, true)).bitmask(), 0b000);
+            assert_eq!((!$mask::new(true, false, true)).bitmask(), 0b010);
+            assert_eq!((!$mask::new(false, true, false)).bitmask(), 0b101);
+        });
+
+        glam_test!(test_mask_fmt, {
+            let a = $mask::new(true, false, false);
+
+            // debug fmt
+            assert_eq!(
+                format!("{:?}", a),
+                format!("{}(0xffffffff, 0x0, 0x0)", stringify!($mask))
+            );
+
+            // display fmt
+            assert_eq!(format!("{}", a), "[true, false, false]");
+        });
+
+        glam_test!(test_mask_eq, {
+            let a = $mask::new(true, false, true);
+            let b = $mask::new(true, false, true);
+            let c = $mask::new(false, true, true);
+
+            assert_eq!(a, b);
+            assert_eq!(b, a);
+            assert_ne!(a, c);
+            assert_ne!(b, c);
+        });
+
+        glam_test!(test_mask_test, {
+            let a = $mask::new(true, false, true);
+            assert_eq!(a.test(0), true);
+            assert_eq!(a.test(1), false);
+            assert_eq!(a.test(2), true);
+
+            let b = $mask::new(false, true, false);
+            assert_eq!(b.test(0), false);
+            assert_eq!(b.test(1), true);
+            assert_eq!(b.test(2), false);
+        });
+
+        glam_test!(test_mask_set, {
+            let mut a = $mask::new(false, true, false);
+            a.set(0, true);
+            assert_eq!(a.test(0), true);
+            a.set(1, false);
+            assert_eq!(a.test(1), false);
+            a.set(2, true);
+            assert_eq!(a.test(2), true);
+
+            let mut b = $mask::new(true, false, true);
+            b.set(0, false);
+            assert_eq!(b.test(0), false);
+            b.set(1, true);
+            assert_eq!(b.test(1), true);
+            b.set(2, false);
+            assert_eq!(b.test(2), false);
+        });
+
+        glam_test!(test_mask_hash, {
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::Hash;
+            use std::hash::Hasher;
+
+            let a = $mask::new(true, false, true);
+            let b = $mask::new(true, false, true);
+            let c = $mask::new(false, true, true);
+
+            let mut hasher = DefaultHasher::new();
+            a.hash(&mut hasher);
+            let a_hashed = hasher.finish();
+
+            let mut hasher = DefaultHasher::new();
+            b.hash(&mut hasher);
+            let b_hashed = hasher.finish();
+
+            let mut hasher = DefaultHasher::new();
+            c.hash(&mut hasher);
+            let c_hashed = hasher.finish();
+
+            assert_eq!(a, b);
+            assert_eq!(a_hashed, b_hashed);
+            assert_ne!(a, c);
+            assert_ne!(a_hashed, c_hashed);
+        });
+    };
+}
+
 macro_rules! impl_vec3_tests {
-    ($t:ident, $new:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
+    ($t:ident, $new:ident, $vec3:ident, $mask:ident) => {
         glam_test!(test_const, {
             const V0: $vec3 = $vec3::splat(1 as $t);
             const V1: $vec3 = $vec3::new(1 as $t, 2 as $t, 3 as $t);
@@ -413,127 +695,6 @@ macro_rules! impl_vec3_tests {
             assert!(a.cmpeq($vec3::ONE).all());
         });
 
-        glam_test!(test_mask_new, {
-            assert_eq!(
-                $mask::new(false, false, false),
-                $masknew(false, false, false)
-            );
-            assert_eq!($mask::new(true, false, false), $masknew(true, false, false));
-            assert_eq!($mask::new(false, true, true), $masknew(false, true, true));
-            assert_eq!($mask::new(false, true, false), $masknew(false, true, false));
-            assert_eq!($mask::new(true, false, true), $masknew(true, false, true));
-            assert_eq!($mask::new(true, true, true), $masknew(true, true, true));
-        });
-
-        glam_test!(test_mask_from_array_bool, {
-            assert_eq!(
-                $mask::new(false, false, false),
-                $mask::from([false, false, false])
-            );
-            assert_eq!(
-                $mask::new(true, false, false),
-                $mask::from([true, false, false])
-            );
-            assert_eq!(
-                $mask::new(false, true, true),
-                $mask::from([false, true, true])
-            );
-            assert_eq!(
-                $mask::new(false, true, false),
-                $mask::from([false, true, false])
-            );
-            assert_eq!(
-                $mask::new(true, false, true),
-                $mask::from([true, false, true])
-            );
-            assert_eq!(
-                $mask::new(true, true, true),
-                $mask::from([true, true, true])
-            );
-        });
-
-        glam_test!(test_mask_into_array_u32, {
-            assert_eq!(
-                Into::<[u32; 3]>::into($mask::new(false, false, false)),
-                [0, 0, 0]
-            );
-            assert_eq!(
-                Into::<[u32; 3]>::into($mask::new(true, false, false)),
-                [!0, 0, 0]
-            );
-            assert_eq!(
-                Into::<[u32; 3]>::into($mask::new(false, true, true)),
-                [0, !0, !0]
-            );
-            assert_eq!(
-                Into::<[u32; 3]>::into($mask::new(false, true, false)),
-                [0, !0, 0]
-            );
-            assert_eq!(
-                Into::<[u32; 3]>::into($mask::new(true, false, true)),
-                [!0, 0, !0]
-            );
-            assert_eq!(
-                Into::<[u32; 3]>::into($mask::new(true, true, true)),
-                [!0, !0, !0]
-            );
-        });
-
-        glam_test!(test_mask_into_array_bool, {
-            assert_eq!(
-                Into::<[bool; 3]>::into($mask::new(false, false, false)),
-                [false, false, false]
-            );
-            assert_eq!(
-                Into::<[bool; 3]>::into($mask::new(true, false, false)),
-                [true, false, false]
-            );
-            assert_eq!(
-                Into::<[bool; 3]>::into($mask::new(false, true, true)),
-                [false, true, true]
-            );
-            assert_eq!(
-                Into::<[bool; 3]>::into($mask::new(false, true, false)),
-                [false, true, false]
-            );
-            assert_eq!(
-                Into::<[bool; 3]>::into($mask::new(true, false, true)),
-                [true, false, true]
-            );
-            assert_eq!(
-                Into::<[bool; 3]>::into($mask::new(true, true, true)),
-                [true, true, true]
-            );
-        });
-
-        glam_test!(test_mask_splat, {
-            assert_eq!($mask::splat(false), $mask::new(false, false, false));
-            assert_eq!($mask::splat(true), $mask::new(true, true, true));
-        });
-
-        glam_test!(test_mask_bitmask, {
-            assert_eq!($mask::new(false, false, false).bitmask(), 0b000);
-            assert_eq!($mask::new(true, false, false).bitmask(), 0b001);
-            assert_eq!($mask::new(false, true, true).bitmask(), 0b110);
-            assert_eq!($mask::new(false, true, false).bitmask(), 0b010);
-            assert_eq!($mask::new(true, false, true).bitmask(), 0b101);
-            assert_eq!($mask::new(true, true, true).bitmask(), 0b111);
-        });
-
-        glam_test!(test_mask_any, {
-            assert_eq!($mask::new(false, false, false).any(), false);
-            assert_eq!($mask::new(true, false, false).any(), true);
-            assert_eq!($mask::new(false, true, false).any(), true);
-            assert_eq!($mask::new(false, false, true).any(), true);
-        });
-
-        glam_test!(test_mask_all, {
-            assert_eq!($mask::new(true, true, true).all(), true);
-            assert_eq!($mask::new(false, true, true).all(), false);
-            assert_eq!($mask::new(true, false, true).all(), false);
-            assert_eq!($mask::new(true, true, false).all(), false);
-        });
-
         glam_test!(test_mask_select, {
             let a = $vec3::new(1 as $t, 2 as $t, 3 as $t);
             let b = $vec3::new(4 as $t, 5 as $t, 6 as $t);
@@ -553,163 +714,6 @@ macro_rules! impl_vec3_tests {
                 $vec3::select($mask::new(false, false, false), a, b),
                 $vec3::new(4 as $t, 5 as $t, 6 as $t),
             );
-        });
-
-        glam_test!(test_mask_and, {
-            assert_eq!(
-                ($mask::new(false, false, false) & $mask::new(false, false, false)).bitmask(),
-                0b000,
-            );
-            assert_eq!(
-                ($mask::new(true, true, true) & $mask::new(true, true, true)).bitmask(),
-                0b111,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true) & $mask::new(false, true, false)).bitmask(),
-                0b000,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true) & $mask::new(true, true, true)).bitmask(),
-                0b101,
-            );
-
-            let mut mask = $mask::new(true, true, false);
-            mask &= $mask::new(true, false, false);
-            assert_eq!(mask.bitmask(), 0b001);
-        });
-
-        glam_test!(test_mask_or, {
-            assert_eq!(
-                ($mask::new(false, false, false) | $mask::new(false, false, false)).bitmask(),
-                0b000,
-            );
-            assert_eq!(
-                ($mask::new(true, true, true) | $mask::new(true, true, true)).bitmask(),
-                0b111,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true) | $mask::new(false, true, false)).bitmask(),
-                0b111,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true) | $mask::new(true, false, true)).bitmask(),
-                0b101,
-            );
-
-            let mut mask = $mask::new(true, true, false);
-            mask |= $mask::new(true, false, false);
-            assert_eq!(mask.bitmask(), 0b011);
-        });
-
-        glam_test!(test_mask_xor, {
-            assert_eq!(
-                ($mask::new(false, false, false) ^ $mask::new(false, false, false)).bitmask(),
-                0b000,
-            );
-            assert_eq!(
-                ($mask::new(true, true, true) ^ $mask::new(true, true, true)).bitmask(),
-                0b000,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true) ^ $mask::new(false, true, false)).bitmask(),
-                0b111,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true) ^ $mask::new(true, false, true)).bitmask(),
-                0b000,
-            );
-
-            let mut mask = $mask::new(true, true, false);
-            mask ^= $mask::new(true, false, false);
-            assert_eq!(mask.bitmask(), 0b010);
-        });
-
-        glam_test!(test_mask_not, {
-            assert_eq!((!$mask::new(false, false, false)).bitmask(), 0b111);
-            assert_eq!((!$mask::new(true, true, true)).bitmask(), 0b000);
-            assert_eq!((!$mask::new(true, false, true)).bitmask(), 0b010);
-            assert_eq!((!$mask::new(false, true, false)).bitmask(), 0b101);
-        });
-
-        glam_test!(test_mask_fmt, {
-            let a = $mask::new(true, false, false);
-
-            // debug fmt
-            assert_eq!(
-                format!("{:?}", a),
-                format!("{}(0xffffffff, 0x0, 0x0)", stringify!($mask))
-            );
-
-            // display fmt
-            assert_eq!(format!("{}", a), "[true, false, false]");
-        });
-
-        glam_test!(test_mask_eq, {
-            let a = $mask::new(true, false, true);
-            let b = $mask::new(true, false, true);
-            let c = $mask::new(false, true, true);
-
-            assert_eq!(a, b);
-            assert_eq!(b, a);
-            assert_ne!(a, c);
-            assert_ne!(b, c);
-        });
-
-        glam_test!(test_mask_test, {
-            let a = $mask::new(true, false, true);
-            assert_eq!(a.test(0), true);
-            assert_eq!(a.test(1), false);
-            assert_eq!(a.test(2), true);
-
-            let b = $mask::new(false, true, false);
-            assert_eq!(b.test(0), false);
-            assert_eq!(b.test(1), true);
-            assert_eq!(b.test(2), false);
-        });
-
-        glam_test!(test_mask_set, {
-            let mut a = $mask::new(false, true, false);
-            a.set(0, true);
-            assert_eq!(a.test(0), true);
-            a.set(1, false);
-            assert_eq!(a.test(1), false);
-            a.set(2, true);
-            assert_eq!(a.test(2), true);
-
-            let mut b = $mask::new(true, false, true);
-            b.set(0, false);
-            assert_eq!(b.test(0), false);
-            b.set(1, true);
-            assert_eq!(b.test(1), true);
-            b.set(2, false);
-            assert_eq!(b.test(2), false);
-        });
-
-        glam_test!(test_mask_hash, {
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::Hash;
-            use std::hash::Hasher;
-
-            let a = $mask::new(true, false, true);
-            let b = $mask::new(true, false, true);
-            let c = $mask::new(false, true, true);
-
-            let mut hasher = DefaultHasher::new();
-            a.hash(&mut hasher);
-            let a_hashed = hasher.finish();
-
-            let mut hasher = DefaultHasher::new();
-            b.hash(&mut hasher);
-            let b_hashed = hasher.finish();
-
-            let mut hasher = DefaultHasher::new();
-            c.hash(&mut hasher);
-            let c_hashed = hasher.finish();
-
-            assert_eq!(a, b);
-            assert_eq!(a_hashed, b_hashed);
-            assert_ne!(a, c);
-            assert_ne!(a_hashed, c_hashed);
         });
 
         glam_test!(test_to_from_slice, {
@@ -742,8 +746,8 @@ macro_rules! impl_vec3_tests {
 }
 
 macro_rules! impl_vec3_signed_tests {
-    ($t:ident, $new:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
-        impl_vec3_tests!($t, $new, $vec3, $mask, $masknew);
+    ($t:ident, $new:ident, $vec3:ident, $mask:ident) => {
+        impl_vec3_tests!($t, $new, $vec3, $mask);
 
         glam_test!(test_neg, {
             let a = $new(1 as $t, 2 as $t, 3 as $t);
@@ -841,8 +845,8 @@ macro_rules! impl_vec3_signed_tests {
 }
 
 macro_rules! impl_vec3_signed_integer_tests {
-    ($t:ident, $new:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
-        impl_vec3_signed_tests!($t, $new, $vec3, $mask, $masknew);
+    ($t:ident, $new:ident, $vec3:ident, $mask:ident) => {
+        impl_vec3_signed_tests!($t, $new, $vec3, $mask);
 
         glam_test!(test_signum, {
             assert_eq!($vec3::ZERO.signum(), $vec3::ZERO);
@@ -945,8 +949,8 @@ macro_rules! impl_vec3_signed_integer_tests {
 }
 
 macro_rules! impl_vec3_unsigned_integer_tests {
-    ($t:ident, $new:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
-        impl_vec3_tests!($t, $new, $vec3, $mask, $masknew);
+    ($t:ident, $new:ident, $vec3:ident, $mask:ident) => {
+        impl_vec3_tests!($t, $new, $vec3, $mask);
 
         glam_test!(test_checked_add, {
             assert_eq!($vec3::MAX.checked_add($vec3::ONE), None);
@@ -1055,8 +1059,8 @@ macro_rules! impl_vec3_eq_hash_tests {
 }
 
 macro_rules! impl_vec3_float_tests {
-    ($t:ident, $new:ident, $vec3:ident, $mask:ident, $masknew:ident) => {
-        impl_vec3_signed_tests!($t, $new, $vec3, $mask, $masknew);
+    ($t:ident, $new:ident, $vec3:ident, $mask:ident) => {
+        impl_vec3_signed_tests!($t, $new, $vec3, $mask);
         impl_vec_float_normalize_tests!($t, $vec3);
 
         glam_test!(test_nan, {
@@ -1624,8 +1628,18 @@ macro_rules! impl_vec3_bit_op_tests {
     };
 }
 
+mod bvec3 {
+    use glam::{bvec3, BVec3};
+    impl_bvec3_tests!(BVec3, bvec3);
+}
+
+mod bvec3a {
+    use glam::{bvec3a, BVec3A};
+    impl_bvec3_tests!(BVec3A, bvec3a);
+}
+
 mod vec3 {
-    use glam::{bvec3, vec3, BVec3, Vec3};
+    use glam::{vec3, BVec3, Vec3};
 
     glam_test!(test_align, {
         use std::mem;
@@ -1879,11 +1893,11 @@ mod vec3 {
         assert_eq!(Vec3A::new(1.0, 2.0, 3.0), U64Vec3::new(1, 2, 3).as_vec3a());
     });
 
-    impl_vec3_float_tests!(f32, vec3, Vec3, BVec3, bvec3);
+    impl_vec3_float_tests!(f32, vec3, Vec3, BVec3);
 }
 
 mod vec3a {
-    use glam::{bvec3a, vec3a, BVec3A, Vec3A, Vec4};
+    use glam::{vec3a, BVec3A, Vec3A, Vec4};
 
     glam_test!(test_align, {
         use std::mem;
@@ -1948,11 +1962,11 @@ mod vec3a {
         assert_eq!(v2.min_element(), 2.0);
     });
 
-    impl_vec3_float_tests!(f32, vec3a, Vec3A, BVec3A, bvec3a);
+    impl_vec3_float_tests!(f32, vec3a, Vec3A, BVec3A);
 }
 
 mod dvec3 {
-    use glam::{bvec3, dvec3, BVec3, DVec3, IVec3, UVec3, Vec3};
+    use glam::{dvec3, BVec3, DVec3, IVec3, UVec3, Vec3};
 
     glam_test!(test_align, {
         use std::mem;
@@ -1971,13 +1985,11 @@ mod dvec3 {
         assert_eq!(DVec3::new(1.0, 2.0, 3.0), DVec3::from(UVec3::new(1, 2, 3)));
     });
 
-    impl_vec3_float_tests!(f64, dvec3, DVec3, BVec3, bvec3);
+    impl_vec3_float_tests!(f64, dvec3, DVec3, BVec3);
 }
 
 mod i8vec3 {
-    use glam::{
-        bvec3, i8vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3,
-    };
+    use glam::{i8vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3};
 
     glam_test!(test_align, {
         use std::mem;
@@ -2143,7 +2155,7 @@ mod i8vec3 {
         );
     });
 
-    impl_vec3_signed_integer_tests!(i8, i8vec3, I8Vec3, BVec3, bvec3);
+    impl_vec3_signed_integer_tests!(i8, i8vec3, I8Vec3, BVec3);
     impl_vec3_eq_hash_tests!(i8, i8vec3);
 
     impl_vec3_scalar_shift_op_tests!(I8Vec3, -2, 2);
@@ -2154,9 +2166,7 @@ mod i8vec3 {
 }
 
 mod u8vec3 {
-    use glam::{
-        bvec3, u8vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3,
-    };
+    use glam::{u8vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3};
 
     glam_test!(test_align, {
         use std::mem;
@@ -2304,7 +2314,7 @@ mod u8vec3 {
         );
     });
 
-    impl_vec3_unsigned_integer_tests!(u8, u8vec3, U8Vec3, BVec3, bvec3);
+    impl_vec3_unsigned_integer_tests!(u8, u8vec3, U8Vec3, BVec3);
     impl_vec3_eq_hash_tests!(u8, u8vec3);
 
     impl_vec3_scalar_shift_op_tests!(U8Vec3, 0, 2);
@@ -2315,9 +2325,7 @@ mod u8vec3 {
 }
 
 mod i16vec3 {
-    use glam::{
-        bvec3, i16vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3,
-    };
+    use glam::{i16vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3};
 
     glam_test!(test_align, {
         use std::mem;
@@ -2472,7 +2480,7 @@ mod i16vec3 {
         );
     });
 
-    impl_vec3_signed_integer_tests!(i16, i16vec3, I16Vec3, BVec3, bvec3);
+    impl_vec3_signed_integer_tests!(i16, i16vec3, I16Vec3, BVec3);
     impl_vec3_eq_hash_tests!(i16, i16vec3);
 
     impl_vec3_scalar_shift_op_tests!(I16Vec3, -2, 2);
@@ -2483,9 +2491,7 @@ mod i16vec3 {
 }
 
 mod u16vec3 {
-    use glam::{
-        bvec3, u16vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3,
-    };
+    use glam::{u16vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3};
 
     glam_test!(test_align, {
         use std::mem;
@@ -2623,7 +2629,7 @@ mod u16vec3 {
         );
     });
 
-    impl_vec3_unsigned_integer_tests!(u16, u16vec3, U16Vec3, BVec3, bvec3);
+    impl_vec3_unsigned_integer_tests!(u16, u16vec3, U16Vec3, BVec3);
     impl_vec3_eq_hash_tests!(u16, u16vec3);
 
     impl_vec3_scalar_shift_op_tests!(U16Vec3, 0, 2);
@@ -2634,9 +2640,7 @@ mod u16vec3 {
 }
 
 mod ivec3 {
-    use glam::{
-        bvec3, ivec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3,
-    };
+    use glam::{ivec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3};
 
     glam_test!(test_align, {
         use std::mem;
@@ -2778,7 +2782,7 @@ mod ivec3 {
         );
     });
 
-    impl_vec3_signed_integer_tests!(i32, ivec3, IVec3, BVec3, bvec3);
+    impl_vec3_signed_integer_tests!(i32, ivec3, IVec3, BVec3);
     impl_vec3_eq_hash_tests!(i32, ivec3);
 
     impl_vec3_scalar_shift_op_tests!(IVec3, -2, 2);
@@ -2789,9 +2793,7 @@ mod ivec3 {
 }
 
 mod uvec3 {
-    use glam::{
-        bvec3, uvec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3,
-    };
+    use glam::{uvec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3};
 
     glam_test!(test_align, {
         use std::mem;
@@ -2921,7 +2923,7 @@ mod uvec3 {
         );
     });
 
-    impl_vec3_unsigned_integer_tests!(u32, uvec3, UVec3, BVec3, bvec3);
+    impl_vec3_unsigned_integer_tests!(u32, uvec3, UVec3, BVec3);
     impl_vec3_eq_hash_tests!(u32, uvec3);
 
     impl_vec3_scalar_shift_op_tests!(UVec3, 0, 2);
@@ -2932,9 +2934,7 @@ mod uvec3 {
 }
 
 mod i64vec3 {
-    use glam::{
-        bvec3, i64vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3,
-    };
+    use glam::{i64vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3};
 
     glam_test!(test_align, {
         use std::mem;
@@ -3007,7 +3007,7 @@ mod i64vec3 {
         );
     });
 
-    impl_vec3_signed_integer_tests!(i64, i64vec3, I64Vec3, BVec3, bvec3);
+    impl_vec3_signed_integer_tests!(i64, i64vec3, I64Vec3, BVec3);
     impl_vec3_eq_hash_tests!(i64, i64vec3);
 
     impl_vec3_scalar_shift_op_tests!(I64Vec3, -2, 2);
@@ -3018,9 +3018,7 @@ mod i64vec3 {
 }
 
 mod u64vec3 {
-    use glam::{
-        bvec3, u64vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3,
-    };
+    use glam::{u64vec3, BVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, UVec3};
 
     glam_test!(test_align, {
         use std::mem;
@@ -3084,7 +3082,7 @@ mod u64vec3 {
         );
     });
 
-    impl_vec3_unsigned_integer_tests!(u64, u64vec3, U64Vec3, BVec3, bvec3);
+    impl_vec3_unsigned_integer_tests!(u64, u64vec3, U64Vec3, BVec3);
     impl_vec3_eq_hash_tests!(u64, u64vec3);
 
     impl_vec3_scalar_shift_op_tests!(U64Vec3, 0, 2);

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -686,16 +686,7 @@ macro_rules! impl_vec3_tests {
             assert_eq!(a, c);
         });
 
-        glam_test!(test_mask, {
-            let mut a = $vec3::ZERO;
-            a.x = 1 as $t;
-            a.y = 1 as $t;
-            a.z = 1 as $t;
-            assert!(!a.cmpeq($vec3::ZERO).any());
-            assert!(a.cmpeq($vec3::ONE).all());
-        });
-
-        glam_test!(test_mask_select, {
+        glam_test!(test_select, {
             let a = $vec3::new(1 as $t, 2 as $t, 3 as $t);
             let b = $vec3::new(4 as $t, 5 as $t, 6 as $t);
             assert_eq!(
@@ -1630,11 +1621,25 @@ macro_rules! impl_vec3_bit_op_tests {
 
 mod bvec3 {
     use glam::{bvec3, BVec3};
+
+    glam_test!(test_mask_align, {
+        use std::mem;
+        assert_eq!(3, mem::size_of::<BVec3>());
+        assert_eq!(1, mem::align_of::<BVec3>());
+    });
+
     impl_bvec3_tests!(BVec3, bvec3);
 }
 
 mod bvec3a {
     use glam::{bvec3a, BVec3A};
+
+    glam_test!(test_mask_align, {
+        use std::mem;
+        assert_eq!(16, mem::size_of::<BVec3A>());
+        assert_eq!(16, mem::align_of::<BVec3A>());
+    });
+
     impl_bvec3_tests!(BVec3A, bvec3a);
 }
 
@@ -1645,8 +1650,6 @@ mod vec3 {
         use std::mem;
         assert_eq!(12, mem::size_of::<Vec3>());
         assert_eq!(4, mem::align_of::<Vec3>());
-        assert_eq!(3, mem::size_of::<BVec3>());
-        assert_eq!(1, mem::align_of::<BVec3>());
     });
 
     glam_test!(test_as, {
@@ -1903,8 +1906,6 @@ mod vec3a {
         use std::mem;
         assert_eq!(16, mem::size_of::<Vec3A>());
         assert_eq!(16, mem::align_of::<Vec3A>());
-        assert_eq!(16, mem::size_of::<BVec3A>());
-        assert_eq!(16, mem::align_of::<BVec3A>());
     });
 
     glam_test!(test_mask_align16, {
@@ -1972,8 +1973,6 @@ mod dvec3 {
         use std::mem;
         assert_eq!(24, mem::size_of::<DVec3>());
         assert_eq!(mem::align_of::<f64>(), mem::align_of::<DVec3>());
-        assert_eq!(3, mem::size_of::<BVec3>());
-        assert_eq!(1, mem::align_of::<BVec3>());
     });
 
     glam_test!(test_try_from, {
@@ -2646,8 +2645,6 @@ mod ivec3 {
         use std::mem;
         assert_eq!(12, mem::size_of::<IVec3>());
         assert_eq!(4, mem::align_of::<IVec3>());
-        assert_eq!(3, mem::size_of::<BVec3>());
-        assert_eq!(1, mem::align_of::<BVec3>());
     });
 
     glam_test!(test_try_from, {
@@ -2799,8 +2796,6 @@ mod uvec3 {
         use std::mem;
         assert_eq!(12, mem::size_of::<UVec3>());
         assert_eq!(4, mem::align_of::<UVec3>());
-        assert_eq!(3, mem::size_of::<BVec3>());
-        assert_eq!(1, mem::align_of::<BVec3>());
     });
 
     glam_test!(test_try_from, {
@@ -2940,8 +2935,6 @@ mod i64vec3 {
         use std::mem;
         assert_eq!(24, mem::size_of::<I64Vec3>());
         assert_eq!(8, mem::align_of::<I64Vec3>());
-        assert_eq!(3, mem::size_of::<BVec3>());
-        assert_eq!(1, mem::align_of::<BVec3>());
     });
 
     glam_test!(test_try_from, {
@@ -3024,8 +3017,6 @@ mod u64vec3 {
         use std::mem;
         assert_eq!(24, mem::size_of::<U64Vec3>());
         assert_eq!(8, mem::align_of::<U64Vec3>());
-        assert_eq!(3, mem::size_of::<BVec3>());
-        assert_eq!(1, mem::align_of::<BVec3>());
     });
 
     glam_test!(test_try_from, {

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -801,7 +801,7 @@ macro_rules! impl_vec4_tests {
             assert!(a == a);
         });
 
-        glam_test!(test_mask_select, {
+        glam_test!(test_select, {
             let a = $vec4::new(1 as $t, 2 as $t, 3 as $t, 4 as $t);
             let b = $vec4::new(5 as $t, 6 as $t, 7 as $t, 8 as $t);
             assert_eq!(
@@ -1720,11 +1720,25 @@ macro_rules! impl_vec4_bit_op_tests {
 
 mod bvec4 {
     use glam::{bvec4, BVec4};
+
+    glam_test!(test_mask_align, {
+        use std::mem;
+        assert_eq!(4, mem::size_of::<BVec4>());
+        assert_eq!(1, mem::align_of::<BVec4>());
+    });
+
     impl_bvec4_tests!(BVec4, bvec4);
 }
 
 mod bvec4a {
     use glam::{bvec4a, BVec4A};
+
+    glam_test!(test_mask_align, {
+        use std::mem;
+        assert_eq!(16, mem::size_of::<BVec4A>());
+        assert_eq!(16, mem::align_of::<BVec4A>());
+    });
+
     impl_bvec4_tests!(BVec4A, bvec4a);
 }
 
@@ -1742,16 +1756,6 @@ mod vec4 {
             assert_eq!(16, mem::align_of::<Vec4>());
         } else {
             assert_eq!(4, mem::align_of::<Vec4>());
-        }
-        #[cfg(not(feature = "scalar-math"))]
-        {
-            assert_eq!(16, mem::size_of::<BVec4A>());
-            assert_eq!(16, mem::align_of::<BVec4A>());
-        }
-        #[cfg(feature = "scalar-math")]
-        {
-            assert_eq!(4, mem::size_of::<BVec4>());
-            assert_eq!(1, mem::align_of::<BVec4>());
         }
     });
 
@@ -2145,8 +2149,6 @@ mod dvec4 {
         assert_eq!(mem::align_of::<f64>(), mem::align_of::<DVec4>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<DVec4>());
-        assert_eq!(4, mem::size_of::<BVec4>());
-        assert_eq!(1, mem::align_of::<BVec4>());
     });
 
     glam_test!(test_try_from, {
@@ -2909,8 +2911,6 @@ mod ivec4 {
         assert_eq!(4, mem::align_of::<IVec4>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<IVec4>());
-        assert_eq!(4, mem::size_of::<BVec4>());
-        assert_eq!(1, mem::align_of::<BVec4>());
     });
 
     glam_test!(test_try_from, {
@@ -3081,8 +3081,6 @@ mod uvec4 {
         assert_eq!(4, mem::align_of::<UVec4>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<UVec4>());
-        assert_eq!(4, mem::size_of::<BVec4>());
-        assert_eq!(1, mem::align_of::<BVec4>());
     });
 
     glam_test!(test_try_from, {
@@ -3239,8 +3237,6 @@ mod i64vec4 {
         assert_eq!(8, mem::align_of::<I64Vec4>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<I64Vec4>());
-        assert_eq!(4, mem::size_of::<BVec4>());
-        assert_eq!(1, mem::align_of::<BVec4>());
     });
 
     glam_test!(test_try_from, {
@@ -3350,8 +3346,6 @@ mod u64vec4 {
         assert_eq!(8, mem::align_of::<U64Vec4>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<U64Vec4>());
-        assert_eq!(4, mem::size_of::<BVec4>());
-        assert_eq!(1, mem::align_of::<BVec4>());
     });
 
     glam_test!(test_try_from, {

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -3,8 +3,319 @@
 #[macro_use]
 mod support;
 
+macro_rules! impl_bvec4_tests {
+    ($mask:ident, $masknew:ident) => {
+        glam_test!(test_mask_new, {
+            assert_eq!(
+                $mask::new(false, false, false, false),
+                $masknew(false, false, false, false)
+            );
+            assert_eq!(
+                $mask::new(false, false, true, true),
+                $masknew(false, false, true, true)
+            );
+            assert_eq!(
+                $mask::new(true, true, false, false),
+                $masknew(true, true, false, false)
+            );
+            assert_eq!(
+                $mask::new(false, true, false, true),
+                $masknew(false, true, false, true)
+            );
+            assert_eq!(
+                $mask::new(true, false, true, false),
+                $masknew(true, false, true, false)
+            );
+            assert_eq!(
+                $mask::new(true, true, true, true),
+                $masknew(true, true, true, true)
+            );
+        });
+
+        glam_test!(test_mask_from_array_bool, {
+            assert_eq!(
+                $mask::new(false, false, false, false),
+                $mask::from([false, false, false, false])
+            );
+            assert_eq!(
+                $mask::new(false, false, true, true),
+                $mask::from([false, false, true, true])
+            );
+            assert_eq!(
+                $mask::new(true, true, false, false),
+                $mask::from([true, true, false, false])
+            );
+            assert_eq!(
+                $mask::new(false, true, false, true),
+                $mask::from([false, true, false, true])
+            );
+            assert_eq!(
+                $mask::new(true, false, true, false),
+                $mask::from([true, false, true, false])
+            );
+            assert_eq!(
+                $mask::new(true, true, true, true),
+                $mask::from([true, true, true, true])
+            );
+        });
+
+        glam_test!(test_mask_into_array_u32, {
+            assert_eq!(
+                Into::<[u32; 4]>::into($mask::new(false, false, false, false)),
+                [0, 0, 0, 0]
+            );
+            assert_eq!(
+                Into::<[u32; 4]>::into($mask::new(false, false, true, true)),
+                [0, 0, !0, !0]
+            );
+            assert_eq!(
+                Into::<[u32; 4]>::into($mask::new(true, true, false, false)),
+                [!0, !0, 0, 0]
+            );
+            assert_eq!(
+                Into::<[u32; 4]>::into($mask::new(false, true, false, true)),
+                [0, !0, 0, !0]
+            );
+            assert_eq!(
+                Into::<[u32; 4]>::into($mask::new(true, false, true, false)),
+                [!0, 0, !0, 0]
+            );
+            assert_eq!(
+                Into::<[u32; 4]>::into($mask::new(true, true, true, true)),
+                [!0, !0, !0, !0]
+            );
+        });
+
+        glam_test!(test_mask_into_array_bool, {
+            assert_eq!(
+                Into::<[bool; 4]>::into($mask::new(false, false, false, false)),
+                [false, false, false, false]
+            );
+            assert_eq!(
+                Into::<[bool; 4]>::into($mask::new(false, false, true, true)),
+                [false, false, true, true]
+            );
+            assert_eq!(
+                Into::<[bool; 4]>::into($mask::new(true, true, false, false)),
+                [true, true, false, false]
+            );
+            assert_eq!(
+                Into::<[bool; 4]>::into($mask::new(false, true, false, true)),
+                [false, true, false, true]
+            );
+            assert_eq!(
+                Into::<[bool; 4]>::into($mask::new(true, false, true, false)),
+                [true, false, true, false]
+            );
+            assert_eq!(
+                Into::<[bool; 4]>::into($mask::new(true, true, true, true)),
+                [true, true, true, true]
+            );
+        });
+
+        glam_test!(test_mask_splat, {
+            assert_eq!($mask::splat(false), $mask::new(false, false, false, false));
+            assert_eq!($mask::splat(true), $mask::new(true, true, true, true));
+        });
+
+        glam_test!(test_mask_bitmask, {
+            assert_eq!($mask::new(false, false, false, false).bitmask(), 0b0000);
+            assert_eq!($mask::new(false, false, true, true).bitmask(), 0b1100);
+            assert_eq!($mask::new(true, true, false, false).bitmask(), 0b0011);
+            assert_eq!($mask::new(false, true, false, true).bitmask(), 0b1010);
+            assert_eq!($mask::new(true, false, true, false).bitmask(), 0b0101);
+            assert_eq!($mask::new(true, true, true, true).bitmask(), 0b1111);
+        });
+
+        glam_test!(test_mask_any, {
+            assert_eq!($mask::new(false, false, false, false).any(), false);
+            assert_eq!($mask::new(true, false, false, false).any(), true);
+            assert_eq!($mask::new(false, true, false, false).any(), true);
+            assert_eq!($mask::new(false, false, true, false).any(), true);
+            assert_eq!($mask::new(false, false, false, true).any(), true);
+        });
+
+        glam_test!(test_mask_all, {
+            assert_eq!($mask::new(true, true, true, true).all(), true);
+            assert_eq!($mask::new(false, true, true, true).all(), false);
+            assert_eq!($mask::new(true, false, true, true).all(), false);
+            assert_eq!($mask::new(true, true, false, true).all(), false);
+            assert_eq!($mask::new(true, true, true, false).all(), false);
+        });
+
+        glam_test!(test_mask_and, {
+            assert_eq!(
+                ($mask::new(false, false, false, false) & $mask::new(false, false, false, false))
+                    .bitmask(),
+                0b0000,
+            );
+            assert_eq!(
+                ($mask::new(true, true, true, true) & $mask::new(true, true, true, true)).bitmask(),
+                0b1111,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true, false) & $mask::new(false, true, false, true))
+                    .bitmask(),
+                0b0000,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true, true) & $mask::new(true, true, true, false))
+                    .bitmask(),
+                0b0101,
+            );
+
+            let mut mask = $mask::new(true, true, false, false);
+            mask &= $mask::new(true, false, true, false);
+            assert_eq!(mask.bitmask(), 0b0001);
+        });
+
+        glam_test!(test_mask_or, {
+            assert_eq!(
+                ($mask::new(false, false, false, false) | $mask::new(false, false, false, false))
+                    .bitmask(),
+                0b0000,
+            );
+            assert_eq!(
+                ($mask::new(true, true, true, true) | $mask::new(true, true, true, true)).bitmask(),
+                0b1111,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true, false) | $mask::new(false, true, false, true))
+                    .bitmask(),
+                0b1111,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true, false) | $mask::new(true, false, true, false))
+                    .bitmask(),
+                0b0101,
+            );
+
+            let mut mask = $mask::new(true, true, false, false);
+            mask |= $mask::new(true, false, true, false);
+            assert_eq!(mask.bitmask(), 0b0111);
+        });
+
+        glam_test!(test_mask_xor, {
+            assert_eq!(
+                ($mask::new(false, false, false, false) ^ $mask::new(false, false, false, false))
+                    .bitmask(),
+                0b0000,
+            );
+            assert_eq!(
+                ($mask::new(true, true, true, true) ^ $mask::new(true, true, true, true)).bitmask(),
+                0b0000,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true, false) ^ $mask::new(false, true, false, true))
+                    .bitmask(),
+                0b1111,
+            );
+            assert_eq!(
+                ($mask::new(true, false, true, false) ^ $mask::new(true, false, true, false))
+                    .bitmask(),
+                0b0000,
+            );
+
+            let mut mask = $mask::new(true, true, false, false);
+            mask ^= $mask::new(true, false, true, false);
+            assert_eq!(mask.bitmask(), 0b0110);
+        });
+
+        glam_test!(test_mask_not, {
+            assert_eq!((!$mask::new(false, false, false, false)).bitmask(), 0b1111);
+            assert_eq!((!$mask::new(true, true, true, true)).bitmask(), 0b0000);
+            assert_eq!((!$mask::new(true, false, true, false)).bitmask(), 0b1010);
+            assert_eq!((!$mask::new(false, true, false, true)).bitmask(), 0b0101);
+        });
+
+        glam_test!(test_mask_fmt, {
+            let a = $mask::new(true, false, true, false);
+
+            assert_eq!(format!("{}", a), "[true, false, true, false]");
+            assert_eq!(
+                format!("{:?}", a),
+                format!("{}(0xffffffff, 0x0, 0xffffffff, 0x0)", stringify!($mask))
+            );
+        });
+
+        glam_test!(test_mask_eq, {
+            let a = $mask::new(true, false, true, false);
+            let b = $mask::new(true, false, true, false);
+            let c = $mask::new(false, true, true, false);
+
+            assert_eq!(a, b);
+            assert_eq!(b, a);
+            assert_ne!(a, c);
+            assert_ne!(b, c);
+        });
+
+        glam_test!(test_mask_test, {
+            let a = $mask::new(true, false, true, false);
+            assert_eq!(a.test(0), true);
+            assert_eq!(a.test(1), false);
+            assert_eq!(a.test(2), true);
+            assert_eq!(a.test(3), false);
+
+            let b = $mask::new(false, true, false, true);
+            assert_eq!(b.test(0), false);
+            assert_eq!(b.test(1), true);
+            assert_eq!(b.test(2), false);
+            assert_eq!(b.test(3), true);
+        });
+
+        glam_test!(test_mask_set, {
+            let mut a = $mask::new(false, true, false, true);
+            a.set(0, true);
+            assert_eq!(a.test(0), true);
+            a.set(1, false);
+            assert_eq!(a.test(1), false);
+            a.set(2, true);
+            assert_eq!(a.test(2), true);
+            a.set(3, false);
+            assert_eq!(a.test(3), false);
+
+            let mut b = $mask::new(true, false, true, false);
+            b.set(0, false);
+            assert_eq!(b.test(0), false);
+            b.set(1, true);
+            assert_eq!(b.test(1), true);
+            b.set(2, false);
+            assert_eq!(b.test(2), false);
+            b.set(3, true);
+            assert_eq!(b.test(3), true);
+        });
+
+        glam_test!(test_mask_hash, {
+            use std::collections::hash_map::DefaultHasher;
+            use std::hash::Hash;
+            use std::hash::Hasher;
+
+            let a = $mask::new(true, false, true, false);
+            let b = $mask::new(true, false, true, false);
+            let c = $mask::new(false, true, true, false);
+
+            let mut hasher = DefaultHasher::new();
+            a.hash(&mut hasher);
+            let a_hashed = hasher.finish();
+
+            let mut hasher = DefaultHasher::new();
+            b.hash(&mut hasher);
+            let b_hashed = hasher.finish();
+
+            let mut hasher = DefaultHasher::new();
+            c.hash(&mut hasher);
+            let c_hashed = hasher.finish();
+
+            assert_eq!(a, b);
+            assert_eq!(a_hashed, b_hashed);
+            assert_ne!(a, c);
+            assert_ne!(a_hashed, c_hashed);
+        });
+    };
+}
+
 macro_rules! impl_vec4_tests {
-    ($t:ident, $new:ident, $vec4:ident, $vec3:ident, $vec2:ident, $mask:ident, $masknew:ident) => {
+    ($t:ident, $new:ident, $vec4:ident, $vec3:ident, $vec2:ident, $mask:ident) => {
         glam_test!(test_const, {
             const V0: $vec4 = $vec4::splat(1 as $t);
             const V1: $vec4 = $vec4::new(1 as $t, 2 as $t, 3 as $t, 4 as $t);
@@ -490,157 +801,6 @@ macro_rules! impl_vec4_tests {
             assert!(a == a);
         });
 
-        glam_test!(test_slice, {
-            let a = [1 as $t, 2 as $t, 3 as $t, 4 as $t];
-            let b = $vec4::from_slice(&a);
-            let c: [$t; 4] = b.into();
-            assert_eq!(a, c);
-            let mut d = [0 as $t, 0 as $t, 0 as $t, 0 as $t];
-            b.write_to_slice(&mut d[..]);
-            assert_eq!(a, d);
-
-            should_panic!({ $vec4::ONE.write_to_slice(&mut [0 as $t; 3]) });
-            should_panic!({ $vec4::from_slice(&[0 as $t; 3]) });
-        });
-
-        glam_test!(test_mask_new, {
-            assert_eq!(
-                $mask::new(false, false, false, false),
-                $masknew(false, false, false, false)
-            );
-            assert_eq!(
-                $mask::new(false, false, true, true),
-                $masknew(false, false, true, true)
-            );
-            assert_eq!(
-                $mask::new(true, true, false, false),
-                $masknew(true, true, false, false)
-            );
-            assert_eq!(
-                $mask::new(false, true, false, true),
-                $masknew(false, true, false, true)
-            );
-            assert_eq!(
-                $mask::new(true, false, true, false),
-                $masknew(true, false, true, false)
-            );
-            assert_eq!(
-                $mask::new(true, true, true, true),
-                $masknew(true, true, true, true)
-            );
-        });
-
-        glam_test!(test_mask_from_array_bool, {
-            assert_eq!(
-                $mask::new(false, false, false, false),
-                $mask::from([false, false, false, false])
-            );
-            assert_eq!(
-                $mask::new(false, false, true, true),
-                $mask::from([false, false, true, true])
-            );
-            assert_eq!(
-                $mask::new(true, true, false, false),
-                $mask::from([true, true, false, false])
-            );
-            assert_eq!(
-                $mask::new(false, true, false, true),
-                $mask::from([false, true, false, true])
-            );
-            assert_eq!(
-                $mask::new(true, false, true, false),
-                $mask::from([true, false, true, false])
-            );
-            assert_eq!(
-                $mask::new(true, true, true, true),
-                $mask::from([true, true, true, true])
-            );
-        });
-
-        glam_test!(test_mask_into_array_u32, {
-            assert_eq!(
-                Into::<[u32; 4]>::into($mask::new(false, false, false, false)),
-                [0, 0, 0, 0]
-            );
-            assert_eq!(
-                Into::<[u32; 4]>::into($mask::new(false, false, true, true)),
-                [0, 0, !0, !0]
-            );
-            assert_eq!(
-                Into::<[u32; 4]>::into($mask::new(true, true, false, false)),
-                [!0, !0, 0, 0]
-            );
-            assert_eq!(
-                Into::<[u32; 4]>::into($mask::new(false, true, false, true)),
-                [0, !0, 0, !0]
-            );
-            assert_eq!(
-                Into::<[u32; 4]>::into($mask::new(true, false, true, false)),
-                [!0, 0, !0, 0]
-            );
-            assert_eq!(
-                Into::<[u32; 4]>::into($mask::new(true, true, true, true)),
-                [!0, !0, !0, !0]
-            );
-        });
-
-        glam_test!(test_mask_into_array_bool, {
-            assert_eq!(
-                Into::<[bool; 4]>::into($mask::new(false, false, false, false)),
-                [false, false, false, false]
-            );
-            assert_eq!(
-                Into::<[bool; 4]>::into($mask::new(false, false, true, true)),
-                [false, false, true, true]
-            );
-            assert_eq!(
-                Into::<[bool; 4]>::into($mask::new(true, true, false, false)),
-                [true, true, false, false]
-            );
-            assert_eq!(
-                Into::<[bool; 4]>::into($mask::new(false, true, false, true)),
-                [false, true, false, true]
-            );
-            assert_eq!(
-                Into::<[bool; 4]>::into($mask::new(true, false, true, false)),
-                [true, false, true, false]
-            );
-            assert_eq!(
-                Into::<[bool; 4]>::into($mask::new(true, true, true, true)),
-                [true, true, true, true]
-            );
-        });
-
-        glam_test!(test_mask_splat, {
-            assert_eq!($mask::splat(false), $mask::new(false, false, false, false));
-            assert_eq!($mask::splat(true), $mask::new(true, true, true, true));
-        });
-
-        glam_test!(test_mask_bitmask, {
-            assert_eq!($mask::new(false, false, false, false).bitmask(), 0b0000);
-            assert_eq!($mask::new(false, false, true, true).bitmask(), 0b1100);
-            assert_eq!($mask::new(true, true, false, false).bitmask(), 0b0011);
-            assert_eq!($mask::new(false, true, false, true).bitmask(), 0b1010);
-            assert_eq!($mask::new(true, false, true, false).bitmask(), 0b0101);
-            assert_eq!($mask::new(true, true, true, true).bitmask(), 0b1111);
-        });
-
-        glam_test!(test_mask_any, {
-            assert_eq!($mask::new(false, false, false, false).any(), false);
-            assert_eq!($mask::new(true, false, false, false).any(), true);
-            assert_eq!($mask::new(false, true, false, false).any(), true);
-            assert_eq!($mask::new(false, false, true, false).any(), true);
-            assert_eq!($mask::new(false, false, false, true).any(), true);
-        });
-
-        glam_test!(test_mask_all, {
-            assert_eq!($mask::new(true, true, true, true).all(), true);
-            assert_eq!($mask::new(false, true, true, true).all(), false);
-            assert_eq!($mask::new(true, false, true, true).all(), false);
-            assert_eq!($mask::new(true, true, false, true).all(), false);
-            assert_eq!($mask::new(true, true, true, false).all(), false);
-        });
-
         glam_test!(test_mask_select, {
             let a = $vec4::new(1 as $t, 2 as $t, 3 as $t, 4 as $t);
             let b = $vec4::new(5 as $t, 6 as $t, 7 as $t, 8 as $t);
@@ -662,173 +822,17 @@ macro_rules! impl_vec4_tests {
             );
         });
 
-        glam_test!(test_mask_and, {
-            assert_eq!(
-                ($mask::new(false, false, false, false) & $mask::new(false, false, false, false))
-                    .bitmask(),
-                0b0000,
-            );
-            assert_eq!(
-                ($mask::new(true, true, true, true) & $mask::new(true, true, true, true)).bitmask(),
-                0b1111,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true, false) & $mask::new(false, true, false, true))
-                    .bitmask(),
-                0b0000,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true, true) & $mask::new(true, true, true, false))
-                    .bitmask(),
-                0b0101,
-            );
+        glam_test!(test_slice, {
+            let a = [1 as $t, 2 as $t, 3 as $t, 4 as $t];
+            let b = $vec4::from_slice(&a);
+            let c: [$t; 4] = b.into();
+            assert_eq!(a, c);
+            let mut d = [0 as $t, 0 as $t, 0 as $t, 0 as $t];
+            b.write_to_slice(&mut d[..]);
+            assert_eq!(a, d);
 
-            let mut mask = $mask::new(true, true, false, false);
-            mask &= $mask::new(true, false, true, false);
-            assert_eq!(mask.bitmask(), 0b0001);
-        });
-
-        glam_test!(test_mask_or, {
-            assert_eq!(
-                ($mask::new(false, false, false, false) | $mask::new(false, false, false, false))
-                    .bitmask(),
-                0b0000,
-            );
-            assert_eq!(
-                ($mask::new(true, true, true, true) | $mask::new(true, true, true, true)).bitmask(),
-                0b1111,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true, false) | $mask::new(false, true, false, true))
-                    .bitmask(),
-                0b1111,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true, false) | $mask::new(true, false, true, false))
-                    .bitmask(),
-                0b0101,
-            );
-
-            let mut mask = $mask::new(true, true, false, false);
-            mask |= $mask::new(true, false, true, false);
-            assert_eq!(mask.bitmask(), 0b0111);
-        });
-
-        glam_test!(test_mask_xor, {
-            assert_eq!(
-                ($mask::new(false, false, false, false) ^ $mask::new(false, false, false, false))
-                    .bitmask(),
-                0b0000,
-            );
-            assert_eq!(
-                ($mask::new(true, true, true, true) ^ $mask::new(true, true, true, true)).bitmask(),
-                0b0000,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true, false) ^ $mask::new(false, true, false, true))
-                    .bitmask(),
-                0b1111,
-            );
-            assert_eq!(
-                ($mask::new(true, false, true, false) ^ $mask::new(true, false, true, false))
-                    .bitmask(),
-                0b0000,
-            );
-
-            let mut mask = $mask::new(true, true, false, false);
-            mask ^= $mask::new(true, false, true, false);
-            assert_eq!(mask.bitmask(), 0b0110);
-        });
-
-        glam_test!(test_mask_not, {
-            assert_eq!((!$mask::new(false, false, false, false)).bitmask(), 0b1111);
-            assert_eq!((!$mask::new(true, true, true, true)).bitmask(), 0b0000);
-            assert_eq!((!$mask::new(true, false, true, false)).bitmask(), 0b1010);
-            assert_eq!((!$mask::new(false, true, false, true)).bitmask(), 0b0101);
-        });
-
-        glam_test!(test_mask_fmt, {
-            let a = $mask::new(true, false, true, false);
-
-            assert_eq!(format!("{}", a), "[true, false, true, false]");
-            assert_eq!(
-                format!("{:?}", a),
-                format!("{}(0xffffffff, 0x0, 0xffffffff, 0x0)", stringify!($mask))
-            );
-        });
-
-        glam_test!(test_mask_eq, {
-            let a = $mask::new(true, false, true, false);
-            let b = $mask::new(true, false, true, false);
-            let c = $mask::new(false, true, true, false);
-
-            assert_eq!(a, b);
-            assert_eq!(b, a);
-            assert_ne!(a, c);
-            assert_ne!(b, c);
-        });
-
-        glam_test!(test_mask_test, {
-            let a = $mask::new(true, false, true, false);
-            assert_eq!(a.test(0), true);
-            assert_eq!(a.test(1), false);
-            assert_eq!(a.test(2), true);
-            assert_eq!(a.test(3), false);
-
-            let b = $mask::new(false, true, false, true);
-            assert_eq!(b.test(0), false);
-            assert_eq!(b.test(1), true);
-            assert_eq!(b.test(2), false);
-            assert_eq!(b.test(3), true);
-        });
-
-        glam_test!(test_mask_set, {
-            let mut a = $mask::new(false, true, false, true);
-            a.set(0, true);
-            assert_eq!(a.test(0), true);
-            a.set(1, false);
-            assert_eq!(a.test(1), false);
-            a.set(2, true);
-            assert_eq!(a.test(2), true);
-            a.set(3, false);
-            assert_eq!(a.test(3), false);
-
-            let mut b = $mask::new(true, false, true, false);
-            b.set(0, false);
-            assert_eq!(b.test(0), false);
-            b.set(1, true);
-            assert_eq!(b.test(1), true);
-            b.set(2, false);
-            assert_eq!(b.test(2), false);
-            b.set(3, true);
-            assert_eq!(b.test(3), true);
-        });
-
-        glam_test!(test_mask_hash, {
-            use std::collections::hash_map::DefaultHasher;
-            use std::hash::Hash;
-            use std::hash::Hasher;
-
-            let a = $mask::new(true, false, true, false);
-            let b = $mask::new(true, false, true, false);
-            let c = $mask::new(false, true, true, false);
-
-            let mut hasher = DefaultHasher::new();
-            a.hash(&mut hasher);
-            let a_hashed = hasher.finish();
-
-            let mut hasher = DefaultHasher::new();
-            b.hash(&mut hasher);
-            let b_hashed = hasher.finish();
-
-            let mut hasher = DefaultHasher::new();
-            c.hash(&mut hasher);
-            let c_hashed = hasher.finish();
-
-            assert_eq!(a, b);
-            assert_eq!(a_hashed, b_hashed);
-            assert_ne!(a, c);
-            assert_ne!(a_hashed, c_hashed);
+            should_panic!({ $vec4::ONE.write_to_slice(&mut [0 as $t; 3]) });
+            should_panic!({ $vec4::from_slice(&[0 as $t; 3]) });
         });
 
         glam_test!(test_to_from_slice, {
@@ -858,8 +862,8 @@ macro_rules! impl_vec4_tests {
 }
 
 macro_rules! impl_vec4_signed_tests {
-    ($t:ident, $new:ident, $vec4:ident, $vec3:ident, $vec2:ident, $mask:ident, $masknew:ident) => {
-        impl_vec4_tests!($t, $new, $vec4, $vec3, $vec2, $mask, $masknew);
+    ($t:ident, $new:ident, $vec4:ident, $vec3:ident, $vec2:ident, $mask:ident) => {
+        impl_vec4_tests!($t, $new, $vec4, $vec3, $vec2, $mask);
 
         glam_test!(test_neg, {
             let a = $new(1 as $t, 2 as $t, 3 as $t, 4 as $t);
@@ -959,8 +963,8 @@ macro_rules! impl_vec4_signed_tests {
 }
 
 macro_rules! impl_vec4_signed_integer_tests {
-    ($t:ident, $new:ident, $vec4:ident, $vec3:ident, $vec2:ident, $mask:ident, $masknew:ident) => {
-        impl_vec4_signed_tests!($t, $new, $vec4, $vec3, $vec2, $mask, $masknew);
+    ($t:ident, $new:ident, $vec4:ident, $vec3:ident, $vec2:ident, $mask:ident) => {
+        impl_vec4_signed_tests!($t, $new, $vec4, $vec3, $vec2, $mask);
 
         glam_test!(test_signum, {
             assert_eq!($vec4::ZERO.signum(), $vec4::ZERO);
@@ -1065,8 +1069,8 @@ macro_rules! impl_vec4_signed_integer_tests {
 }
 
 macro_rules! impl_vec4_unsigned_integer_tests {
-    ($t:ident, $new:ident, $vec4:ident, $vec3:ident, $vec2:ident, $mask:ident, $masknew:ident) => {
-        impl_vec4_tests!($t, $new, $vec4, $vec3, $vec2, $mask, $masknew);
+    ($t:ident, $new:ident, $vec4:ident, $vec3:ident, $vec2:ident, $mask:ident) => {
+        impl_vec4_tests!($t, $new, $vec4, $vec3, $vec2, $mask);
 
         glam_test!(test_checked_add, {
             assert_eq!($vec4::MAX.checked_add($vec4::ONE), None);
@@ -1176,8 +1180,8 @@ macro_rules! impl_vec4_eq_hash_tests {
 }
 
 macro_rules! impl_vec4_float_tests {
-    ($t:ident, $new:ident, $vec4:ident, $vec3:ident, $vec2:ident, $mask:ident, $masknew:ident) => {
-        impl_vec4_signed_tests!($t, $new, $vec4, $vec3, $vec2, $mask, $masknew);
+    ($t:ident, $new:ident, $vec4:ident, $vec3:ident, $vec2:ident, $mask:ident) => {
+        impl_vec4_signed_tests!($t, $new, $vec4, $vec3, $vec2, $mask);
         impl_vec_float_normalize_tests!($t, $vec4);
 
         glam_test!(test_vec4_nan, {
@@ -1714,11 +1718,21 @@ macro_rules! impl_vec4_bit_op_tests {
     };
 }
 
+mod bvec4 {
+    use glam::{bvec4, BVec4};
+    impl_bvec4_tests!(BVec4, bvec4);
+}
+
+mod bvec4a {
+    use glam::{bvec4a, BVec4A};
+    impl_bvec4_tests!(BVec4A, bvec4a);
+}
+
 mod vec4 {
     #[cfg(feature = "scalar-math")]
-    use glam::{bvec4, BVec4};
+    use glam::BVec4;
     #[cfg(not(feature = "scalar-math"))]
-    use glam::{bvec4a, BVec4A};
+    use glam::BVec4A;
     use glam::{vec4, Vec2, Vec3, Vec4};
 
     glam_test!(test_align, {
@@ -2115,14 +2129,14 @@ mod vec4 {
     });
 
     #[cfg(not(feature = "scalar-math"))]
-    impl_vec4_float_tests!(f32, vec4, Vec4, Vec3, Vec2, BVec4A, bvec4a);
+    impl_vec4_float_tests!(f32, vec4, Vec4, Vec3, Vec2, BVec4A);
 
     #[cfg(feature = "scalar-math")]
-    impl_vec4_float_tests!(f32, vec4, Vec4, Vec3, Vec2, BVec4, bvec4);
+    impl_vec4_float_tests!(f32, vec4, Vec4, Vec3, Vec2, BVec4);
 }
 
 mod dvec4 {
-    use glam::{bvec4, dvec4, BVec4, DVec2, DVec3, DVec4, IVec4, UVec4, Vec4};
+    use glam::{dvec4, BVec4, DVec2, DVec3, DVec4, IVec4, UVec4, Vec4};
 
     glam_test!(test_align, {
         use std::mem;
@@ -2150,13 +2164,13 @@ mod dvec4 {
         );
     });
 
-    impl_vec4_float_tests!(f64, dvec4, DVec4, DVec3, DVec2, BVec4, bvec4);
+    impl_vec4_float_tests!(f64, dvec4, DVec4, DVec3, DVec2, BVec4);
 }
 
 mod i8vec4 {
     use glam::{
-        bvec4, i8vec4, BVec4, I16Vec4, I64Vec4, I8Vec2, I8Vec3, I8Vec4, IVec4, U16Vec4, U64Vec4,
-        U8Vec4, UVec4,
+        i8vec4, BVec4, I16Vec4, I64Vec4, I8Vec2, I8Vec3, I8Vec4, IVec4, U16Vec4, U64Vec4, U8Vec4,
+        UVec4,
     };
 
     glam_test!(test_align, {
@@ -2337,7 +2351,7 @@ mod i8vec4 {
         );
     });
 
-    impl_vec4_signed_integer_tests!(i8, i8vec4, I8Vec4, I8Vec3, I8Vec2, BVec4, bvec4);
+    impl_vec4_signed_integer_tests!(i8, i8vec4, I8Vec4, I8Vec3, I8Vec2, BVec4);
     impl_vec4_eq_hash_tests!(i8, i8vec4);
 
     impl_vec4_scalar_shift_op_tests!(I8Vec4, -2, 2);
@@ -2349,8 +2363,8 @@ mod i8vec4 {
 
 mod u8vec4 {
     use glam::{
-        bvec4, u8vec4, BVec4, I16Vec4, I64Vec4, I8Vec4, IVec4, U16Vec4, U64Vec4, U8Vec2, U8Vec3,
-        U8Vec4, UVec4,
+        u8vec4, BVec4, I16Vec4, I64Vec4, I8Vec4, IVec4, U16Vec4, U64Vec4, U8Vec2, U8Vec3, U8Vec4,
+        UVec4,
     };
 
     glam_test!(test_align, {
@@ -2514,7 +2528,7 @@ mod u8vec4 {
         );
     });
 
-    impl_vec4_unsigned_integer_tests!(u8, u8vec4, U8Vec4, U8Vec3, U8Vec2, BVec4, bvec4);
+    impl_vec4_unsigned_integer_tests!(u8, u8vec4, U8Vec4, U8Vec3, U8Vec2, BVec4);
     impl_vec4_eq_hash_tests!(u8, u8vec4);
 
     impl_vec4_scalar_shift_op_tests!(U8Vec4, 0, 2);
@@ -2526,7 +2540,7 @@ mod u8vec4 {
 
 mod i16vec4 {
     use glam::{
-        bvec4, i16vec4, BVec4, I16Vec2, I16Vec3, I16Vec4, I64Vec4, I8Vec4, IVec4, U16Vec4, U64Vec4,
+        i16vec4, BVec4, I16Vec2, I16Vec3, I16Vec4, I64Vec4, I8Vec4, IVec4, U16Vec4, U64Vec4,
         U8Vec4, UVec4,
     };
 
@@ -2699,7 +2713,7 @@ mod i16vec4 {
         );
     });
 
-    impl_vec4_signed_integer_tests!(i16, i16vec4, I16Vec4, I16Vec3, I16Vec2, BVec4, bvec4);
+    impl_vec4_signed_integer_tests!(i16, i16vec4, I16Vec4, I16Vec3, I16Vec2, BVec4);
     impl_vec4_eq_hash_tests!(i16, i16vec4);
 
     impl_vec4_scalar_shift_op_tests!(I16Vec4, -2, 2);
@@ -2711,7 +2725,7 @@ mod i16vec4 {
 
 mod u16vec4 {
     use glam::{
-        bvec4, u16vec4, BVec4, I16Vec4, I64Vec4, I8Vec4, IVec4, U16Vec2, U16Vec3, U16Vec4, U64Vec4,
+        u16vec4, BVec4, I16Vec4, I64Vec4, I8Vec4, IVec4, U16Vec2, U16Vec3, U16Vec4, U64Vec4,
         U8Vec4, UVec4,
     };
 
@@ -2872,7 +2886,7 @@ mod u16vec4 {
         );
     });
 
-    impl_vec4_unsigned_integer_tests!(u16, u16vec4, U16Vec4, U16Vec3, U16Vec2, BVec4, bvec4);
+    impl_vec4_unsigned_integer_tests!(u16, u16vec4, U16Vec4, U16Vec3, U16Vec2, BVec4);
     impl_vec4_eq_hash_tests!(u16, u16vec4);
 
     impl_vec4_scalar_shift_op_tests!(U16Vec4, 0, 2);
@@ -2884,8 +2898,8 @@ mod u16vec4 {
 
 mod ivec4 {
     use glam::{
-        bvec4, ivec4, BVec4, I16Vec4, I64Vec4, I8Vec4, IVec2, IVec3, IVec4, U16Vec4, U64Vec4,
-        U8Vec4, UVec4,
+        ivec4, BVec4, I16Vec4, I64Vec4, I8Vec4, IVec2, IVec3, IVec4, U16Vec4, U64Vec4, U8Vec4,
+        UVec4,
     };
 
     glam_test!(test_align, {
@@ -3044,7 +3058,7 @@ mod ivec4 {
         );
     });
 
-    impl_vec4_signed_integer_tests!(i32, ivec4, IVec4, IVec3, IVec2, BVec4, bvec4);
+    impl_vec4_signed_integer_tests!(i32, ivec4, IVec4, IVec3, IVec2, BVec4);
     impl_vec4_eq_hash_tests!(i32, ivec4);
 
     impl_vec4_scalar_shift_op_tests!(IVec4, -2, 2);
@@ -3056,8 +3070,8 @@ mod ivec4 {
 
 mod uvec4 {
     use glam::{
-        bvec4, uvec4, BVec4, I16Vec4, I64Vec4, I8Vec4, IVec4, U16Vec4, U64Vec4, U8Vec4, UVec2,
-        UVec3, UVec4,
+        uvec4, BVec4, I16Vec4, I64Vec4, I8Vec4, IVec4, U16Vec4, U64Vec4, U8Vec4, UVec2, UVec3,
+        UVec4,
     };
 
     glam_test!(test_align, {
@@ -3202,7 +3216,7 @@ mod uvec4 {
         );
     });
 
-    impl_vec4_unsigned_integer_tests!(u32, uvec4, UVec4, UVec3, UVec2, BVec4, bvec4);
+    impl_vec4_unsigned_integer_tests!(u32, uvec4, UVec4, UVec3, UVec2, BVec4);
     impl_vec4_eq_hash_tests!(u32, uvec4);
 
     impl_vec4_scalar_shift_op_tests!(UVec4, 0, 2);
@@ -3214,7 +3228,7 @@ mod uvec4 {
 
 mod i64vec4 {
     use glam::{
-        bvec4, i64vec4, BVec4, I16Vec4, I64Vec2, I64Vec3, I64Vec4, I8Vec4, IVec4, U16Vec4, U64Vec4,
+        i64vec4, BVec4, I16Vec4, I64Vec2, I64Vec3, I64Vec4, I8Vec4, IVec4, U16Vec4, U64Vec4,
         U8Vec4, UVec4,
     };
 
@@ -3313,7 +3327,7 @@ mod i64vec4 {
         );
     });
 
-    impl_vec4_signed_integer_tests!(i64, i64vec4, I64Vec4, I64Vec3, I64Vec2, BVec4, bvec4);
+    impl_vec4_signed_integer_tests!(i64, i64vec4, I64Vec4, I64Vec3, I64Vec2, BVec4);
     impl_vec4_eq_hash_tests!(i64, i64vec4);
 
     impl_vec4_scalar_shift_op_tests!(I64Vec4, -2, 2);
@@ -3325,7 +3339,7 @@ mod i64vec4 {
 
 mod u64vec4 {
     use glam::{
-        bvec4, u64vec4, BVec4, I16Vec4, I64Vec4, I8Vec4, IVec4, U16Vec4, U64Vec2, U64Vec3, U64Vec4,
+        u64vec4, BVec4, I16Vec4, I64Vec4, I8Vec4, IVec4, U16Vec4, U64Vec2, U64Vec3, U64Vec4,
         U8Vec4, UVec4,
     };
 
@@ -3409,7 +3423,7 @@ mod u64vec4 {
         );
     });
 
-    impl_vec4_unsigned_integer_tests!(u64, u64vec4, U64Vec4, U64Vec3, U64Vec2, BVec4, bvec4);
+    impl_vec4_unsigned_integer_tests!(u64, u64vec4, U64Vec4, U64Vec3, U64Vec2, BVec4);
     impl_vec4_eq_hash_tests!(u64, u64vec4);
 
     impl_vec4_scalar_shift_op_tests!(U64Vec4, 0, 2);


### PR DESCRIPTION
Support testing BVec* vector masks separately from the other vector types for better coverage.