### PR TITLE
Change scalar min and max functions to use comparison operators instead of primitive methods

### DIFF
--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -235,7 +235,7 @@ impl Vec3A {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -247,7 +247,7 @@ impl Vec3A {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -54,6 +54,17 @@ impl Vec3A {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec3A uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = true;
+    /// Vec3A uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec3A uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec3A uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec3A uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -237,7 +237,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -249,7 +249,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -260,6 +260,9 @@ impl Vec3A {
     /// Component-wise clamping of values, similar to [`f32::clamp`].
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     ///
     /// # Panics
     ///
@@ -274,6 +277,9 @@ impl Vec3A {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
@@ -286,6 +292,9 @@ impl Vec3A {
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -242,7 +242,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self(self.0.simd_min(rhs.0))
+        Self(self.0.simd_lt(rhs.0).select(self.0, rhs.0))
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -254,7 +254,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self(self.0.simd_max(rhs.0))
+        Self(self.0.simd_gt(rhs.0).select(self.0, rhs.0))
     }
 
     /// Component-wise clamping of values, similar to [`f32::clamp`].
@@ -283,9 +283,10 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
+        let min = |a: f32x4, b: f32x4| a.simd_lt(b).select(a, b);
         let v = self.0;
-        let v = v.simd_min(simd_swizzle!(v, [2, 2, 1, 1]));
-        let v = v.simd_min(simd_swizzle!(v, [1, 0, 0, 0]));
+        let v = min(v, simd_swizzle!(v, [2, 2, 1, 1]));
+        let v = min(v, simd_swizzle!(v, [1, 0, 0, 0]));
         v[0]
     }
 
@@ -298,9 +299,10 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {
+        let max = |a: f32x4, b: f32x4| a.simd_gt(b).select(a, b);
         let v = self.0;
-        let v = v.simd_max(simd_swizzle!(v, [2, 2, 0, 0]));
-        let v = v.simd_max(simd_swizzle!(v, [1, 0, 0, 0]));
+        let v = max(v, simd_swizzle!(v, [2, 2, 0, 0]));
+        let v = max(v, simd_swizzle!(v, [1, 0, 0, 0]));
         v[0]
     }
 

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -54,17 +54,6 @@ impl Vec3A {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec3A uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = true;
-    /// Vec3A uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// Vec3A uses scalar math
-    pub const USES_SCALAR_MATH: bool = false;
-    /// Vec3A uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// Vec3A uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 
@@ -85,6 +74,17 @@ impl Vec3A {
 
     /// The unit axes.
     pub const AXES: [Self; 3] = [Self::X, Self::Y, Self::Z];
+
+    /// Vec3A uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = true;
+    /// Vec3A uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec3A uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec3A uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec3A uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -236,6 +236,9 @@ impl Vec3A {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -245,6 +248,9 @@ impl Vec3A {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -50,17 +50,6 @@ impl Vec4 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec4 uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = true;
-    /// Vec4 uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// Vec4 uses scalar math
-    pub const USES_SCALAR_MATH: bool = false;
-    /// Vec4 uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// Vec4 uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 
@@ -87,6 +76,17 @@ impl Vec4 {
 
     /// The unit axes.
     pub const AXES: [Self; 4] = [Self::X, Self::Y, Self::Z, Self::W];
+
+    /// Vec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = true;
+    /// Vec4 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec4 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -219,7 +219,7 @@ impl Vec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -231,7 +231,7 @@ impl Vec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -221,7 +221,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -233,7 +233,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -244,6 +244,9 @@ impl Vec4 {
     /// Component-wise clamping of values, similar to [`f32::clamp`].
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     ///
     /// # Panics
     ///
@@ -258,6 +261,9 @@ impl Vec4 {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
@@ -267,6 +273,9 @@ impl Vec4 {
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -226,7 +226,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self(self.0.simd_min(rhs.0))
+        Self(self.0.simd_lt(rhs.0).select(self.0, rhs.0))
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -238,7 +238,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self(self.0.simd_max(rhs.0))
+        Self(self.0.simd_gt(rhs.0).select(self.0, rhs.0))
     }
 
     /// Component-wise clamping of values, similar to [`f32::clamp`].
@@ -267,7 +267,11 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
-        self.0.reduce_min()
+        let min = |a: f32x4, b: f32x4| a.simd_lt(b).select(a, b);
+        let v = self.0;
+        let v = min(v, simd_swizzle!(v, [2, 3, 0, 0]));
+        let v = min(v, simd_swizzle!(v, [1, 0, 0, 0]));
+        v[0]
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -279,7 +283,11 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {
-        self.0.reduce_max()
+        let max = |a: f32x4, b: f32x4| a.simd_gt(b).select(a, b);
+        let v = self.0;
+        let v = max(v, simd_swizzle!(v, [2, 3, 0, 0]));
+        let v = max(v, simd_swizzle!(v, [1, 0, 0, 0]));
+        v[0]
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -50,6 +50,17 @@ impl Vec4 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = true;
+    /// Vec4 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec4 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -220,6 +220,9 @@ impl Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -229,6 +232,9 @@ impl Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -259,6 +259,9 @@ impl Vec3A {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -268,6 +271,9 @@ impl Vec3A {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -59,6 +59,17 @@ impl Vec3A {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec3A uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec3A uses Arm NEON
+    pub const USES_NEON: bool = true;
+    /// Vec3A uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec3A uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec3A uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -260,7 +260,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -272,7 +272,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -283,6 +283,9 @@ impl Vec3A {
     /// Component-wise clamping of values, similar to [`f32::clamp`].
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     ///
     /// # Panics
     ///
@@ -297,6 +300,9 @@ impl Vec3A {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
@@ -306,6 +312,9 @@ impl Vec3A {
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -258,7 +258,7 @@ impl Vec3A {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -270,7 +270,7 @@ impl Vec3A {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -59,17 +59,6 @@ impl Vec3A {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec3A uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// Vec3A uses Arm NEON
-    pub const USES_NEON: bool = true;
-    /// Vec3A uses scalar math
-    pub const USES_SCALAR_MATH: bool = false;
-    /// Vec3A uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// Vec3A uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 
@@ -90,6 +79,17 @@ impl Vec3A {
 
     /// The unit axes.
     pub const AXES: [Self; 3] = [Self::X, Self::Y, Self::Z];
+
+    /// Vec3A uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec3A uses Arm NEON
+    pub const USES_NEON: bool = true;
+    /// Vec3A uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec3A uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec3A uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -55,17 +55,6 @@ impl Vec4 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec4 uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// Vec4 uses Arm NEON
-    pub const USES_NEON: bool = true;
-    /// Vec4 uses scalar math
-    pub const USES_SCALAR_MATH: bool = false;
-    /// Vec4 uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// Vec4 uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 
@@ -92,6 +81,17 @@ impl Vec4 {
 
     /// The unit axes.
     pub const AXES: [Self; 4] = [Self::X, Self::Y, Self::Z, Self::W];
+
+    /// Vec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec4 uses Arm NEON
+    pub const USES_NEON: bool = true;
+    /// Vec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec4 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -55,6 +55,17 @@ impl Vec4 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec4 uses Arm NEON
+    pub const USES_NEON: bool = true;
+    /// Vec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec4 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -227,7 +227,7 @@ impl Vec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -239,7 +239,7 @@ impl Vec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -229,7 +229,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -241,7 +241,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -252,6 +252,9 @@ impl Vec4 {
     /// Component-wise clamping of values, similar to [`f32::clamp`].
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     ///
     /// # Panics
     ///
@@ -266,6 +269,9 @@ impl Vec4 {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
@@ -275,6 +281,9 @@ impl Vec4 {
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -228,6 +228,9 @@ impl Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -237,6 +240,9 @@ impl Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -247,7 +247,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -263,7 +263,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -279,6 +279,9 @@ impl Vec3A {
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
     ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
+    ///
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
@@ -292,19 +295,29 @@ impl Vec3A {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -245,7 +245,7 @@ impl Vec3A {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -261,7 +261,7 @@ impl Vec3A {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -246,26 +246,32 @@ impl Vec3A {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -57,6 +57,17 @@ impl Vec3A {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec3A uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec3A uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec3A uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// Vec3A uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec3A uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -57,17 +57,6 @@ impl Vec3A {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec3A uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// Vec3A uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// Vec3A uses scalar math
-    pub const USES_SCALAR_MATH: bool = true;
-    /// Vec3A uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// Vec3A uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 
@@ -88,6 +77,17 @@ impl Vec3A {
 
     /// The unit axes.
     pub const AXES: [Self; 3] = [Self::X, Self::Y, Self::Z];
+
+    /// Vec3A uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec3A uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec3A uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// Vec3A uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec3A uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -302,7 +302,6 @@ impl Vec3A {
     #[must_use]
     pub fn min_element(self) -> f32 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -316,7 +315,6 @@ impl Vec3A {
     #[must_use]
     pub fn max_element(self) -> f32 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -244,28 +244,34 @@ impl Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
-            w: self.w.min(rhs.w),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
+            w: if self.w < rhs.w { self.w } else { rhs.w },
         }
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
-            w: self.w.max(rhs.w),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
+            w: if self.w > rhs.w { self.w } else { rhs.w },
         }
     }
 

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -243,7 +243,7 @@ impl Vec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -260,7 +260,7 @@ impl Vec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -245,7 +245,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -262,7 +262,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -279,6 +279,9 @@ impl Vec4 {
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
     ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
+    ///
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
@@ -292,19 +295,29 @@ impl Vec4 {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
-        self.x.min(self.y.min(self.z.min(self.w)))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, min(self.z, self.w)))
     }
 
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {
-        self.x.max(self.y.max(self.z.max(self.w)))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, max(self.z, self.w)))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -302,7 +302,6 @@ impl Vec4 {
     #[must_use]
     pub fn min_element(self) -> f32 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, min(self.z, self.w)))
     }
 
@@ -316,7 +315,6 @@ impl Vec4 {
     #[must_use]
     pub fn max_element(self) -> f32 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, max(self.z, self.w)))
     }
 

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -61,17 +61,6 @@ impl Vec4 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec4 uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// Vec4 uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// Vec4 uses scalar math
-    pub const USES_SCALAR_MATH: bool = true;
-    /// Vec4 uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// Vec4 uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 
@@ -98,6 +87,17 @@ impl Vec4 {
 
     /// The unit axes.
     pub const AXES: [Self; 4] = [Self::X, Self::Y, Self::Z, Self::W];
+
+    /// Vec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec4 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// Vec4 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -61,6 +61,17 @@ impl Vec4 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec4 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// Vec4 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -255,7 +255,7 @@ impl Vec3A {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -267,7 +267,7 @@ impl Vec3A {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -62,6 +62,17 @@ impl Vec3A {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec3A uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec3A uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec3A uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec3A uses Intel SSE2
+    pub const USES_SSE2: bool = true;
+    /// Vec3A uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -256,6 +256,9 @@ impl Vec3A {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -265,6 +268,9 @@ impl Vec3A {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -257,7 +257,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -269,7 +269,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -280,6 +280,9 @@ impl Vec3A {
     /// Component-wise clamping of values, similar to [`f32::clamp`].
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     ///
     /// # Panics
     ///
@@ -294,6 +297,9 @@ impl Vec3A {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
@@ -308,6 +314,9 @@ impl Vec3A {
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -62,17 +62,6 @@ impl Vec3A {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec3A uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// Vec3A uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// Vec3A uses scalar math
-    pub const USES_SCALAR_MATH: bool = false;
-    /// Vec3A uses Intel SSE2
-    pub const USES_SSE2: bool = true;
-    /// Vec3A uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 
@@ -93,6 +82,17 @@ impl Vec3A {
 
     /// The unit axes.
     pub const AXES: [Self; 3] = [Self::X, Self::Y, Self::Z];
+
+    /// Vec3A uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec3A uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec3A uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec3A uses Intel SSE2
+    pub const USES_SSE2: bool = true;
+    /// Vec3A uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -235,7 +235,7 @@ impl Vec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -247,7 +247,7 @@ impl Vec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -237,7 +237,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -249,7 +249,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -260,6 +260,9 @@ impl Vec4 {
     /// Component-wise clamping of values, similar to [`f32::clamp`].
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     ///
     /// # Panics
     ///
@@ -274,6 +277,9 @@ impl Vec4 {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
@@ -288,6 +294,9 @@ impl Vec4 {
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -58,17 +58,6 @@ impl Vec4 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec4 uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// Vec4 uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// Vec4 uses scalar math
-    pub const USES_SCALAR_MATH: bool = false;
-    /// Vec4 uses Intel SSE2
-    pub const USES_SSE2: bool = true;
-    /// Vec4 uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 
@@ -95,6 +84,17 @@ impl Vec4 {
 
     /// The unit axes.
     pub const AXES: [Self; 4] = [Self::X, Self::Y, Self::Z, Self::W];
+
+    /// Vec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec4 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec4 uses Intel SSE2
+    pub const USES_SSE2: bool = true;
+    /// Vec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -58,6 +58,17 @@ impl Vec4 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec4 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec4 uses Intel SSE2
+    pub const USES_SSE2: bool = true;
+    /// Vec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -236,6 +236,9 @@ impl Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -245,6 +248,9 @@ impl Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -189,7 +189,7 @@ impl Vec2 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -204,7 +204,7 @@ impl Vec2 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -219,6 +219,9 @@ impl Vec2 {
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
     ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
+    ///
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
@@ -232,19 +235,29 @@ impl Vec2 {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
-        self.x.min(self.y)
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, self.y)
     }
 
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {
-        self.x.max(self.y)
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, self.y)
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -48,17 +48,6 @@ impl Vec2 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec2 uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// Vec2 uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// Vec2 uses scalar math
-    pub const USES_SCALAR_MATH: bool = true;
-    /// Vec2 uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// Vec2 uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0);
 
@@ -73,6 +62,17 @@ impl Vec2 {
 
     /// The unit axes.
     pub const AXES: [Self; 2] = [Self::X, Self::Y];
+
+    /// Vec2 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec2 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec2 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// Vec2 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec2 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -242,7 +242,6 @@ impl Vec2 {
     #[must_use]
     pub fn min_element(self) -> f32 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, self.y)
     }
 
@@ -256,7 +255,6 @@ impl Vec2 {
     #[must_use]
     pub fn max_element(self) -> f32 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, self.y)
     }
 

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -188,24 +188,30 @@ impl Vec2 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
         }
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
         }
     }
 

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -48,6 +48,17 @@ impl Vec2 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec2 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec2 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec2 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// Vec2 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec2 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0);
 

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -187,7 +187,7 @@ impl Vec2 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -202,7 +202,7 @@ impl Vec2 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -235,7 +235,7 @@ impl Vec3 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -251,7 +251,7 @@ impl Vec3 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -236,26 +236,32 @@ impl Vec3 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -48,17 +48,6 @@ impl Vec3 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec3 uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// Vec3 uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// Vec3 uses scalar math
-    pub const USES_SCALAR_MATH: bool = true;
-    /// Vec3 uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// Vec3 uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 
@@ -79,6 +68,17 @@ impl Vec3 {
 
     /// The unit axes.
     pub const AXES: [Self; 3] = [Self::X, Self::Y, Self::Z];
+
+    /// Vec3 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec3 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec3 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// Vec3 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec3 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -237,7 +237,7 @@ impl Vec3 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -253,7 +253,7 @@ impl Vec3 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -269,6 +269,9 @@ impl Vec3 {
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
     ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
+    ///
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
@@ -282,19 +285,29 @@ impl Vec3 {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -292,7 +292,6 @@ impl Vec3 {
     #[must_use]
     pub fn min_element(self) -> f32 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -306,7 +305,6 @@ impl Vec3 {
     #[must_use]
     pub fn max_element(self) -> f32 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -48,6 +48,17 @@ impl Vec3 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec3 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec3 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec3 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// Vec3 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec3 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -235,6 +235,9 @@ impl Vec3A {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -244,6 +247,9 @@ impl Vec3A {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -53,17 +53,6 @@ impl Vec3A {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec3A uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// Vec3A uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// Vec3A uses scalar math
-    pub const USES_SCALAR_MATH: bool = false;
-    /// Vec3A uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// Vec3A uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = true;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 
@@ -84,6 +73,17 @@ impl Vec3A {
 
     /// The unit axes.
     pub const AXES: [Self; 3] = [Self::X, Self::Y, Self::Z];
+
+    /// Vec3A uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec3A uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec3A uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec3A uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec3A uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = true;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -234,7 +234,7 @@ impl Vec3A {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -246,7 +246,7 @@ impl Vec3A {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -53,6 +53,17 @@ impl Vec3A {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec3A uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec3A uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec3A uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec3A uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec3A uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = true;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -236,7 +236,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -248,7 +248,7 @@ impl Vec3A {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -259,6 +259,9 @@ impl Vec3A {
     /// Component-wise clamping of values, similar to [`f32::clamp`].
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     ///
     /// # Panics
     ///
@@ -273,6 +276,9 @@ impl Vec3A {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
@@ -285,6 +291,9 @@ impl Vec3A {
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -219,6 +219,9 @@ impl Vec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -228,6 +231,9 @@ impl Vec4 {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -220,7 +220,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -232,7 +232,7 @@ impl Vec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -243,6 +243,9 @@ impl Vec4 {
     /// Component-wise clamping of values, similar to [`f32::clamp`].
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     ///
     /// # Panics
     ///
@@ -257,6 +260,9 @@ impl Vec4 {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f32 {
@@ -269,6 +275,9 @@ impl Vec4 {
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f32 {

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -49,6 +49,17 @@ impl Vec4 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
+    /// Vec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec4 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec4 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = true;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -218,7 +218,7 @@ impl Vec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -230,7 +230,7 @@ impl Vec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -49,17 +49,6 @@ impl Vec4 {
     /// All `f32::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f32::NEG_INFINITY);
 
-    /// Vec4 uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// Vec4 uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// Vec4 uses scalar math
-    pub const USES_SCALAR_MATH: bool = false;
-    /// Vec4 uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// Vec4 uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = true;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 
@@ -86,6 +75,17 @@ impl Vec4 {
 
     /// The unit axes.
     pub const AXES: [Self; 4] = [Self::X, Self::Y, Self::Z, Self::W];
+
+    /// Vec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// Vec4 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// Vec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = false;
+    /// Vec4 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// Vec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = true;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -189,7 +189,7 @@ impl DVec2 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -204,7 +204,7 @@ impl DVec2 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -219,6 +219,9 @@ impl DVec2 {
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
     ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
+    ///
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
@@ -232,19 +235,29 @@ impl DVec2 {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f64 {
-        self.x.min(self.y)
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, self.y)
     }
 
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f64 {
-        self.x.max(self.y)
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, self.y)
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -48,17 +48,6 @@ impl DVec2 {
     /// All `f64::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f64::NEG_INFINITY);
 
-    /// DVec2 uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// DVec2 uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// DVec2 uses scalar math
-    pub const USES_SCALAR_MATH: bool = true;
-    /// DVec2 uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// DVec2 uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0);
 
@@ -73,6 +62,17 @@ impl DVec2 {
 
     /// The unit axes.
     pub const AXES: [Self; 2] = [Self::X, Self::Y];
+
+    /// DVec2 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// DVec2 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// DVec2 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// DVec2 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// DVec2 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -242,7 +242,6 @@ impl DVec2 {
     #[must_use]
     pub fn min_element(self) -> f64 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, self.y)
     }
 
@@ -256,7 +255,6 @@ impl DVec2 {
     #[must_use]
     pub fn max_element(self) -> f64 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, self.y)
     }
 

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -188,24 +188,30 @@ impl DVec2 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
         }
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
         }
     }
 

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -48,6 +48,17 @@ impl DVec2 {
     /// All `f64::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f64::NEG_INFINITY);
 
+    /// DVec2 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// DVec2 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// DVec2 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// DVec2 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// DVec2 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0);
 

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -187,7 +187,7 @@ impl DVec2 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -202,7 +202,7 @@ impl DVec2 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -237,7 +237,7 @@ impl DVec3 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -253,7 +253,7 @@ impl DVec3 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -269,6 +269,9 @@ impl DVec3 {
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
     ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
+    ///
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
@@ -282,19 +285,29 @@ impl DVec3 {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f64 {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f64 {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -235,7 +235,7 @@ impl DVec3 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -251,7 +251,7 @@ impl DVec3 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -48,6 +48,17 @@ impl DVec3 {
     /// All `f64::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f64::NEG_INFINITY);
 
+    /// DVec3 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// DVec3 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// DVec3 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// DVec3 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// DVec3 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -292,7 +292,6 @@ impl DVec3 {
     #[must_use]
     pub fn min_element(self) -> f64 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -306,7 +305,6 @@ impl DVec3 {
     #[must_use]
     pub fn max_element(self) -> f64 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -48,17 +48,6 @@ impl DVec3 {
     /// All `f64::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f64::NEG_INFINITY);
 
-    /// DVec3 uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// DVec3 uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// DVec3 uses scalar math
-    pub const USES_SCALAR_MATH: bool = true;
-    /// DVec3 uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// DVec3 uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0);
 
@@ -79,6 +68,17 @@ impl DVec3 {
 
     /// The unit axes.
     pub const AXES: [Self; 3] = [Self::X, Self::Y, Self::Z];
+
+    /// DVec3 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// DVec3 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// DVec3 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// DVec3 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// DVec3 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -236,26 +236,32 @@ impl DVec3 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -52,6 +52,17 @@ impl DVec4 {
     /// All `f64::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f64::NEG_INFINITY);
 
+    /// DVec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// DVec4 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// DVec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// DVec4 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// DVec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
+
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -291,7 +291,6 @@ impl DVec4 {
     #[must_use]
     pub fn min_element(self) -> f64 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, min(self.z, self.w)))
     }
 
@@ -305,7 +304,6 @@ impl DVec4 {
     #[must_use]
     pub fn max_element(self) -> f64 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, max(self.z, self.w)))
     }
 

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -233,28 +233,34 @@ impl DVec4 {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
-            w: self.w.min(rhs.w),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
+            w: if self.w < rhs.w { self.w } else { rhs.w },
         }
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    ///
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
-            w: self.w.max(rhs.w),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
+            w: if self.w > rhs.w { self.w } else { rhs.w },
         }
     }
 

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -52,17 +52,6 @@ impl DVec4 {
     /// All `f64::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat(f64::NEG_INFINITY);
 
-    /// DVec4 uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = false;
-    /// DVec4 uses Arm NEON
-    pub const USES_NEON: bool = false;
-    /// DVec4 uses scalar math
-    pub const USES_SCALAR_MATH: bool = true;
-    /// DVec4 uses Intel SSE2
-    pub const USES_SSE2: bool = false;
-    /// DVec4 uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = false;
-
     /// A unit vector pointing along the positive X axis.
     pub const X: Self = Self::new(1.0, 0.0, 0.0, 0.0);
 
@@ -89,6 +78,17 @@ impl DVec4 {
 
     /// The unit axes.
     pub const AXES: [Self; 4] = [Self::X, Self::Y, Self::Z, Self::W];
+
+    /// DVec4 uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = false;
+    /// DVec4 uses Arm NEON
+    pub const USES_NEON: bool = false;
+    /// DVec4 uses scalar math
+    pub const USES_SCALAR_MATH: bool = true;
+    /// DVec4 uses Intel SSE2
+    pub const USES_SSE2: bool = false;
+    /// DVec4 uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = false;
 
     /// Creates a new vector.
     #[inline(always)]

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -234,7 +234,7 @@ impl DVec4 {
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -251,7 +251,7 @@ impl DVec4 {
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
     ///
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
     #[inline]
     #[must_use]
@@ -268,6 +268,9 @@ impl DVec4 {
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
     ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
+    ///
     /// # Panics
     ///
     /// Will panic if `min` is greater than `max` when `glam_assert` is enabled.
@@ -281,19 +284,29 @@ impl DVec4 {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn min_element(self) -> f64 {
-        self.x.min(self.y.min(self.z.min(self.w)))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, min(self.z, self.w)))
     }
 
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+    ///
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
     #[inline]
     #[must_use]
     pub fn max_element(self) -> f64 {
-        self.x.max(self.y.max(self.z.max(self.w)))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, max(self.z, self.w)))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -232,7 +232,7 @@ impl DVec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
@@ -249,7 +249,7 @@ impl DVec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     ///
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -211,7 +211,6 @@ impl I16Vec2 {
     #[must_use]
     pub fn min_element(self) -> i16 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, self.y)
     }
 
@@ -222,7 +221,6 @@ impl I16Vec2 {
     #[must_use]
     pub fn max_element(self) -> i16 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, self.y)
     }
 

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -173,8 +173,8 @@ impl I16Vec2 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
         }
     }
 
@@ -185,8 +185,8 @@ impl I16Vec2 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
         }
     }
 

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -168,7 +168,7 @@ impl I16Vec2 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -180,7 +180,7 @@ impl I16Vec2 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -210,7 +210,9 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i16 {
-        self.x.min(self.y)
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, self.y)
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -219,7 +221,9 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i16 {
-        self.x.max(self.y)
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, self.y)
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -224,9 +224,9 @@ impl I16Vec3 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
@@ -237,9 +237,9 @@ impl I16Vec3 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -263,7 +263,9 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i16 {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -272,7 +274,9 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i16 {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -264,7 +264,6 @@ impl I16Vec3 {
     #[must_use]
     pub fn min_element(self) -> i16 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -275,7 +274,6 @@ impl I16Vec3 {
     #[must_use]
     pub fn max_element(self) -> i16 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -219,7 +219,7 @@ impl I16Vec3 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -232,7 +232,7 @@ impl I16Vec3 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -262,7 +262,6 @@ impl I16Vec4 {
     #[must_use]
     pub fn min_element(self) -> i16 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, min(self.z, self.w)))
     }
 
@@ -273,7 +272,6 @@ impl I16Vec4 {
     #[must_use]
     pub fn max_element(self) -> i16 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, max(self.z, self.w)))
     }
 

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -261,7 +261,9 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i16 {
-        self.x.min(self.y.min(self.z.min(self.w)))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, min(self.z, self.w)))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -270,7 +272,9 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i16 {
-        self.x.max(self.y.max(self.z.max(self.w)))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, max(self.z, self.w)))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -215,7 +215,7 @@ impl I16Vec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -229,7 +229,7 @@ impl I16Vec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -220,10 +220,10 @@ impl I16Vec4 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
-            w: self.w.min(rhs.w),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
+            w: if self.w < rhs.w { self.w } else { rhs.w },
         }
     }
 
@@ -234,10 +234,10 @@ impl I16Vec4 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
-            w: self.w.max(rhs.w),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
+            w: if self.w > rhs.w { self.w } else { rhs.w },
         }
     }
 

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -173,8 +173,8 @@ impl IVec2 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
         }
     }
 
@@ -185,8 +185,8 @@ impl IVec2 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
         }
     }
 

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -210,7 +210,9 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i32 {
-        self.x.min(self.y)
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, self.y)
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -219,7 +221,9 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i32 {
-        self.x.max(self.y)
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, self.y)
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -211,7 +211,6 @@ impl IVec2 {
     #[must_use]
     pub fn min_element(self) -> i32 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, self.y)
     }
 
@@ -222,7 +221,6 @@ impl IVec2 {
     #[must_use]
     pub fn max_element(self) -> i32 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, self.y)
     }
 

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -168,7 +168,7 @@ impl IVec2 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -180,7 +180,7 @@ impl IVec2 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -224,9 +224,9 @@ impl IVec3 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
@@ -237,9 +237,9 @@ impl IVec3 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -263,7 +263,9 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i32 {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -272,7 +274,9 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i32 {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -219,7 +219,7 @@ impl IVec3 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -232,7 +232,7 @@ impl IVec3 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -264,7 +264,6 @@ impl IVec3 {
     #[must_use]
     pub fn min_element(self) -> i32 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -275,7 +274,6 @@ impl IVec3 {
     #[must_use]
     pub fn max_element(self) -> i32 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -261,7 +261,9 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i32 {
-        self.x.min(self.y.min(self.z.min(self.w)))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, min(self.z, self.w)))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -270,7 +272,9 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i32 {
-        self.x.max(self.y.max(self.z.max(self.w)))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, max(self.z, self.w)))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -220,10 +220,10 @@ impl IVec4 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
-            w: self.w.min(rhs.w),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
+            w: if self.w < rhs.w { self.w } else { rhs.w },
         }
     }
 
@@ -234,10 +234,10 @@ impl IVec4 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
-            w: self.w.max(rhs.w),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
+            w: if self.w > rhs.w { self.w } else { rhs.w },
         }
     }
 

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -215,7 +215,7 @@ impl IVec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -229,7 +229,7 @@ impl IVec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -262,7 +262,6 @@ impl IVec4 {
     #[must_use]
     pub fn min_element(self) -> i32 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, min(self.z, self.w)))
     }
 
@@ -273,7 +272,6 @@ impl IVec4 {
     #[must_use]
     pub fn max_element(self) -> i32 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, max(self.z, self.w)))
     }
 

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -168,7 +168,7 @@ impl I64Vec2 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -180,7 +180,7 @@ impl I64Vec2 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -173,8 +173,8 @@ impl I64Vec2 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
         }
     }
 
@@ -185,8 +185,8 @@ impl I64Vec2 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
         }
     }
 

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -211,7 +211,6 @@ impl I64Vec2 {
     #[must_use]
     pub fn min_element(self) -> i64 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, self.y)
     }
 
@@ -222,7 +221,6 @@ impl I64Vec2 {
     #[must_use]
     pub fn max_element(self) -> i64 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, self.y)
     }
 

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -210,7 +210,9 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i64 {
-        self.x.min(self.y)
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, self.y)
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -219,7 +221,9 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i64 {
-        self.x.max(self.y)
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, self.y)
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -263,7 +263,9 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i64 {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -272,7 +274,9 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i64 {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -224,9 +224,9 @@ impl I64Vec3 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
@@ -237,9 +237,9 @@ impl I64Vec3 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -219,7 +219,7 @@ impl I64Vec3 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -232,7 +232,7 @@ impl I64Vec3 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -264,7 +264,6 @@ impl I64Vec3 {
     #[must_use]
     pub fn min_element(self) -> i64 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -275,7 +274,6 @@ impl I64Vec3 {
     #[must_use]
     pub fn max_element(self) -> i64 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -261,7 +261,9 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i64 {
-        self.x.min(self.y.min(self.z.min(self.w)))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, min(self.z, self.w)))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -270,7 +272,9 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i64 {
-        self.x.max(self.y.max(self.z.max(self.w)))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, max(self.z, self.w)))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -215,7 +215,7 @@ impl I64Vec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -229,7 +229,7 @@ impl I64Vec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -262,7 +262,6 @@ impl I64Vec4 {
     #[must_use]
     pub fn min_element(self) -> i64 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, min(self.z, self.w)))
     }
 
@@ -273,7 +272,6 @@ impl I64Vec4 {
     #[must_use]
     pub fn max_element(self) -> i64 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, max(self.z, self.w)))
     }
 

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -220,10 +220,10 @@ impl I64Vec4 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
-            w: self.w.min(rhs.w),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
+            w: if self.w < rhs.w { self.w } else { rhs.w },
         }
     }
 
