### PR TITLE
Implement ser/de via `speedy` crate under feature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## Unreleased
+
+### Added
+
+* Added `speedy` feature, implementing serialization and deserialization via the `speedy` crate.
+
 ## [0.30.2] - 2025-04-13
 
-## Added
+### Added
 
 * Added precision conversion functions for affine types:
   `Affine3A::as_daffine3`, `DAffine3::as_affine3a`, `Affine2::as_daffine2` and
@@ -15,7 +21,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 * Added `normalize_and_length` method to `f32` and `f64` vectors.
 
-## Changed
+### Changed
 
 * Vector min and max scalar implementations have been changed to use an `if`
   check instead of the built in Rust floating point primitive `min` and `max`
@@ -25,7 +31,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [0.30.1] - 2025-03-20
 
-## Added
+### Added
 
 * Added `usize` vector types, `USizeVec2`, `USizeVec3` and `USizeVec4`.
 
@@ -34,7 +40,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 * Added `rotate_towards` method to 3D vector types.
 
-## Changed
+### Changed
 
 * Removed the small angle check from 2D vector `rotate_towards` implementations
   as it was unnecessary and would not preserve the length of the input.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ rand = { version = "0.9", optional = true, default-features = false }
 serde = { version = "1.0", optional = true, default-features = false }
 rkyv = { version = "0.8", optional = true, default-features = false }
 libm = { version = "0.2", optional = true, default-features = false }
+speedy = { version = "0.8", optional = true, default-features = false }
 
 [dev-dependencies]
 # rand_xoshiro is required for tests if rand is enabled

