### PR TITLE
feat: add fract_gl for f32 and f64 types to match VecN

### DIFF
--- a/src/f32/float.rs
+++ b/src/f32/float.rs
@@ -18,4 +18,9 @@ impl FloatExt for f32 {
         let t = f32::inverse_lerp(in_start, in_end, self);
         f32::lerp(out_start, out_end, t)
     }
+
+    #[inline]
+    fn fract_gl(self) -> f32 {
+        self - crate::f32::math::floor(self)
+    }
 }

--- a/src/f64/float.rs
+++ b/src/f64/float.rs
@@ -18,4 +18,9 @@ impl FloatExt for f64 {
         let t = f64::inverse_lerp(in_start, in_end, self);
         f64::lerp(out_start, out_end, t)
     }
+
+    #[inline]
+    fn fract_gl(self) -> f64 {
+        self - crate::f64::math::floor(self)
+    }
 }

--- a/src/float.rs
+++ b/src/float.rs
@@ -27,4 +27,12 @@ pub trait FloatExt {
     /// `in_start` and `in_end` must not be equal, otherwise the result will be either infinite or `NAN`.
     #[must_use]
     fn remap(self, in_start: Self, in_end: Self, out_start: Self, out_end: Self) -> Self;
+
+    /// Returns the fractional part of the input as `self - self.floor()`.
+    ///
+    /// Note that this differs from the Rust implementation of `fract` which returns
+    /// `self - self.trunc()`.
+    ///
+    /// Note that this is fast but not precise for large numbers.
+    fn fract_gl(self) -> Self;
 }

--- a/templates/float.rs.tera
+++ b/templates/float.rs.tera
@@ -18,4 +18,9 @@ impl FloatExt for {{ scalar_t }} {
         let t = {{ scalar_t }}::inverse_lerp(in_start, in_end, self);
         {{ scalar_t }}::lerp(out_start, out_end, t)
     }
+
+    #[inline]
+    fn fract_gl(self) -> {{ scalar_t }} {
+        self - crate::{{ scalar_t }}::math::floor(self)
+    }
 }


### PR DESCRIPTION
# Objective

- Match Vec fract_gl on f32 for generic macro codegen reasons

## Solution

- Add FloatExt

## Code generation

- Not my first rodeo

## Testing and linting

- Didn't do this, but its a straight copy paste from Vec basically

You can run most of glam's tests locally by running the `build_and_test_features.sh` script.