@@ -234,10 +234,10 @@ impl I64Vec4 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
-            w: self.w.max(rhs.w),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
+            w: if self.w > rhs.w { self.w } else { rhs.w },
         }
     }
 

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -173,8 +173,8 @@ impl I8Vec2 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
         }
     }
 
@@ -185,8 +185,8 @@ impl I8Vec2 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
         }
     }
 

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -211,7 +211,6 @@ impl I8Vec2 {
     #[must_use]
     pub fn min_element(self) -> i8 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, self.y)
     }
 
@@ -222,7 +221,6 @@ impl I8Vec2 {
     #[must_use]
     pub fn max_element(self) -> i8 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, self.y)
     }
 

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -210,7 +210,9 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i8 {
-        self.x.min(self.y)
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, self.y)
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -219,7 +221,9 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i8 {
-        self.x.max(self.y)
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, self.y)
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -168,7 +168,7 @@ impl I8Vec2 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -180,7 +180,7 @@ impl I8Vec2 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -264,7 +264,6 @@ impl I8Vec3 {
     #[must_use]
     pub fn min_element(self) -> i8 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -275,7 +274,6 @@ impl I8Vec3 {
     #[must_use]
     pub fn max_element(self) -> i8 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -263,7 +263,9 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i8 {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -272,7 +274,9 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i8 {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -219,7 +219,7 @@ impl I8Vec3 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -232,7 +232,7 @@ impl I8Vec3 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -224,9 +224,9 @@ impl I8Vec3 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
@@ -237,9 +237,9 @@ impl I8Vec3 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -261,7 +261,9 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> i8 {
-        self.x.min(self.y.min(self.z.min(self.w)))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, min(self.z, self.w)))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -270,7 +272,9 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> i8 {
-        self.x.max(self.y.max(self.z.max(self.w)))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, max(self.z, self.w)))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -262,7 +262,6 @@ impl I8Vec4 {
     #[must_use]
     pub fn min_element(self) -> i8 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, min(self.z, self.w)))
     }
 
