### PR TITLE
Add `nostd-libm` feature (#617) and prepare for 0.29.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## [0.29.3] - 2025-03-22
+
+### Added
+
+* Added `nostd-libm` feature to assist with `no_std` compatible libraries.
+
 ## [0.29.2] - 2024-11-05
 
 ### Fixed
@@ -1149,7 +1155,8 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 [Keep a Changelog]: https://keepachangelog.com/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
-[Unreleased]: https://github.com/bitshifter/glam-rs/compare/0.29.2...HEAD
+[Unreleased]: https://github.com/bitshifter/glam-rs/compare/0.29.3...HEAD
+[0.29.3]: https://github.com/bitshifter/glam-rs/compare/0.29.2...0.29.3
 [0.29.2]: https://github.com/bitshifter/glam-rs/compare/0.29.1...0.29.2
 [0.29.1]: https://github.com/bitshifter/glam-rs/compare/0.29.0...0.29.1
 [0.29.0]: https://github.com/bitshifter/glam-rs/compare/0.28.0...0.29.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "glam"
-version = "0.29.2" # remember to update html_root_url
+version = "0.29.3" # remember to update html_root_url
 edition = "2021"
 authors = ["Cameron Hart <cameron.hart@gmail.com>"]
 description = "A simple and fast 3D math library for games and graphics"
@@ -40,6 +40,12 @@ fast-math = []
 
 # experimental nightly portable-simd support
 core-simd = []
+
+# enables libm and prefers it over std
+libm = ["dep:libm"]
+
+# enables libm but will prefer std if available
+nostd-libm = ["dep:libm"]
 
 [dependencies]
 approx = { version = "0.5", optional = true, default-features = false }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ defined in `std`. For example:
 
 ```toml
 [dependencies]
-glam = { version = "0.29.2", default-features = false, features = ["libm"] }
+glam = { version = "0.29.3", default-features = false, features = ["libm"] }
 ```
 
 To support both `std` and `no_std` builds in project, you can use the following
@@ -98,15 +98,30 @@ std = ["glam/std"]
 libm = ["glam/libm"]
 
 [dependencies]
-glam = { version = "0.29.2", default-features = false }
+glam = { version = "0.29.3", default-features = false }
+```
+
+Alternatively, you can use the `nostd-libm` feature.
+This will always include a `libm` dependency, but allows the user to still override it with `std` if they prefer.
+This will allow your crate to compile with default features disabled, instead of forcing the user to enable either `std` or `libm`.
+
+```toml
+[features]
+default = ["std"]
+
+std = ["glam/std"]
+libm = ["glam/libm"]
+
+[dependencies]
+glam = { version = "0.30.0", default-features = false, features = ["nostd-libm"] }
 ```
 
 ### Optional features
 
 * [`approx`] - traits and macros for approximate float comparisons
 * [`bytemuck`] - for casting into slices of bytes
-* [`libm`] - uses `libm` math functions instead of `std`, required to compile
-  with `no_std`
+* [`libm`] - uses `libm` math functions instead of `std`
+* [`nostd-libm`] - uses `libm` math functions if `std` is not available
 * [`mint`] - for interoperating with other 3D math libraries
 * [`rand`] - implementations of `Distribution` trait for all `glam` types.
 * [`serde`] - implementations of `Serialize` and `Deserialize` for all `glam`

--- a/benches/vec3.rs
+++ b/benches/vec3.rs
@@ -19,7 +19,7 @@ bench_binop!(
 #[inline]
 fn vec3_to_rgb_op(v: Vec3) -> u32 {
     let (red, green, blue) = (v.min(Vec3::ONE).max(Vec3::ZERO) * 255.0).into();
-    (red as u32) << 16 | (green as u32) << 8 | (blue as u32)
+    ((red as u32) << 16) | ((green as u32) << 8) | (blue as u32)
 }
 
 #[inline]

--- a/benches/vec3a.rs
+++ b/benches/vec3a.rs
@@ -19,7 +19,7 @@ bench_binop!(
 #[inline]
 fn vec3a_to_rgb_op(v: Vec3A) -> u32 {
     let (red, green, blue) = (v.min(Vec3A::ONE).max(Vec3A::ZERO) * 255.0).into();
-    (red as u32) << 16 | (green as u32) << 8 | (blue as u32)
+    ((red as u32) << 16) | ((green as u32) << 8) | (blue as u32)
 }
 
 #[inline]

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -4235,9 +4235,7 @@ impl From<{{ bvec_from_type }}> for {{ self_t }} {
 }
 
 {% if bveca_from_type %}
-    {% if bveca_from_type == "BVec4A" %}
-    #[cfg(not(feature = "scalar-math"))]
-    {% endif %}
+    {% if bveca_from_type == "BVec4A" %}#[cfg(not(feature = "scalar-math"))]{% endif %}
     impl From<{{ bveca_from_type }}> for {{ self_t }} {
         #[inline]
         fn from(v: {{ bveca_from_type }}) -> Self {

--- a/codegen/templates/vec.rs.tera
+++ b/codegen/templates/vec.rs.tera
@@ -1315,7 +1315,7 @@ impl {{ self_t }} {
                 {% if loop.first %}
                     (self.{{ c }}.is_sign_negative() as u32) |
                 {% else %}
-                    (self.{{ c }}.is_sign_negative() as u32) << {{ loop.index0 }} {% if not loop.last %} | {% endif %}
+                    ((self.{{ c }}.is_sign_negative() as u32) << {{ loop.index0 }}) {% if not loop.last %} | {% endif %}
                 {% endif %}
             {% endfor %}
         {% elif is_scalar %}
@@ -1323,7 +1323,7 @@ impl {{ self_t }} {
                 {% if loop.first %}
                     (self.{{ c }}.is_negative() as u32) |
                 {% else %}
-                    (self.{{ c }}.is_negative() as u32) << {{ loop.index0 }} {% if not loop.last %} | {% endif %}
+                    ((self.{{ c }}.is_negative() as u32) << {{ loop.index0 }}) {% if not loop.last %} | {% endif %}
                 {% endif %}
             {% endfor %}
         {% elif is_sse2 %}

--- a/codegen/templates/vec_mask.rs.tera
+++ b/codegen/templates/vec_mask.rs.tera
@@ -178,7 +178,7 @@ impl {{ self_t }} {
                 {% if loop.first %}
                     (self.{{ c }} as u32) |
                 {% else %}
-                    (self.{{ c }} as u32) << {{ loop.index0 }} {% if not loop.last %} | {% endif %}
+                    ((self.{{ c }} as u32) << {{ loop.index0 }}) {% if not loop.last %} | {% endif %}
                 {% endif %}
             {% endfor %}
         {% elif is_scalar and is_u32 %}
@@ -186,7 +186,7 @@ impl {{ self_t }} {
                 {% if loop.first %}
                     (self.{{ c }} & 0x1) |
                 {% else %}
-                    (self.{{ c }} & 0x1) << {{ loop.index0 }} {% if not loop.last %} | {% endif %}
+                    ((self.{{ c }} & 0x1) << {{ loop.index0 }}) {% if not loop.last %} | {% endif %}
                 {% endif %}
             {% endfor %}
         {% elif is_sse2 %}

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,3 @@
-[advisories]
-# criterion is currently failing cargo-deny due to serde_cbor being unmaintained
-unmaintained = "warn"
-
 [bans]
 multiple-versions = "deny"
 deny = []
@@ -11,13 +7,8 @@ skip-tree = [
 ]
 
 [licenses]
-unlicensed = "deny"
 allow = [
     "Apache-2.0",
     "MIT",
-]
-exceptions = [
-    { allow = [
-        "Unicode-DFS-2016",
-    ], name = "unicode-ident" },
+    "Unicode-3.0",
 ]

--- a/src/bool/bvec2.rs
+++ b/src/bool/bvec2.rs
@@ -55,7 +55,7 @@ impl BVec2 {
     #[inline]
     #[must_use]
     pub fn bitmask(self) -> u32 {
-        (self.x as u32) | (self.y as u32) << 1
+        (self.x as u32) | ((self.y as u32) << 1)
     }
 
     /// Returns true if any of the elements are true, false otherwise.

--- a/src/bool/bvec3.rs
+++ b/src/bool/bvec3.rs
@@ -56,7 +56,7 @@ impl BVec3 {
     #[inline]
     #[must_use]
     pub fn bitmask(self) -> u32 {
-        (self.x as u32) | (self.y as u32) << 1 | (self.z as u32) << 2
+        (self.x as u32) | ((self.y as u32) << 1) | ((self.z as u32) << 2)
     }
 
     /// Returns true if any of the elements are true, false otherwise.

--- a/src/bool/bvec4.rs
+++ b/src/bool/bvec4.rs
@@ -57,7 +57,7 @@ impl BVec4 {
     #[inline]
     #[must_use]
     pub fn bitmask(self) -> u32 {
-        (self.x as u32) | (self.y as u32) << 1 | (self.z as u32) << 2 | (self.w as u32) << 3
+        (self.x as u32) | ((self.y as u32) << 1) | ((self.z as u32) << 2) | ((self.w as u32) << 3)
     }
 
     /// Returns true if any of the elements are true, false otherwise.

--- a/src/bool/scalar/bvec3a.rs
+++ b/src/bool/scalar/bvec3a.rs
@@ -60,7 +60,7 @@ impl BVec3A {
     #[inline]
     #[must_use]
     pub fn bitmask(self) -> u32 {
-        (self.x & 0x1) | (self.y & 0x1) << 1 | (self.z & 0x1) << 2
+        (self.x & 0x1) | ((self.y & 0x1) << 1) | ((self.z & 0x1) << 2)
     }
 
     /// Returns true if any of the elements are true, false otherwise.

--- a/src/bool/scalar/bvec4a.rs
+++ b/src/bool/scalar/bvec4a.rs
@@ -62,7 +62,7 @@ impl BVec4A {
     #[inline]
     #[must_use]
     pub fn bitmask(self) -> u32 {
-        (self.x & 0x1) | (self.y & 0x1) << 1 | (self.z & 0x1) << 2 | (self.w & 0x1) << 3
+        (self.x & 0x1) | ((self.y & 0x1) << 1) | ((self.z & 0x1) << 2) | ((self.w & 0x1) << 3)
     }
 
     /// Returns true if any of the elements are true, false otherwise.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -1780,7 +1780,6 @@ impl From<BVec4> for Vec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for Vec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/f32/math.rs
+++ b/src/f32/math.rs
@@ -32,7 +32,7 @@ fn acos_approx_f32(v: f32) -> f32 {
     }
 }
 
-#[cfg(feature = "libm")]
+#[cfg(any(feature = "libm", all(feature = "nostd-libm", not(feature = "std"))))]
 mod libm_math {
     #[inline(always)]
     pub(crate) fn abs(f: f32) -> f32 {
@@ -140,7 +140,7 @@ mod libm_math {
     }
 }
 
-#[cfg(not(feature = "libm"))]
+#[cfg(all(not(feature = "libm"), feature = "std"))]
 mod std_math {
     #[inline(always)]
     pub(crate) fn abs(f: f32) -> f32 {
@@ -234,8 +234,8 @@ mod std_math {
     }
 }
 
-#[cfg(feature = "libm")]
+#[cfg(any(feature = "libm", all(feature = "nostd-libm", not(feature = "std"))))]
 pub(crate) use libm_math::*;
 
-#[cfg(not(feature = "libm"))]
+#[cfg(all(not(feature = "libm"), feature = "std"))]
 pub(crate) use std_math::*;

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -1844,7 +1844,6 @@ impl From<BVec4> for Vec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for Vec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -419,8 +419,8 @@ impl Vec3A {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_sign_negative() as u32)
-            | (self.y.is_sign_negative() as u32) << 1
-            | (self.z.is_sign_negative() as u32) << 2
+            | ((self.y.is_sign_negative() as u32) << 1)
+            | ((self.z.is_sign_negative() as u32) << 2)
     }
 
     /// Returns `true` if, and only if, all elements are finite.  If any element is either

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -1985,7 +1985,6 @@ impl From<BVec4> for Vec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for Vec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -452,9 +452,9 @@ impl Vec4 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_sign_negative() as u32)
-            | (self.y.is_sign_negative() as u32) << 1
-            | (self.z.is_sign_negative() as u32) << 2
-            | (self.w.is_sign_negative() as u32) << 3
+            | ((self.y.is_sign_negative() as u32) << 1)
+            | ((self.z.is_sign_negative() as u32) << 2)
+            | ((self.w.is_sign_negative() as u32) << 3)
     }
 
     /// Returns `true` if, and only if, all elements are finite.  If any element is either

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -1862,7 +1862,6 @@ impl From<BVec4> for Vec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for Vec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -355,7 +355,7 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
-        (self.x.is_sign_negative() as u32) | (self.y.is_sign_negative() as u32) << 1
+        (self.x.is_sign_negative() as u32) | ((self.y.is_sign_negative() as u32) << 1)
     }
 
     /// Returns `true` if, and only if, all elements are finite.  If any element is either

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -409,8 +409,8 @@ impl Vec3 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_sign_negative() as u32)
-            | (self.y.is_sign_negative() as u32) << 1
-            | (self.z.is_sign_negative() as u32) << 2
+            | ((self.y.is_sign_negative() as u32) << 1)
+            | ((self.z.is_sign_negative() as u32) << 2)
     }
 
     /// Returns `true` if, and only if, all elements are finite.  If any element is either

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -1815,7 +1815,6 @@ impl From<BVec4> for Vec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for Vec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -355,7 +355,7 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
-        (self.x.is_sign_negative() as u32) | (self.y.is_sign_negative() as u32) << 1
+        (self.x.is_sign_negative() as u32) | ((self.y.is_sign_negative() as u32) << 1)
     }
 
     /// Returns `true` if, and only if, all elements are finite.  If any element is either

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -409,8 +409,8 @@ impl DVec3 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_sign_negative() as u32)
-            | (self.y.is_sign_negative() as u32) << 1
-            | (self.z.is_sign_negative() as u32) << 2
+            | ((self.y.is_sign_negative() as u32) << 1)
+            | ((self.z.is_sign_negative() as u32) << 2)
     }
 
     /// Returns `true` if, and only if, all elements are finite.  If any element is either

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -1996,7 +1996,6 @@ impl From<BVec4> for DVec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for DVec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -441,9 +441,9 @@ impl DVec4 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_sign_negative() as u32)
-            | (self.y.is_sign_negative() as u32) << 1
-            | (self.z.is_sign_negative() as u32) << 2
-            | (self.w.is_sign_negative() as u32) << 3
+            | ((self.y.is_sign_negative() as u32) << 1)
+            | ((self.z.is_sign_negative() as u32) << 2)
+            | ((self.w.is_sign_negative() as u32) << 3)
     }
 
     /// Returns `true` if, and only if, all elements are finite.  If any element is either

--- a/src/f64/math.rs
+++ b/src/f64/math.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "libm")]
+#[cfg(any(feature = "libm", all(feature = "nostd-libm", not(feature = "std"))))]
 mod libm_math {
     #[inline(always)]
     pub(crate) fn abs(f: f64) -> f64 {
@@ -105,7 +105,7 @@ mod libm_math {
     }
 }
 
-#[cfg(not(feature = "libm"))]
+#[cfg(all(not(feature = "libm"), feature = "std"))]
 mod std_math {
     #[inline(always)]
     pub(crate) fn abs(f: f64) -> f64 {
@@ -198,8 +198,8 @@ mod std_math {
     }
 }
 
-#[cfg(feature = "libm")]
+#[cfg(any(feature = "libm", all(feature = "nostd-libm", not(feature = "std"))))]
 pub(crate) use libm_math::*;
 
-#[cfg(not(feature = "libm"))]
+#[cfg(all(not(feature = "libm"), feature = "std"))]
 pub(crate) use std_math::*;

--- a/src/features/impl_rkyv.rs
+++ b/src/features/impl_rkyv.rs
@@ -46,6 +46,7 @@ macro_rules! impl_rkyv_derive {
 
             #[inline]
             unsafe fn resolve(&self, _: usize, _: Self::Resolver, out: *mut Self::Archived) {
+                #[allow(unexpected_cfgs)]
                 out.write(to_archived!(*self as Self));
             }
         }
@@ -53,6 +54,7 @@ macro_rules! impl_rkyv_derive {
         impl<D: Fallible + ?Sized> Deserialize<$type, D> for $type {
             #[inline]
             fn deserialize(&self, _: &mut D) -> Result<$type, D::Error> {
+                #[allow(unexpected_cfgs)]
                 Ok(from_archived!(*self))
             }
         }

--- a/src/features/impl_serde.rs
+++ b/src/features/impl_serde.rs
@@ -1295,7 +1295,7 @@ mod euler {
             }
             struct FieldVisitor;
 
-            impl<'de> serde::de::Visitor<'de> for FieldVisitor {
+            impl serde::de::Visitor<'_> for FieldVisitor {
                 type Value = Field;
                 fn expecting(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
                     core::fmt::Formatter::write_str(formatter, "a variant identifier")

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -337,7 +337,7 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
-        (self.x.is_negative() as u32) | (self.y.is_negative() as u32) << 1
+        (self.x.is_negative() as u32) | ((self.y.is_negative() as u32) << 1)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -392,8 +392,8 @@ impl I16Vec3 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_negative() as u32)
-            | (self.y.is_negative() as u32) << 1
-            | (self.z.is_negative() as u32) << 2
+            | ((self.y.is_negative() as u32) << 1)
+            | ((self.z.is_negative() as u32) << 2)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -2072,7 +2072,6 @@ impl From<BVec4> for I16Vec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for I16Vec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -421,9 +421,9 @@ impl I16Vec4 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_negative() as u32)
-            | (self.y.is_negative() as u32) << 1
-            | (self.z.is_negative() as u32) << 2
-            | (self.w.is_negative() as u32) << 3
+            | ((self.y.is_negative() as u32) << 1)
+            | ((self.z.is_negative() as u32) << 2)
+            | ((self.w.is_negative() as u32) << 3)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -337,7 +337,7 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
-        (self.x.is_negative() as u32) | (self.y.is_negative() as u32) << 1
+        (self.x.is_negative() as u32) | ((self.y.is_negative() as u32) << 1)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -392,8 +392,8 @@ impl IVec3 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_negative() as u32)
-            | (self.y.is_negative() as u32) << 1
-            | (self.z.is_negative() as u32) << 2
+            | ((self.y.is_negative() as u32) << 1)
+            | ((self.z.is_negative() as u32) << 2)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -421,9 +421,9 @@ impl IVec4 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_negative() as u32)
-            | (self.y.is_negative() as u32) << 1
-            | (self.z.is_negative() as u32) << 2
-            | (self.w.is_negative() as u32) << 3
+            | ((self.y.is_negative() as u32) << 1)
+            | ((self.z.is_negative() as u32) << 2)
+            | ((self.w.is_negative() as u32) << 3)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -2068,7 +2068,6 @@ impl From<BVec4> for IVec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for IVec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -337,7 +337,7 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
-        (self.x.is_negative() as u32) | (self.y.is_negative() as u32) << 1
+        (self.x.is_negative() as u32) | ((self.y.is_negative() as u32) << 1)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -392,8 +392,8 @@ impl I64Vec3 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_negative() as u32)
-            | (self.y.is_negative() as u32) << 1
-            | (self.z.is_negative() as u32) << 2
+            | ((self.y.is_negative() as u32) << 1)
+            | ((self.z.is_negative() as u32) << 2)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -2064,7 +2064,6 @@ impl From<BVec4> for I64Vec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for I64Vec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -421,9 +421,9 @@ impl I64Vec4 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_negative() as u32)
-            | (self.y.is_negative() as u32) << 1
-            | (self.z.is_negative() as u32) << 2
-            | (self.w.is_negative() as u32) << 3
+            | ((self.y.is_negative() as u32) << 1)
+            | ((self.z.is_negative() as u32) << 2)
+            | ((self.w.is_negative() as u32) << 3)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -337,7 +337,7 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
-        (self.x.is_negative() as u32) | (self.y.is_negative() as u32) << 1
+        (self.x.is_negative() as u32) | ((self.y.is_negative() as u32) << 1)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -392,8 +392,8 @@ impl I8Vec3 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_negative() as u32)
-            | (self.y.is_negative() as u32) << 1
-            | (self.z.is_negative() as u32) << 2
+            | ((self.y.is_negative() as u32) << 1)
+            | ((self.z.is_negative() as u32) << 2)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -421,9 +421,9 @@ impl I8Vec4 {
     #[must_use]
     pub fn is_negative_bitmask(self) -> u32 {
         (self.x.is_negative() as u32)
-            | (self.y.is_negative() as u32) << 1
-            | (self.z.is_negative() as u32) << 2
-            | (self.w.is_negative() as u32) << 3
+            | ((self.y.is_negative() as u32) << 1)
+            | ((self.z.is_negative() as u32) << 2)
+            | ((self.w.is_negative() as u32) << 3)
     }
 
     /// Computes the squared length of `self`.

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -2071,7 +2071,6 @@ impl From<BVec4> for I8Vec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for I8Vec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,8 @@ and benchmarks.
 * `std` - the default feature, has no dependencies.
 * `approx` - traits and macros for approximate float comparisons
 * `bytemuck` - for casting into slices of bytes
-* `libm` - uses `libm` math functions instead of `std`, required to compile with `no_std`
+* `libm` - uses `libm` math functions instead of `std`
+* `nostd-libm` - uses `libm` math functions if `std` is not available
 * `mint` - for interoperating with other 3D math libraries
 * `rand` - implementations of `Distribution` trait for all `glam` types.
 * `rkyv` - implementations of `Archive`, `Serialize` and `Deserialize` for all
@@ -256,7 +257,7 @@ and benchmarks.
 The minimum supported Rust version is `1.68.2`.
 
 */
-#![doc(html_root_url = "https://docs.rs/glam/0.29.2")]
+#![doc(html_root_url = "https://docs.rs/glam/0.29.3")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(target_arch = "spirv", feature(repr_simd))]
 #![deny(

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -1930,7 +1930,6 @@ impl From<BVec4> for U16Vec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for U16Vec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -1928,7 +1928,6 @@ impl From<BVec4> for UVec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for UVec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -1926,7 +1926,6 @@ impl From<BVec4> for U64Vec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for U64Vec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -1927,7 +1927,6 @@ impl From<BVec4> for U8Vec4 {
 }
 
 #[cfg(not(feature = "scalar-math"))]
-
 impl From<BVec4A> for U8Vec4 {
     #[inline]
     fn from(v: BVec4A) -> Self {


### PR DESCRIPTION
# Objective

- Fixes #620

## Solution

- Cherry-picks the changes from #617 
- Bumps the version to 0.29.3

## Code generation

- Modified templates to minimise Clippy lints in current Rust version. Refer to individual commits for specific actions taken.

## Testing and linting

- Linted
