### PR TITLE
Add `nostd-libm` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,12 @@ core-simd = []
 
 bytecheck = ["rkyv/bytecheck"]
 
+# enables libm and prefers it over std
+libm = ["dep:libm"]
+
+# enables libm but will prefer std if available
+libm-fallback = ["dep:libm"]
+
 [dependencies]
 approx = { version = "0.5", optional = true, default-features = false }
 bytemuck = { version = "1.9", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ bytecheck = ["rkyv/bytecheck"]
 libm = ["dep:libm"]
 
 # enables libm but will prefer std if available
-libm-fallback = ["dep:libm"]
+nostd-libm = ["dep:libm"]
 
 [dependencies]
 approx = { version = "0.5", optional = true, default-features = false }

--- a/README.md
+++ b/README.md
@@ -103,12 +103,27 @@ libm = ["glam/libm"]
 glam = { version = "0.30.0", default-features = false }
 ```
 
+Alternatively, you can use the `nostd-libm` feature.
+This will always include a `libm` dependency, but allows the user to still override it with `std` if they prefer.
+This will allow your crate to compile with default features disabled, instead of forcing the user to enable either `std` or `libm`.
+
+```toml
+[features]
+default = ["std"]
+
+std = ["glam/std"]
+libm = ["glam/libm"]
+
+[dependencies]
+glam = { version = "0.30.0", default-features = false, features = ["nostd-libm"] }
+```
+
 ### Optional features
 
 * [`approx`] - traits and macros for approximate float comparisons
 * [`bytemuck`] - for casting into slices of bytes
-* [`libm`] - uses `libm` math functions instead of `std`, required to compile
-  with `no_std`
+* [`libm`] - uses `libm` math functions instead of `std`
+* [`nostd-libm`] - uses `libm` math functions if `std` is not available
 * [`mint`] - for interoperating with other 3D math libraries
 * [`rand`] - implementations of `Distribution` trait for all `glam` types.
 * [`serde`] - implementations of `Serialize` and `Deserialize` for all `glam`

--- a/src/f32/math.rs
+++ b/src/f32/math.rs
@@ -32,7 +32,7 @@ fn acos_approx_f32(v: f32) -> f32 {
     }
 }
 
-#[cfg(feature = "libm")]
+#[cfg(any(feature = "libm", feature = "libm-fallback"))]
 mod libm_math {
     #[inline(always)]
     pub(crate) fn abs(f: f32) -> f32 {
@@ -236,7 +236,7 @@ mod std_math {
 
 // Used to reduce the number of compilation errors, in the event that no other
 // math backend is specified.
-#[cfg(all(not(feature = "libm"), not(feature = "std")))]
+#[cfg(all(not(feature = "libm"), not(feature = "std"), not(feature = "libm-fallback")))]
 mod no_backend_math {
     pub(crate) fn abs(_: f32) -> f32 {
         unimplemented!()
@@ -311,11 +311,11 @@ mod no_backend_math {
     }
 }
 
-#[cfg(feature = "libm")]
+#[cfg(any(feature = "libm", all(feature = "libm-fallback", not(feature = "std"))))]
 pub(crate) use libm_math::*;
 
 #[cfg(all(not(feature = "libm"), feature = "std"))]
 pub(crate) use std_math::*;
 
-#[cfg(all(not(feature = "libm"), not(feature = "std")))]
+#[cfg(all(not(feature = "libm"), not(feature = "std"), not(feature = "libm-fallback")))]
 pub(crate) use no_backend_math::*;

--- a/src/f32/math.rs
+++ b/src/f32/math.rs
@@ -236,7 +236,11 @@ mod std_math {
 
 // Used to reduce the number of compilation errors, in the event that no other
 // math backend is specified.
-#[cfg(all(not(feature = "libm"), not(feature = "std"), not(feature = "libm-fallback")))]
+#[cfg(all(
+    not(feature = "libm"),
+    not(feature = "std"),
+    not(feature = "libm-fallback")
+))]
 mod no_backend_math {
     pub(crate) fn abs(_: f32) -> f32 {
         unimplemented!()
@@ -317,5 +321,9 @@ pub(crate) use libm_math::*;
 #[cfg(all(not(feature = "libm"), feature = "std"))]
 pub(crate) use std_math::*;
 
-#[cfg(all(not(feature = "libm"), not(feature = "std"), not(feature = "libm-fallback")))]
+#[cfg(all(
+    not(feature = "libm"),
+    not(feature = "std"),
+    not(feature = "libm-fallback")
+))]
 pub(crate) use no_backend_math::*;

--- a/src/f32/math.rs
+++ b/src/f32/math.rs
@@ -32,7 +32,7 @@ fn acos_approx_f32(v: f32) -> f32 {
     }
 }
 
-#[cfg(any(feature = "libm", feature = "nostd-libm"))]
+#[cfg(any(feature = "libm", all(feature = "nostd-libm", not(feature = "std"))))]
 mod libm_math {
     #[inline(always)]
     pub(crate) fn abs(f: f32) -> f32 {

--- a/src/f32/math.rs
+++ b/src/f32/math.rs
@@ -32,7 +32,7 @@ fn acos_approx_f32(v: f32) -> f32 {
     }
 }
 
-#[cfg(any(feature = "libm", feature = "libm-fallback"))]
+#[cfg(any(feature = "libm", feature = "nostd-libm"))]
 mod libm_math {
     #[inline(always)]
     pub(crate) fn abs(f: f32) -> f32 {
@@ -239,7 +239,7 @@ mod std_math {
 #[cfg(all(
     not(feature = "libm"),
     not(feature = "std"),
-    not(feature = "libm-fallback")
+    not(feature = "nostd-libm")
 ))]
 mod no_backend_math {
     pub(crate) fn abs(_: f32) -> f32 {
@@ -315,7 +315,7 @@ mod no_backend_math {
     }
 }
 
-#[cfg(any(feature = "libm", all(feature = "libm-fallback", not(feature = "std"))))]
+#[cfg(any(feature = "libm", all(feature = "nostd-libm", not(feature = "std"))))]
 pub(crate) use libm_math::*;
 
 #[cfg(all(not(feature = "libm"), feature = "std"))]
@@ -324,6 +324,6 @@ pub(crate) use std_math::*;
 #[cfg(all(
     not(feature = "libm"),
     not(feature = "std"),
-    not(feature = "libm-fallback")
+    not(feature = "nostd-libm")
 ))]
 pub(crate) use no_backend_math::*;

--- a/src/f64/math.rs
+++ b/src/f64/math.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "libm", feature = "nostd-libm"))]
+#[cfg(any(feature = "libm", all(feature = "nostd-libm", not(feature = "std"))))]
 mod libm_math {
     #[inline(always)]
     pub(crate) fn abs(f: f64) -> f64 {

--- a/src/f64/math.rs
+++ b/src/f64/math.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "libm")]
+#[cfg(any(feature = "libm", feature = "libm-fallback"))]
 mod libm_math {
     #[inline(always)]
     pub(crate) fn abs(f: f64) -> f64 {
@@ -200,7 +200,7 @@ mod std_math {
 
 // Used to reduce the number of compilation errors, in the event that no other
 // math backend is specified.
-#[cfg(all(not(feature = "libm"), not(feature = "std")))]
+#[cfg(all(not(feature = "libm"), not(feature = "std"), not(feature = "libm-fallback")))]
 mod no_backend_math {
     pub(crate) fn abs(_: f64) -> f64 {
         unimplemented!()
@@ -275,11 +275,11 @@ mod no_backend_math {
     }
 }
 
-#[cfg(feature = "libm")]
+#[cfg(any(feature = "libm", all(feature = "libm-fallback", not(feature = "std"))))]
 pub(crate) use libm_math::*;
 
 #[cfg(all(not(feature = "libm"), feature = "std"))]
 pub(crate) use std_math::*;
 
-#[cfg(all(not(feature = "libm"), not(feature = "std")))]
+#[cfg(all(not(feature = "libm"), not(feature = "std"), not(feature = "libm-fallback")))]
 pub(crate) use no_backend_math::*;

--- a/src/f64/math.rs
+++ b/src/f64/math.rs
@@ -1,4 +1,4 @@
-#[cfg(any(feature = "libm", feature = "libm-fallback"))]
+#[cfg(any(feature = "libm", feature = "nostd-libm"))]
 mod libm_math {
     #[inline(always)]
     pub(crate) fn abs(f: f64) -> f64 {
@@ -203,7 +203,7 @@ mod std_math {
 #[cfg(all(
     not(feature = "libm"),
     not(feature = "std"),
-    not(feature = "libm-fallback")
+    not(feature = "nostd-libm")
 ))]
 mod no_backend_math {
     pub(crate) fn abs(_: f64) -> f64 {
@@ -279,7 +279,7 @@ mod no_backend_math {
     }
 }
 
-#[cfg(any(feature = "libm", all(feature = "libm-fallback", not(feature = "std"))))]
+#[cfg(any(feature = "libm", all(feature = "nostd-libm", not(feature = "std"))))]
 pub(crate) use libm_math::*;
 
 #[cfg(all(not(feature = "libm"), feature = "std"))]
@@ -288,6 +288,6 @@ pub(crate) use std_math::*;
 #[cfg(all(
     not(feature = "libm"),
     not(feature = "std"),
-    not(feature = "libm-fallback")
+    not(feature = "nostd-libm")
 ))]
 pub(crate) use no_backend_math::*;

--- a/src/f64/math.rs
+++ b/src/f64/math.rs
@@ -200,7 +200,11 @@ mod std_math {
 
 // Used to reduce the number of compilation errors, in the event that no other
 // math backend is specified.
-#[cfg(all(not(feature = "libm"), not(feature = "std"), not(feature = "libm-fallback")))]
+#[cfg(all(
+    not(feature = "libm"),
+    not(feature = "std"),
+    not(feature = "libm-fallback")
+))]
 mod no_backend_math {
     pub(crate) fn abs(_: f64) -> f64 {
         unimplemented!()
@@ -281,5 +285,9 @@ pub(crate) use libm_math::*;
 #[cfg(all(not(feature = "libm"), feature = "std"))]
 pub(crate) use std_math::*;
 
-#[cfg(all(not(feature = "libm"), not(feature = "std"), not(feature = "libm-fallback")))]
+#[cfg(all(
+    not(feature = "libm"),
+    not(feature = "std"),
+    not(feature = "libm-fallback")
+))]
 pub(crate) use no_backend_math::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -229,7 +229,8 @@ and benchmarks.
 * `std` - the default feature, has no dependencies.
 * `approx` - traits and macros for approximate float comparisons
 * `bytemuck` - for casting into slices of bytes
-* `libm` - uses `libm` math functions instead of `std`, required to compile with `no_std`
+* `libm` - uses `libm` math functions instead of `std`
+* `nostd-libm` - uses `libm` math functions if `std` is not available
 * `mint` - for interoperating with other 3D math libraries
 * `rand` - implementations of `Distribution` trait for all `glam` types.
 * `rkyv` - implementations of `Archive`, `Serialize` and `Deserialize` for all

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -277,7 +277,7 @@ The minimum supported Rust version is `1.68.2`.
 #[cfg(all(
     not(feature = "std"),
     not(feature = "libm"),
-    not(feature = "libm-fallback")
+    not(feature = "nostd-libm")
 ))]
 compile_error!("You must specify a math backend using either the `std` feature or `libm` feature");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,7 +279,9 @@ The minimum supported Rust version is `1.68.2`.
     not(feature = "libm"),
     not(feature = "nostd-libm")
 ))]
-compile_error!("You must specify a math backend using either the `std` feature or `libm` feature");
+compile_error!(
+    "You must specify a math backend. Consider enabling either `std`, `libm`, or `nostd-libm`."
+);
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,7 @@ The minimum supported Rust version is `1.68.2`.
     feature(portable_simd)
 )]
 
-#[cfg(all(not(feature = "std"), not(feature = "libm")))]
+#[cfg(all(not(feature = "std"), not(feature = "libm"), not(feature = "libm-fallback")))]
 compile_error!("You must specify a math backend using either the `std` feature or `libm` feature");
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -274,7 +274,11 @@ The minimum supported Rust version is `1.68.2`.
     feature(portable_simd)
 )]
 
-#[cfg(all(not(feature = "std"), not(feature = "libm"), not(feature = "libm-fallback")))]
+#[cfg(all(
+    not(feature = "std"),
+    not(feature = "libm"),
+    not(feature = "libm-fallback")
+))]
 compile_error!("You must specify a math backend using either the `std` feature or `libm` feature");
 
 #[macro_use]


### PR DESCRIPTION
# Objective

In [Bevy](https://github.com/bevyengine/bevy) we're working on adding `no_std` support, which has forced us to interact with the `std` or `libm` feature pair that Glam has. An issue we have is we want to support compiling `bevy` without default features, but our use of Glam makes that currently impossible. The workaround we've settled on is to just make all of our floating point maths related code optional, but that degrades the developer experience by making what was previously included functionality gated behind a seemingly unrelated question of `std` or `libm`.

Since `libm` compiles relatively instantly in the context of Bevy's other dependencies, and the fact that it's typically included by other dependencies already (e.g., `rand`), we'd like a way to enable `libm` purely for compatibility purposes, but still allow users to choose `std` as the floating point backend if they prefer it.

## Solution

- Add a new feature flag, `libm-fallback`, which includes `libm` as a dependency but only uses it if `std` is disabled.
- This feature is intended for libraries relying on Glam as a way to compile with default features disabled without denying the user the ability to choose their preferred backend.

## Code generation

- Modified code is not generated.

## Testing and linting

- CI