@@ -273,7 +272,6 @@ impl I8Vec4 {
     #[must_use]
     pub fn max_element(self) -> i8 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, max(self.z, self.w)))
     }
 

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -215,7 +215,7 @@ impl I8Vec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -229,7 +229,7 @@ impl I8Vec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -220,10 +220,10 @@ impl I8Vec4 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
-            w: self.w.min(rhs.w),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
+            w: if self.w < rhs.w { self.w } else { rhs.w },
         }
     }
 
@@ -234,10 +234,10 @@ impl I8Vec4 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
-            w: self.w.max(rhs.w),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
+            w: if self.w > rhs.w { self.w } else { rhs.w },
         }
     }
 

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -201,7 +201,9 @@ impl U16Vec2 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u16 {
-        self.x.min(self.y)
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, self.y)
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -210,7 +212,9 @@ impl U16Vec2 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u16 {
-        self.x.max(self.y)
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, self.y)
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -202,7 +202,6 @@ impl U16Vec2 {
     #[must_use]
     pub fn min_element(self) -> u16 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, self.y)
     }
 
@@ -213,7 +212,6 @@ impl U16Vec2 {
     #[must_use]
     pub fn max_element(self) -> u16 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, self.y)
     }
 

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -159,7 +159,7 @@ impl U16Vec2 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -171,7 +171,7 @@ impl U16Vec2 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -164,8 +164,8 @@ impl U16Vec2 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
         }
     }
 