--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ glam = { version = "0.30.2", default-features = false, features = ["nostd-libm"]
 * [`serde`] - implementations of `Serialize` and `Deserialize` for all `glam`
   types. Note that serialization should work between builds of `glam` with and
   without SIMD enabled
+* [`speedy`] - implementations of `speedy`'s `Readable` and `Writable` for all `glam` types.
 * [`rkyv`] - implementations of `Archive`, `Serialize` and `Deserialize` for
   all `glam` types. Note that serialization is not interoperable with and
   without the `scalar-math` feature. It should work between all other builds of
@@ -142,6 +143,7 @@ glam = { version = "0.30.2", default-features = false, features = ["nostd-libm"]
 [`mint`]: https://github.com/kvark/mint
 [`rand`]: https://github.com/rust-random/rand
 [`serde`]: https://serde.rs
+[`speedy`]: https://docs.rs/speedy
 [`rkyv`]: https://github.com/rkyv/rkyv
 [`bytecheck`]: https://github.com/rkyv/bytecheck
 

--- a/src/features.rs
+++ b/src/features.rs
@@ -13,5 +13,8 @@ pub mod impl_rand;
 #[cfg(feature = "serde")]
 pub mod impl_serde;
 
+#[cfg(feature = "speedy")]
+pub mod impl_speedy;
+
 #[cfg(feature = "rkyv")]
 pub mod impl_rkyv;

--- a/src/features/impl_speedy.rs
+++ b/src/features/impl_speedy.rs
@@ -1,0 +1,287 @@
+use {
+    crate::{
+        Affine2, Affine3A, BVec2, BVec3, BVec4, DAffine2, DAffine3, DMat2, DMat3, DMat4, DQuat,
+        DVec2, DVec3, DVec4, IVec2, IVec3, IVec4, Mat2, Mat3, Mat3A, Mat4, Quat, UVec2, UVec3,
+        UVec4, Vec2, Vec3, Vec3A, Vec4,
+    },
+    speedy::{Context, Readable, Reader, Writable, Writer},
+};
+
+macro_rules! impl_for_vec {
+    ($T:ty, $ctor:ident, $comp_ty:ty, $comp_read_fn:ident, $comp_write_fn:ident, $($comp:ident),+) => {
+        impl<'a, C> Readable<'a, C> for $T
+        where
+            C: Context,
+        {
+            #[inline]
+            fn read_from<R: Reader<'a, C>>(reader: &mut R) -> Result<Self, C::Error> {
+                $(
+                    let $comp = reader.$comp_read_fn()?;
+                )+
+
+                Ok(<$T>::$ctor($($comp),+))
+            }
+
+            #[inline]
+            fn minimum_bytes_needed() -> usize {
+                let mut size = 0;
+                $(
+                    let $comp = <$comp_ty as Readable::<'a, C>>::minimum_bytes_needed();
+                    size += $comp;
+                )+
+                size
+            }
+        }
+
+        impl<C> Writable<C> for $T
+        where
+            C: Context,
+        {
+            #[inline]
+            fn write_to<T: ?Sized + Writer<C>>(&self, writer: &mut T) -> Result<(), C::Error> {
+                $(
+                    writer.$comp_write_fn(self.$comp)?;
+                )+
+
+                Ok(())
+            }
+
+            #[inline]
+            fn bytes_needed(&self) -> Result<usize, C::Error> {
+                let mut size = 0;
+                $(
+                    size += Writable::<C>::bytes_needed(&self.$comp)?;
+                )+
+                Ok( size )
+            }
+        }
+    };
+}
+
+impl_for_vec! {Vec2, new, f32, read_f32, write_f32, x, y}
+impl_for_vec! {Vec3, new, f32, read_f32, write_f32, x, y, z}
+impl_for_vec! {Vec3A, new, f32, read_f32, write_f32, x, y, z}
+impl_for_vec! {Vec4, new, f32, read_f32, write_f32, x, y, z, w}
+
+impl_for_vec! {DVec2, new, f64, read_f64, write_f64, x, y}
+impl_for_vec! {DVec3, new, f64, read_f64, write_f64, x, y, z}
+impl_for_vec! {DVec4, new, f64, read_f64, write_f64, x, y, z, w}
+
+impl_for_vec! {IVec2, new, i32, read_i32, write_i32, x, y}
+impl_for_vec! {IVec3, new, i32, read_i32, write_i32, x, y, z}
+impl_for_vec! {IVec4, new, i32, read_i32, write_i32, x, y, z, w}
+
+impl_for_vec! {UVec2, new, u32, read_u32, write_u32, x, y}
+impl_for_vec! {UVec3, new, u32, read_u32, write_u32, x, y, z}
+impl_for_vec! {UVec4, new, u32, read_u32, write_u32, x, y, z, w}
+
+impl_for_vec! {Quat, from_xyzw, f32, read_f32, write_f32, x, y, z, w}
+impl_for_vec! {DQuat, from_xyzw, f64, read_f64, write_f64, x, y, z, w}
+
+macro_rules! impl_for_bvec {
+    ($T:ty, $($comp:ident),+) => {
+        impl<'a, C> Readable<'a, C> for $T
+        where
+            C: Context,
+        {
+            #[inline]
+            #[allow(unused_assignments)]
+            fn read_from<R: Reader<'a, C>>(reader: &mut R) -> Result<Self, C::Error> {
+                let mask = reader.read_u8()?;
+                let mut shift = 0;
+
+                $(
+                    let $comp = (mask & (1 << shift)) != 0;
+                    shift += 1;
+                )+
+
+                Ok(<$T>::new($($comp),+))
+            }
+
+            #[inline]
+            fn minimum_bytes_needed() -> usize {
+                <u8 as Readable::<'a, C>>::minimum_bytes_needed()
+            }
+        }
+
+        impl<C> Writable<C> for $T
+        where
+            C: Context,
+        {
+            #[inline]
+            fn write_to<T: ?Sized + Writer<C>>(&self, writer: &mut T) -> Result<(), C::Error> {
+                writer.write_u8(self.bitmask() as u8)
+            }
+
+            #[inline]
+            fn bytes_needed(&self) -> Result<usize, C::Error> {
+                Writable::<C>::bytes_needed(&0u8)
+            }
+        }
+    };
+}
+
+impl_for_bvec! {BVec2, x, y}
+impl_for_bvec! {BVec3, x, y, z}
+impl_for_bvec! {BVec4, x, y, z, w}
+
+macro_rules! impl_for_mat {
+    ($T:ty, $comp_count:literal, $comp_ty:ty) => {
+        impl<'a, C> Readable<'a, C> for $T
+        where
+            C: Context,
+        {
+            #[inline]
+            fn read_from<R: Reader<'a, C>>(reader: &mut R) -> Result<Self, C::Error> {
+                let mut values = [Default::default(); $comp_count];
+                for v in &mut values {
+                    *v = reader.read_value()?;
+                }
+                Ok(<$T>::from_cols_array(&values))
+            }
+
+            #[inline]
+            fn minimum_bytes_needed() -> usize {
+                <$comp_ty as Readable<'a, C>>::minimum_bytes_needed() * $comp_count
+            }
+        }
+
+        impl<C> Writable<C> for $T
+        where
+            C: Context,
+        {
+            #[inline]
+            fn write_to<T: ?Sized + Writer<C>>(&self, writer: &mut T) -> Result<(), C::Error> {
+                for comp in self.to_cols_array().iter() {
+                    writer.write_value(comp)?
+                }
+
+                Ok(())
+            }
+
+            #[inline]
+            fn bytes_needed(&self) -> Result<usize, C::Error> {
+                let mut size = 0;
+                for comp in self.to_cols_array().iter() {
+                    size += Writable::<C>::bytes_needed(comp)?;
+                }
+                Ok(size)
+            }
+        }
+    };
+}
+
+impl_for_mat! { Mat2, 4, f32 }
+impl_for_mat! { Mat3, 9, f32 }
+impl_for_mat! { Mat3A, 9, f32 }
+impl_for_mat! { Mat4, 16, f32 }
+
+impl_for_mat! { DMat2, 4, f64 }
+impl_for_mat! { DMat3, 9, f64 }
+impl_for_mat! { DMat4, 16, f64 }
+
+impl_for_mat! { Affine2, 6, f32 }
+impl_for_mat! { Affine3A, 12, f32 }
+
+impl_for_mat! { DAffine2, 6, f64 }
+impl_for_mat! { DAffine3, 12, f64 }
+
+#[test]
+fn test_speedy() {
+    use speedy::Endianness;
+
+    macro_rules! test_vec {
+        ($T:ty, $ctor:ident, $($values:literal),+) => {{
+            let original = <$T>::$ctor($($values as _),+);
+            let serialized = original.write_to_vec_with_ctx(Endianness::NATIVE).unwrap();
+            let deserialized = <$T>::read_from_buffer_with_ctx(Endianness::NATIVE, &serialized).unwrap();
+            assert_eq!(original, deserialized);
+        }}
+    }
+
+    test_vec!(Vec2, new, 1, 2);
+    test_vec!(Vec3, new, 1, 2, 3);
+    test_vec!(Vec3A, new, 1, 2, 3);
+    test_vec!(Vec4, new, 1, 2, 3, 4);
+
+    test_vec!(DVec2, new, 1, 2);
+    test_vec!(DVec3, new, 1, 2, 3);
+    test_vec!(DVec4, new, 1, 2, 3, 4);
+
+    test_vec!(IVec2, new, 1, 2);
+    test_vec!(IVec3, new, 1, 2, 3);
+    test_vec!(IVec4, new, 1, 2, 3, 4);
+
+    test_vec!(UVec2, new, 1, 2);
+    test_vec!(UVec3, new, 1, 2, 3);
+    test_vec!(UVec4, new, 1, 2, 3, 4);
+
+    test_vec!(Quat, from_xyzw, 1, 2, 3, 4);
+    test_vec!(DQuat, from_xyzw, 1, 2, 3, 4);
+
+    for a in [false, true] {
+        for b in [false, true] {
+            let original = BVec2::new(a, b);
+            let serialized = original.write_to_vec_with_ctx(Endianness::NATIVE).unwrap();
+            let deserialized =
+                BVec2::read_from_buffer_with_ctx(Endianness::NATIVE, &serialized).unwrap();
+            assert_eq!(original, deserialized);
+        }
+    }
+
+    for a in [false, true] {
+        for b in [false, true] {
+            for c in [false, true] {
+                let original = BVec3::new(a, b, c);
+                let serialized = original.write_to_vec_with_ctx(Endianness::NATIVE).unwrap();
+                let deserialized =
+                    BVec3::read_from_buffer_with_ctx(Endianness::NATIVE, &serialized).unwrap();
+                assert_eq!(original, deserialized);
+            }
+        }
+    }
+
+    for a in [false, true] {
+        for b in [false, true] {
+            for c in [false, true] {
+                for d in [false, true] {
+                    let original = BVec4::new(a, b, c, d);
+                    let serialized = original.write_to_vec_with_ctx(Endianness::NATIVE).unwrap();
+                    let deserialized =
+                        BVec4::read_from_buffer_with_ctx(Endianness::NATIVE, &serialized).unwrap();
+                    assert_eq!(original, deserialized);
+                }
+            }
+        }
+    }
+
+    macro_rules! test_mat {
+        ($T:ty) => {{
+            let mut cols = <$T>::IDENTITY.to_cols_array();
+            for (i, c) in cols.iter_mut().enumerate() {
+                *c = (i + 1) as _;
+            }
+
+            let original = <$T>::from_cols_array(&cols);
+            let serialized = original.write_to_vec_with_ctx(Endianness::NATIVE).unwrap();
+            let deserialized =
+                <$T>::read_from_buffer_with_ctx(Endianness::NATIVE, &serialized).unwrap();
+            assert_eq!(original, deserialized);
+        }};
+    }
+
+    test_mat!(Mat2);
+    test_mat!(Mat3);
+    test_mat!(Mat3A);
+    test_mat!(Mat4);
+
+    test_mat!(DMat2);
+    test_mat!(DMat3);
+    test_mat!(DMat4);
+
+    test_mat!(Affine2);
+    test_mat!(Affine3A);
+
+    test_mat!(DAffine2);
+    test_mat!(DAffine3);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,7 @@ and benchmarks.
 * `bytecheck` - to perform archive validation when using the `rkyv` feature
 * `serde` - implementations of `Serialize` and `Deserialize` for all `glam`
   types. Note that serialization should work between builds of `glam` with and without SIMD enabled
+* `speedy` - implementations of `speedy`'s `Readable` and `Writable` for all `glam` types.
 * `scalar-math` - disables SIMD support and uses native alignment for all types.
 * `debug-glam-assert` - adds assertions in debug builds which check the validity of parameters
   passed to `glam` to help catch runtime errors.


### PR DESCRIPTION
# Objective

Have support for `speedy` with `glam`'s types

## Solution

I've moved the current implementation that exists in `speedy` under a `glam` feature flag over here to glam under a `speedy` feature flag instead. This is the better way for this to be set up in any case, and especially because `glam` releases significantly more often than `speedy` does.