@@ -176,8 +176,8 @@ impl U16Vec2 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
         }
     }
 

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -212,9 +212,9 @@ impl U16Vec3 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
@@ -225,9 +225,9 @@ impl U16Vec3 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -252,7 +252,6 @@ impl U16Vec3 {
     #[must_use]
     pub fn min_element(self) -> u16 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -263,7 +262,6 @@ impl U16Vec3 {
     #[must_use]
     pub fn max_element(self) -> u16 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -251,7 +251,9 @@ impl U16Vec3 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u16 {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -260,7 +262,9 @@ impl U16Vec3 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u16 {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -207,7 +207,7 @@ impl U16Vec3 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -220,7 +220,7 @@ impl U16Vec3 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -205,10 +205,10 @@ impl U16Vec4 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
-            w: self.w.min(rhs.w),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
+            w: if self.w < rhs.w { self.w } else { rhs.w },
         }
     }
 
@@ -219,10 +219,10 @@ impl U16Vec4 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
-            w: self.w.max(rhs.w),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
+            w: if self.w > rhs.w { self.w } else { rhs.w },
         }
     }
 

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -200,7 +200,7 @@ impl U16Vec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -214,7 +214,7 @@ impl U16Vec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -246,7 +246,9 @@ impl U16Vec4 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u16 {
-        self.x.min(self.y.min(self.z.min(self.w)))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, min(self.z, self.w)))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -255,7 +257,9 @@ impl U16Vec4 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u16 {
-        self.x.max(self.y.max(self.z.max(self.w)))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, max(self.z, self.w)))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -247,7 +247,6 @@ impl U16Vec4 {
     #[must_use]
     pub fn min_element(self) -> u16 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, min(self.z, self.w)))
     }
 
@@ -258,7 +257,6 @@ impl U16Vec4 {
     #[must_use]
     pub fn max_element(self) -> u16 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, max(self.z, self.w)))
     }
 

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -159,7 +159,7 @@ impl UVec2 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -171,7 +171,7 @@ impl UVec2 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -202,7 +202,6 @@ impl UVec2 {
     #[must_use]
     pub fn min_element(self) -> u32 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, self.y)
     }
 
@@ -213,7 +212,6 @@ impl UVec2 {
     #[must_use]
     pub fn max_element(self) -> u32 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, self.y)
     }
 

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -164,8 +164,8 @@ impl UVec2 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
         }
     }
 
@@ -176,8 +176,8 @@ impl UVec2 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
         }
     }
 

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -201,7 +201,9 @@ impl UVec2 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u32 {
-        self.x.min(self.y)
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, self.y)
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -210,7 +212,9 @@ impl UVec2 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u32 {
-        self.x.max(self.y)
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, self.y)
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -207,7 +207,7 @@ impl UVec3 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -220,7 +220,7 @@ impl UVec3 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -251,7 +251,9 @@ impl UVec3 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u32 {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -260,7 +262,9 @@ impl UVec3 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u32 {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -212,9 +212,9 @@ impl UVec3 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
@@ -225,9 +225,9 @@ impl UVec3 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -252,7 +252,6 @@ impl UVec3 {
     #[must_use]
     pub fn min_element(self) -> u32 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -263,7 +262,6 @@ impl UVec3 {
     #[must_use]
     pub fn max_element(self) -> u32 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -205,10 +205,10 @@ impl UVec4 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
-            w: self.w.min(rhs.w),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
+            w: if self.w < rhs.w { self.w } else { rhs.w },
         }
     }
 
@@ -219,10 +219,10 @@ impl UVec4 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
-            w: self.w.max(rhs.w),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
+            w: if self.w > rhs.w { self.w } else { rhs.w },
         }
     }
 

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -247,7 +247,6 @@ impl UVec4 {
     #[must_use]
     pub fn min_element(self) -> u32 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, min(self.z, self.w)))
     }
 
@@ -258,7 +257,6 @@ impl UVec4 {
     #[must_use]
     pub fn max_element(self) -> u32 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, max(self.z, self.w)))
     }
 

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -246,7 +246,9 @@ impl UVec4 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u32 {
-        self.x.min(self.y.min(self.z.min(self.w)))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, min(self.z, self.w)))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -255,7 +257,9 @@ impl UVec4 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u32 {
-        self.x.max(self.y.max(self.z.max(self.w)))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, max(self.z, self.w)))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -200,7 +200,7 @@ impl UVec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -214,7 +214,7 @@ impl UVec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -164,8 +164,8 @@ impl U64Vec2 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
         }
     }
 
@@ -176,8 +176,8 @@ impl U64Vec2 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
         }
     }
 

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -202,7 +202,6 @@ impl U64Vec2 {
     #[must_use]
     pub fn min_element(self) -> u64 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, self.y)
     }
 
@@ -213,7 +212,6 @@ impl U64Vec2 {
     #[must_use]
     pub fn max_element(self) -> u64 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, self.y)
     }
 

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -201,7 +201,9 @@ impl U64Vec2 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u64 {
-        self.x.min(self.y)
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, self.y)
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -210,7 +212,9 @@ impl U64Vec2 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u64 {
-        self.x.max(self.y)
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, self.y)
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -159,7 +159,7 @@ impl U64Vec2 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -171,7 +171,7 @@ impl U64Vec2 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -212,9 +212,9 @@ impl U64Vec3 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
@@ -225,9 +225,9 @@ impl U64Vec3 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -252,7 +252,6 @@ impl U64Vec3 {
     #[must_use]
     pub fn min_element(self) -> u64 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -263,7 +262,6 @@ impl U64Vec3 {
     #[must_use]
     pub fn max_element(self) -> u64 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -251,7 +251,9 @@ impl U64Vec3 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u64 {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -260,7 +262,9 @@ impl U64Vec3 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u64 {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -207,7 +207,7 @@ impl U64Vec3 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -220,7 +220,7 @@ impl U64Vec3 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -205,10 +205,10 @@ impl U64Vec4 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
-            w: self.w.min(rhs.w),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
+            w: if self.w < rhs.w { self.w } else { rhs.w },
         }
     }
 
@@ -219,10 +219,10 @@ impl U64Vec4 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
-            w: self.w.max(rhs.w),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
+            w: if self.w > rhs.w { self.w } else { rhs.w },
         }
     }
 

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -247,7 +247,6 @@ impl U64Vec4 {
     #[must_use]
     pub fn min_element(self) -> u64 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, min(self.z, self.w)))
     }
 
@@ -258,7 +257,6 @@ impl U64Vec4 {
     #[must_use]
     pub fn max_element(self) -> u64 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, max(self.z, self.w)))
     }
 

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -246,7 +246,9 @@ impl U64Vec4 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u64 {
-        self.x.min(self.y.min(self.z.min(self.w)))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, min(self.z, self.w)))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -255,7 +257,9 @@ impl U64Vec4 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u64 {
-        self.x.max(self.y.max(self.z.max(self.w)))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, max(self.z, self.w)))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -200,7 +200,7 @@ impl U64Vec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -214,7 +214,7 @@ impl U64Vec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -164,8 +164,8 @@ impl U8Vec2 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
         }
     }
 
@@ -176,8 +176,8 @@ impl U8Vec2 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
         }
     }
 

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -201,7 +201,9 @@ impl U8Vec2 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u8 {
-        self.x.min(self.y)
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, self.y)
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -210,7 +212,9 @@ impl U8Vec2 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u8 {
-        self.x.max(self.y)
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, self.y)
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -202,7 +202,6 @@ impl U8Vec2 {
     #[must_use]
     pub fn min_element(self) -> u8 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, self.y)
     }
 
@@ -213,7 +212,6 @@ impl U8Vec2 {
     #[must_use]
     pub fn max_element(self) -> u8 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, self.y)
     }
 

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -159,7 +159,7 @@ impl U8Vec2 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -171,7 +171,7 @@ impl U8Vec2 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -252,7 +252,6 @@ impl U8Vec3 {
     #[must_use]
     pub fn min_element(self) -> u8 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -263,7 +262,6 @@ impl U8Vec3 {
     #[must_use]
     pub fn max_element(self) -> u8 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -251,7 +251,9 @@ impl U8Vec3 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u8 {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -260,7 +262,9 @@ impl U8Vec3 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u8 {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -207,7 +207,7 @@ impl U8Vec3 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -220,7 +220,7 @@ impl U8Vec3 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -212,9 +212,9 @@ impl U8Vec3 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
@@ -225,9 +225,9 @@ impl U8Vec3 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -200,7 +200,7 @@ impl U8Vec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -214,7 +214,7 @@ impl U8Vec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -246,7 +246,9 @@ impl U8Vec4 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> u8 {
-        self.x.min(self.y.min(self.z.min(self.w)))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, min(self.z, self.w)))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -255,7 +257,9 @@ impl U8Vec4 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> u8 {
-        self.x.max(self.y.max(self.z.max(self.w)))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, max(self.z, self.w)))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -205,10 +205,10 @@ impl U8Vec4 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
-            w: self.w.min(rhs.w),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
+            w: if self.w < rhs.w { self.w } else { rhs.w },
         }
     }
 
@@ -219,10 +219,10 @@ impl U8Vec4 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
-            w: self.w.max(rhs.w),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
+            w: if self.w > rhs.w { self.w } else { rhs.w },
         }
     }
 

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -247,7 +247,6 @@ impl U8Vec4 {
     #[must_use]
     pub fn min_element(self) -> u8 {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, min(self.z, self.w)))
     }
 
@@ -258,7 +257,6 @@ impl U8Vec4 {
     #[must_use]
     pub fn max_element(self) -> u8 {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, max(self.z, self.w)))
     }
 

--- a/src/usize/usizevec2.rs
+++ b/src/usize/usizevec2.rs
@@ -159,7 +159,7 @@ impl USizeVec2 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -171,7 +171,7 @@ impl USizeVec2 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/usize/usizevec2.rs
+++ b/src/usize/usizevec2.rs
@@ -201,7 +201,9 @@ impl USizeVec2 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> usize {
-        self.x.min(self.y)
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, self.y)
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -210,7 +212,9 @@ impl USizeVec2 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> usize {
-        self.x.max(self.y)
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, self.y)
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/usize/usizevec2.rs
+++ b/src/usize/usizevec2.rs
@@ -164,8 +164,8 @@ impl USizeVec2 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
         }
     }
 
@@ -176,8 +176,8 @@ impl USizeVec2 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
         }
     }
 

--- a/src/usize/usizevec2.rs
+++ b/src/usize/usizevec2.rs
@@ -202,7 +202,6 @@ impl USizeVec2 {
     #[must_use]
     pub fn min_element(self) -> usize {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, self.y)
     }
 
@@ -213,7 +212,6 @@ impl USizeVec2 {
     #[must_use]
     pub fn max_element(self) -> usize {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, self.y)
     }
 

--- a/src/usize/usizevec3.rs
+++ b/src/usize/usizevec3.rs
@@ -251,7 +251,9 @@ impl USizeVec3 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> usize {
-        self.x.min(self.y.min(self.z))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, self.z))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -260,7 +262,9 @@ impl USizeVec3 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> usize {
-        self.x.max(self.y.max(self.z))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, self.z))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/usize/usizevec3.rs
+++ b/src/usize/usizevec3.rs
@@ -252,7 +252,6 @@ impl USizeVec3 {
     #[must_use]
     pub fn min_element(self) -> usize {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, self.z))
     }
 
@@ -263,7 +262,6 @@ impl USizeVec3 {
     #[must_use]
     pub fn max_element(self) -> usize {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, self.z))
     }
 

--- a/src/usize/usizevec3.rs
+++ b/src/usize/usizevec3.rs
@@ -212,9 +212,9 @@ impl USizeVec3 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
         }
     }
 
@@ -225,9 +225,9 @@ impl USizeVec3 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
         }
     }
 

--- a/src/usize/usizevec3.rs
+++ b/src/usize/usizevec3.rs
@@ -207,7 +207,7 @@ impl USizeVec3 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -220,7 +220,7 @@ impl USizeVec3 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/src/usize/usizevec4.rs
+++ b/src/usize/usizevec4.rs
@@ -246,7 +246,9 @@ impl USizeVec4 {
     #[inline]
     #[must_use]
     pub fn min_element(self) -> usize {
-        self.x.min(self.y.min(self.z.min(self.w)))
+        let min = |a, b| if a < b { a } else { b };
+
+        min(self.x, min(self.y, min(self.z, self.w)))
     }
 
     /// Returns the horizontal maximum of `self`.
@@ -255,7 +257,9 @@ impl USizeVec4 {
     #[inline]
     #[must_use]
     pub fn max_element(self) -> usize {
-        self.x.max(self.y.max(self.z.max(self.w)))
+        let max = |a, b| if a > b { a } else { b };
+
+        max(self.x, max(self.y, max(self.z, self.w)))
     }
 
     /// Returns the index of the first minimum element of `self`.

--- a/src/usize/usizevec4.rs
+++ b/src/usize/usizevec4.rs
@@ -247,7 +247,6 @@ impl USizeVec4 {
     #[must_use]
     pub fn min_element(self) -> usize {
         let min = |a, b| if a < b { a } else { b };
-
         min(self.x, min(self.y, min(self.z, self.w)))
     }
 
@@ -258,7 +257,6 @@ impl USizeVec4 {
     #[must_use]
     pub fn max_element(self) -> usize {
         let max = |a, b| if a > b { a } else { b };
-
         max(self.x, max(self.y, max(self.z, self.w)))
     }
 

--- a/src/usize/usizevec4.rs
+++ b/src/usize/usizevec4.rs
@@ -205,10 +205,10 @@ impl USizeVec4 {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         Self {
-            x: self.x.min(rhs.x),
-            y: self.y.min(rhs.y),
-            z: self.z.min(rhs.z),
-            w: self.w.min(rhs.w),
+            x: if self.x < rhs.x { self.x } else { rhs.x },
+            y: if self.y < rhs.y { self.y } else { rhs.y },
+            z: if self.z < rhs.z { self.z } else { rhs.z },
+            w: if self.w < rhs.w { self.w } else { rhs.w },
         }
     }
 
@@ -219,10 +219,10 @@ impl USizeVec4 {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         Self {
-            x: self.x.max(rhs.x),
-            y: self.y.max(rhs.y),
-            z: self.z.max(rhs.z),
-            w: self.w.max(rhs.w),
+            x: if self.x > rhs.x { self.x } else { rhs.x },
+            y: if self.y > rhs.y { self.y } else { rhs.y },
+            z: if self.z > rhs.z { self.z } else { rhs.z },
+            w: if self.w > rhs.w { self.w } else { rhs.w },
         }
     }
 

--- a/src/usize/usizevec4.rs
+++ b/src/usize/usizevec4.rs
@@ -200,7 +200,7 @@ impl USizeVec4 {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
@@ -214,7 +214,7 @@ impl USizeVec4 {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -768,7 +768,7 @@ impl {{ self_t }} {
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+    /// In other words this computes `[min(x, rhs.x), min(self.y, rhs.y), ..]`.
 {%- if is_float  %}
     /// 
     /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
@@ -798,7 +798,7 @@ impl {{ self_t }} {
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
-    /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+    /// In other words this computes `[max(self.x, rhs.x), max(self.y, rhs.y), ..]`.
 {%- if is_float  %}
     /// 
     /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -364,6 +364,17 @@ impl {{ self_t }} {
 
     /// All `{{ scalar_t }}::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat({{ scalar_t }}::NEG_INFINITY);
+
+    /// {{ self_t }} uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = {{ is_coresimd }};
+    /// {{ self_t }} uses Arm NEON
+    pub const USES_NEON: bool = {{ is_neon }};
+    /// {{ self_t }} uses scalar math
+    pub const USES_SCALAR_MATH: bool = {{ is_scalar }};
+    /// {{ self_t }} uses Intel SSE2
+    pub const USES_SSE2: bool = {{ is_sse2 }};
+    /// {{ self_t }} uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = {{ is_wasm32 }};
 {% endif %}
 
 {% for i in range(end = dim) %}

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -767,13 +767,18 @@ impl {{ self_t }} {
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
+{%- if is_float  %}
+    /// 
+    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// different SIMD architectures.
+{%- endif %}
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         {% if is_scalar %}
             Self {
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.min(rhs.{{ c }}),
+                    {{ c }}: if self.{{ c }} < rhs.{{ c }} { self.{{ c }} } else { rhs.{{ c }} },
                 {%- endfor %}
             }
         {% elif is_sse2 %}
@@ -792,13 +797,18 @@ impl {{ self_t }} {
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
     ///
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
+{%- if is_float  %}
+    /// 
+    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// different SIMD architectures.
+{%- endif %}
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         {% if is_scalar %}
             Self {
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.max(rhs.{{ c }}),
+                    {{ c }}: if self.{{ c }} > rhs.{{ c }} { self.{{ c }} } else { rhs.{{ c }} },
                 {%- endfor %}
             }
         {% elif is_sse2 %}

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -788,7 +788,7 @@ impl {{ self_t }} {
         {% elif is_wasm32 %}
             Self(f32x4_pmin(self.0, rhs.0))
         {% elif is_coresimd %}
-            Self(self.0.simd_min(rhs.0))
+            Self(self.0.simd_lt(rhs.0).select(self.0, rhs.0))
         {% elif is_neon %}
             Self(unsafe { vminq_f32(self.0, rhs.0) })
         {% else %}
@@ -818,7 +818,7 @@ impl {{ self_t }} {
         {% elif is_wasm32 %}
             Self(f32x4_pmax(self.0, rhs.0))
         {% elif is_coresimd %}
-            Self(self.0.simd_max(rhs.0))
+            Self(self.0.simd_gt(rhs.0).select(self.0, rhs.0))
         {% elif is_neon %}
             Self(unsafe { vmaxq_f32(self.0, rhs.0) })
         {% else %}
@@ -858,11 +858,11 @@ impl {{ self_t }} {
     pub fn min_element(self) -> {{ scalar_t }} {
         {% if is_scalar %}
             let min = |a, b| if a < b { a } else { b };
-            {% if dim == 2 %}
+            {%- if dim == 2 %}
                 min(self.x, self.y)
-            {% elif dim == 3 %}
+            {%- elif dim == 3 %}
                 min(self.x, min(self.y, self.z))
-            {% elif dim == 4 %}
+            {%- elif dim == 4 %}
                 min(self.x, min(self.y, min(self.z, self.w)))
             {% endif %}
         {% elif is_sse2 %}
@@ -894,13 +894,17 @@ impl {{ self_t }} {
                 f32x4_extract_lane::<0>(v)
             {% endif %}
         {% elif is_coresimd %}
-            {% if dim == 3 %}
+            let min = |a: {{ simd_t }}, b: {{ simd_t }}| a.simd_lt(b).select(a, b);
+            {%- if dim == 3 %}
                 let v = self.0;
-                let v = v.simd_min(simd_swizzle!(v, [2, 2, 1, 1]));
-                let v = v.simd_min(simd_swizzle!(v, [1, 0, 0, 0]));
+                let v = min(v, simd_swizzle!(v, [2, 2, 1, 1]));
+                let v = min(v, simd_swizzle!(v, [1, 0, 0, 0]));
                 v[0]
-            {% elif dim == 4 %}
-                self.0.reduce_min()
+            {%- elif dim == 4 %}
+                let v = self.0;
+                let v = min(v, simd_swizzle!(v, [2, 3, 0, 0]));
+                let v = min(v, simd_swizzle!(v, [1, 0, 0, 0]));
+                v[0]
             {% endif %}
         {% elif is_neon %}
             {% if dim == 3 %}
@@ -926,11 +930,11 @@ impl {{ self_t }} {
     pub fn max_element(self) -> {{ scalar_t }} {
         {% if is_scalar %}
             let max = |a, b| if a > b { a } else { b };
-            {% if dim == 2 %}
+            {%- if dim == 2 %}
                 max(self.x, self.y)
-            {% elif dim == 3 %}
+            {%- elif dim == 3 %}
                 max(self.x, max(self.y, self.z))
-            {% elif dim == 4 %}
+            {%- elif dim == 4 %}
                 max(self.x, max(self.y, max(self.z, self.w)))
             {% endif %}
         {% elif is_sse2 %}
@@ -962,13 +966,17 @@ impl {{ self_t }} {
                 f32x4_extract_lane::<0>(v)
             {% endif %}
         {% elif is_coresimd %}
-            {% if dim == 3 %}
+            let max = |a: {{ simd_t }}, b: {{ simd_t }}| a.simd_gt(b).select(a, b);
+            {%- if dim == 3 %}
                 let v = self.0;
-                let v = v.simd_max(simd_swizzle!(v, [2, 2, 0, 0]));
-                let v = v.simd_max(simd_swizzle!(v, [1, 0, 0, 0]));
+                let v = max(v, simd_swizzle!(v, [2, 2, 0, 0]));
+                let v = max(v, simd_swizzle!(v, [1, 0, 0, 0]));
                 v[0]
-            {% elif dim == 4 %}
-                self.0.reduce_max()
+            {%- elif dim == 4 %}
+                let v = self.0;
+                let v = max(v, simd_swizzle!(v, [2, 3, 0, 0]));
+                let v = max(v, simd_swizzle!(v, [1, 0, 0, 0]));
+                v[0]
             {% endif %}
         {% elif is_neon %}
             {% if dim == 3 %}

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -769,7 +769,7 @@ impl {{ self_t }} {
     /// In other words this computes `[self.x.min(rhs.x), self.y.min(rhs.y), ..]`.
 {%- if is_float  %}
     /// 
-    /// Nan propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for minNum and may differ on
     /// different SIMD architectures.
 {%- endif %}
     #[inline]
@@ -799,7 +799,7 @@ impl {{ self_t }} {
     /// In other words this computes `[self.x.max(rhs.x), self.y.max(rhs.y), ..]`.
 {%- if is_float  %}
     /// 
-    /// Nan propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
+    /// NaN propogation does not follow IEEE 754-2008 semantics for maxNum and may differ on
     /// different SIMD architectures.
 {%- endif %}
     #[inline]
@@ -827,6 +827,11 @@ impl {{ self_t }} {
     /// Component-wise clamping of values, similar to [`{{ scalar_t }}::clamp`].
     ///
     /// Each element in `min` must be less-or-equal to the corresponding element in `max`.
+{%- if is_float  %}
+    /// 
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
+{%- endif %}
     ///
     /// # Panics
     ///
@@ -841,16 +846,22 @@ impl {{ self_t }} {
     /// Returns the horizontal minimum of `self`.
     ///
     /// In other words this computes `min(x, y, ..)`.
+{%- if is_float  %}
+    /// 
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
+{%- endif %}
     #[inline]
     #[must_use]
     pub fn min_element(self) -> {{ scalar_t }} {
         {% if is_scalar %}
+            let min = |a, b| if a < b { a } else { b };
             {% if dim == 2 %}
-                self.x.min(self.y)
+                min(self.x, self.y)
             {% elif dim == 3 %}
-                self.x.min(self.y.min(self.z))
+                min(self.x, min(self.y, self.z))
             {% elif dim == 4 %}
-                self.x.min(self.y.min(self.z.min(self.w)))
+                min(self.x, min(self.y, min(self.z, self.w)))
             {% endif %}
         {% elif is_sse2 %}
             {% if dim == 3 %}
@@ -903,16 +914,22 @@ impl {{ self_t }} {
     /// Returns the horizontal maximum of `self`.
     ///
     /// In other words this computes `max(x, y, ..)`.
+{%- if is_float  %}
+    /// 
+    /// NaN propogation does not follow IEEE 754-2008 semantics and may differ on
+    /// different SIMD architectures.
+{%- endif %}
     #[inline]
     #[must_use]
     pub fn max_element(self) -> {{ scalar_t }} {
         {% if is_scalar %}
+            let max = |a, b| if a > b { a } else { b };
             {% if dim == 2 %}
-                self.x.max(self.y)
+                max(self.x, self.y)
             {% elif dim == 3 %}
-                self.x.max(self.y.max(self.z))
+                max(self.x, max(self.y, self.z))
             {% elif dim == 4 %}
-                self.x.max(self.y.max(self.z.max(self.w)))
+                max(self.x, max(self.y, max(self.z, self.w)))
             {% endif %}
         {% elif is_sse2 %}
             {% if dim == 3 %}

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -364,17 +364,6 @@ impl {{ self_t }} {
 
     /// All `{{ scalar_t }}::NEG_INFINITY`.
     pub const NEG_INFINITY: Self = Self::splat({{ scalar_t }}::NEG_INFINITY);
-
-    /// {{ self_t }} uses Rust Portable SIMD
-    pub const USES_CORE_SIMD: bool = {{ is_coresimd }};
-    /// {{ self_t }} uses Arm NEON
-    pub const USES_NEON: bool = {{ is_neon }};
-    /// {{ self_t }} uses scalar math
-    pub const USES_SCALAR_MATH: bool = {{ is_scalar }};
-    /// {{ self_t }} uses Intel SSE2
-    pub const USES_SSE2: bool = {{ is_sse2 }};
-    /// {{ self_t }} uses WebAssembly 128-bit SIMD
-    pub const USES_WASM32_SIMD: bool = {{ is_wasm32 }};
 {% endif %}
 
 {% for i in range(end = dim) %}
@@ -405,6 +394,19 @@ impl {{ self_t }} {
             Self::{{ c | upper }},
         {% endfor %}
     ];
+
+{% if is_float %}
+    /// {{ self_t }} uses Rust Portable SIMD
+    pub const USES_CORE_SIMD: bool = {{ is_coresimd }};
+    /// {{ self_t }} uses Arm NEON
+    pub const USES_NEON: bool = {{ is_neon }};
+    /// {{ self_t }} uses scalar math
+    pub const USES_SCALAR_MATH: bool = {{ is_scalar }};
+    /// {{ self_t }} uses Intel SSE2
+    pub const USES_SSE2: bool = {{ is_sse2 }};
+    /// {{ self_t }} uses WebAssembly 128-bit SIMD
+    pub const USES_WASM32_SIMD: bool = {{ is_wasm32 }};
+{% endif %}
 
     /// Creates a new vector.
     #[inline(always)]

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1315,17 +1315,20 @@ macro_rules! impl_vec4_float_tests {
             // The purpose of this test is to document the different behaviour.
             if $vec4::USES_SCALAR_MATH {
                 assert_eq!($vec4::NEG_ONE, $vec4::NAN.clamp($vec4::NEG_ONE, $vec4::ONE));
-                assert_eq!($vec4::ONE, $vec4::NAN.clamp($vec4::NAN, $vec4::ONE));
-                assert_eq!($vec4::NEG_ONE, $vec4::NAN.clamp($vec4::NEG_ONE, $vec4::NAN));
+                // assert_eq!($vec4::ONE, $vec4::NAN.clamp($vec4::NAN, $vec4::ONE));
+                // assert!($vec4::NAN
+                //     .clamp($vec4::NEG_ONE, $vec4::NAN)
+                //     .is_nan_mask()
+                //     .all());
             } else if $vec4::USES_NEON {
                 // TODO
             } else if $vec4::USES_SSE2 {
                 assert_eq!($vec4::NEG_ONE, $vec4::NAN.clamp($vec4::NEG_ONE, $vec4::ONE));
-                assert_eq!($vec4::ONE, $vec4::NAN.clamp($vec4::NAN, $vec4::ONE));
-                assert!($vec4::NAN
-                    .clamp($vec4::NEG_ONE, $vec4::NAN)
-                    .is_nan_mask()
-                    .all());
+                // assert_eq!($vec4::ONE, $vec4::NAN.clamp($vec4::NAN, $vec4::ONE));
+                // assert!($vec4::NAN
+                //     .clamp($vec4::NEG_ONE, $vec4::NAN)
+                //     .is_nan_mask()
+                //     .all());
             }
         });
 

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1322,7 +1322,10 @@ macro_rules! impl_vec4_float_tests {
             } else if $vec4::USES_SSE2 {
                 assert_eq!($vec4::NEG_ONE, $vec4::NAN.clamp($vec4::NEG_ONE, $vec4::ONE));
                 assert_eq!($vec4::ONE, $vec4::NAN.clamp($vec4::NAN, $vec4::ONE));
-                assert!($vec4::NAN.clamp($vec4::NEG_ONE, $vec4::NAN).is_nan_mask().all());
+                assert!($vec4::NAN
+                    .clamp($vec4::NEG_ONE, $vec4::NAN)
+                    .is_nan_mask()
+                    .all());
             }
         });
 

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1302,8 +1302,8 @@ macro_rules! impl_vec4_float_tests {
                 assert_eq!(2.0, v.min_element());
                 assert_eq!(4.0, v.max_element());
             } else if $vec4::USES_NEON {
-                assert!(v.min_element().is_nan());
-                assert!(v.max_element().is_nan());
+                assert_eq!(2.0, v.min_element());
+                assert_eq!(4.0, v.max_element());
             } else if $vec4::USES_SSE2 {
                 assert!(v.min_element().is_nan());
                 assert!(v.max_element().is_nan());

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1293,9 +1293,16 @@ macro_rules! impl_vec4_float_tests {
                 assert!($vec4::NAN.max($vec4::NAN).is_nan_mask().all());
             } else if $vec4::USES_WASM32_SIMD {
                 assert!($vec4::NAN.min($vec4::ZERO).is_nan_mask().all());
-                assert!($vec4::ZERO.min($vec4::NAN).is_nan_mask().all());
+                assert!(!$vec4::ZERO.min($vec4::NAN).is_nan_mask().all());
                 assert!($vec4::NAN.min($vec4::NAN).is_nan_mask().all());
                 assert!($vec4::NAN.max($vec4::ZERO).is_nan_mask().all());
+                assert!(!$vec4::ZERO.max($vec4::NAN).is_nan_mask().all());
+                assert!($vec4::NAN.max($vec4::NAN).is_nan_mask().all());
+            } else if $vec4::USES_CORE_SIMD {
+                assert!(!$vec4::NAN.min($vec4::ZERO).is_nan_mask().all());
+                assert!($vec4::ZERO.min($vec4::NAN).is_nan_mask().all());
+                assert!($vec4::NAN.min($vec4::NAN).is_nan_mask().all());
+                assert!(!$vec4::NAN.max($vec4::ZERO).is_nan_mask().all());
                 assert!($vec4::ZERO.max($vec4::NAN).is_nan_mask().all());
                 assert!($vec4::NAN.max($vec4::NAN).is_nan_mask().all());
             }
@@ -1317,6 +1324,9 @@ macro_rules! impl_vec4_float_tests {
             } else if $vec4::USES_WASM32_SIMD {
                 assert_eq!(2.0, v.min_element());
                 assert_eq!(4.0, v.max_element());
+            } else if $vec4::USES_CORE_SIMD {
+                assert!(v.min_element().is_nan());
+                assert!(v.max_element().is_nan());
             }
         });
 
@@ -1325,22 +1335,60 @@ macro_rules! impl_vec4_float_tests {
             // The purpose of this test is to document the different behaviour.
             if $vec4::USES_SCALAR_MATH {
                 assert_eq!($vec4::NEG_ONE, $vec4::NAN.clamp($vec4::NEG_ONE, $vec4::ONE));
-                // assert_eq!($vec4::ONE, $vec4::NAN.clamp($vec4::NAN, $vec4::ONE));
-                // assert!($vec4::NAN
-                //     .clamp($vec4::NEG_ONE, $vec4::NAN)
-                //     .is_nan_mask()
-                //     .all());
+                #[cfg(not(any(feature = "debug-glam-assert", feature = "glam-assert")))]
+                {
+                    assert_eq!($vec4::ONE, $vec4::NAN.clamp($vec4::NAN, $vec4::ONE));
+                    assert!($vec4::NAN
+                        .clamp($vec4::NEG_ONE, $vec4::NAN)
+                        .is_nan_mask()
+                        .all());
+                }
             } else if $vec4::USES_NEON {
-                assert_eq!($vec4::NEG_ONE, $vec4::NAN.clamp($vec4::NEG_ONE, $vec4::ONE));
+                assert!($vec4::NAN
+                    .clamp($vec4::NEG_ONE, $vec4::ONE)
+                    .is_nan_mask()
+                    .all());
+                #[cfg(not(any(feature = "debug-glam-assert", feature = "glam-assert")))]
+                {
+                    assert!($vec4::NAN.clamp($vec4::NAN, $vec4::ONE).is_nan_mask().all());
+                    assert!($vec4::NAN
+                        .clamp($vec4::NEG_ONE, $vec4::NAN)
+                        .is_nan_mask()
+                        .all());
+                }
             } else if $vec4::USES_SSE2 {
                 assert_eq!($vec4::NEG_ONE, $vec4::NAN.clamp($vec4::NEG_ONE, $vec4::ONE));
-                // assert_eq!($vec4::ONE, $vec4::NAN.clamp($vec4::NAN, $vec4::ONE));
-                // assert!($vec4::NAN
-                //     .clamp($vec4::NEG_ONE, $vec4::NAN)
-                //     .is_nan_mask()
-                //     .all());
+                #[cfg(not(any(feature = "debug-glam-assert", feature = "glam-assert")))]
+                {
+                    assert_eq!($vec4::ONE, $vec4::NAN.clamp($vec4::NAN, $vec4::ONE));
+                    assert!($vec4::NAN
+                        .clamp($vec4::NEG_ONE, $vec4::NAN)
+                        .is_nan_mask()
+                        .all());
+                }
             } else if $vec4::USES_WASM32_SIMD {
+                assert!($vec4::NAN
+                    .clamp($vec4::NEG_ONE, $vec4::ONE)
+                    .is_nan_mask()
+                    .all());
+                #[cfg(not(any(feature = "debug-glam-assert", feature = "glam-assert")))]
+                {
+                    assert!($vec4::NAN.clamp($vec4::NAN, $vec4::ONE).is_nan_mask().all());
+                    assert!($vec4::NAN
+                        .clamp($vec4::NEG_ONE, $vec4::NAN)
+                        .is_nan_mask()
+                        .all());
+                }
+            } else if $vec4::USES_CORE_SIMD {
                 assert_eq!($vec4::NEG_ONE, $vec4::NAN.clamp($vec4::NEG_ONE, $vec4::ONE));
+                #[cfg(not(any(feature = "debug-glam-assert", feature = "glam-assert")))]
+                {
+                    assert_eq!($vec4::ONE, $vec4::NAN.clamp($vec4::NAN, $vec4::ONE));
+                    assert!($vec4::NAN
+                        .clamp($vec4::NEG_ONE, $vec4::NAN)
+                        .is_nan_mask()
+                        .all());
+                }
             }
         });
 

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1291,6 +1291,13 @@ macro_rules! impl_vec4_float_tests {
                 assert!(!$vec4::NAN.max($vec4::ZERO).is_nan_mask().all());
                 assert!($vec4::ZERO.max($vec4::NAN).is_nan_mask().all());
                 assert!($vec4::NAN.max($vec4::NAN).is_nan_mask().all());
+            } else if $vec4::USES_WASM32_SIMD {
+                assert!($vec4::NAN.min($vec4::ZERO).is_nan_mask().all());
+                assert!($vec4::ZERO.min($vec4::NAN).is_nan_mask().all());
+                assert!($vec4::NAN.min($vec4::NAN).is_nan_mask().all());
+                assert!($vec4::NAN.max($vec4::ZERO).is_nan_mask().all());
+                assert!($vec4::ZERO.max($vec4::NAN).is_nan_mask().all());
+                assert!($vec4::NAN.max($vec4::NAN).is_nan_mask().all());
             }
         });
 
@@ -1307,6 +1314,9 @@ macro_rules! impl_vec4_float_tests {
             } else if $vec4::USES_SSE2 {
                 assert!(v.min_element().is_nan());
                 assert!(v.max_element().is_nan());
+            } else if $vec4::USES_WASM32_SIMD {
+                assert_eq!(2.0, v.min_element());
+                assert_eq!(4.0, v.max_element());
             }
         });
 
@@ -1321,7 +1331,7 @@ macro_rules! impl_vec4_float_tests {
                 //     .is_nan_mask()
                 //     .all());
             } else if $vec4::USES_NEON {
-                // TODO
+                assert_eq!($vec4::NEG_ONE, $vec4::NAN.clamp($vec4::NEG_ONE, $vec4::ONE));
             } else if $vec4::USES_SSE2 {
                 assert_eq!($vec4::NEG_ONE, $vec4::NAN.clamp($vec4::NEG_ONE, $vec4::ONE));
                 // assert_eq!($vec4::ONE, $vec4::NAN.clamp($vec4::NAN, $vec4::ONE));
@@ -1329,6 +1339,8 @@ macro_rules! impl_vec4_float_tests {
                 //     .clamp($vec4::NEG_ONE, $vec4::NAN)
                 //     .is_nan_mask()
                 //     .all());
+            } else if $vec4::USES_WASM32_SIMD {
+                assert_eq!($vec4::NEG_ONE, $vec4::NAN.clamp($vec4::NEG_ONE, $vec4::ONE));
             }
         });
 

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1272,10 +1272,10 @@ macro_rules! impl_vec4_float_tests {
             // The purpose of this test is to document the different behaviour.
             if $vec4::USES_SCALAR_MATH {
                 assert!(!$vec4::NAN.min($vec4::ZERO).is_nan_mask().all());
-                assert!(!$vec4::ZERO.min($vec4::NAN).is_nan_mask().all());
+                assert!($vec4::ZERO.min($vec4::NAN).is_nan_mask().all());
                 assert!($vec4::NAN.min($vec4::NAN).is_nan_mask().all());
                 assert!(!$vec4::NAN.max($vec4::ZERO).is_nan_mask().all());
-                assert!(!$vec4::ZERO.max($vec4::NAN).is_nan_mask().all());
+                assert!($vec4::ZERO.max($vec4::NAN).is_nan_mask().all());
                 assert!($vec4::NAN.max($vec4::NAN).is_nan_mask().all());
             } else if $vec4::USES_NEON {
                 assert!($vec4::NAN.min($vec4::ZERO).is_nan_mask().all());
@@ -1299,8 +1299,8 @@ macro_rules! impl_vec4_float_tests {
             // The purpose of this test is to document the different behaviour.
             let v = $vec4::new(4.0, 3.0, 2.0, $t::NAN);
             if $vec4::USES_SCALAR_MATH {
-                assert_eq!(2.0, v.min_element());
-                assert_eq!(4.0, v.max_element());
+                assert!(v.min_element().is_nan());
+                assert!(v.max_element().is_nan());
             } else if $vec4::USES_NEON {
                 assert_eq!(2.0, v.min_element());
                 assert_eq!(4.0, v.max_element());


### PR DESCRIPTION
# Objective

- The min and max NaN propagation behavior is different between the Rust f32 methods and different SIMD architectures, so because it's  not consistent, glam will prefer the optimal method
- Fixes #444

## Solution

- Max scalar min, max, min_element and max_element  implementations use comparison operators instead of Rust core library min and max functions.
-  Add tests that document different NaN propagation behavior of implementations on different architectures.
