### PR TITLE
Implement `AddAssign` for `Quat`/`DQuat`

### DIFF
--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -11,7 +11,7 @@ use core::simd::*;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::ops::{Add, Deref, DerefMut, Div, Mul, MulAssign, Neg, Sub};
+use core::ops::{Add, AddAssign, Deref, DerefMut, Div, Mul, MulAssign, Neg, Sub};
 
 /// Creates a quaternion from `x`, `y`, `z` and `w` values.
 ///
@@ -879,6 +879,19 @@ impl Add<Quat> for Quat {
     #[inline]
     fn add(self, rhs: Self) -> Self {
         Self::from_vec4(Vec4::from(self) + Vec4::from(rhs))
+    }
+}
+
+impl AddAssign<Quat> for Quat {
+    /// Adds two quaternions.
+    ///
+    /// The sum is not guaranteed to be normalized.
+    ///
+    /// Note that addition is not the same as combining the rotations represented by the
+    /// two quaternions! That corresponds to multiplication.
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/src/f32/neon/quat.rs
+++ b/src/f32/neon/quat.rs
@@ -11,7 +11,7 @@ use core::arch::aarch64::*;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::ops::{Add, Deref, DerefMut, Div, Mul, MulAssign, Neg, Sub};
+use core::ops::{Add, AddAssign, Deref, DerefMut, Div, Mul, MulAssign, Neg, Sub};
 
 #[repr(C)]
 union UnionCast {
@@ -901,6 +901,19 @@ impl Add<Quat> for Quat {
     #[inline]
     fn add(self, rhs: Self) -> Self {
         Self::from_vec4(Vec4::from(self) + Vec4::from(rhs))
+    }
+}
+
+impl AddAssign<Quat> for Quat {
+    /// Adds two quaternions.
+    ///
+    /// The sum is not guaranteed to be normalized.
+    ///
+    /// Note that addition is not the same as combining the rotations represented by the
+    /// two quaternions! That corresponds to multiplication.
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::ops::{Add, Div, Mul, MulAssign, Neg, Sub};
+use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub};
 
 /// Creates a quaternion from `x`, `y`, `z` and `w` values.
 ///
@@ -861,6 +861,19 @@ impl Add<Quat> for Quat {
     #[inline]
     fn add(self, rhs: Self) -> Self {
         Self::from_vec4(Vec4::from(self) + Vec4::from(rhs))
+    }
+}
+
+impl AddAssign<Quat> for Quat {
+    /// Adds two quaternions.
+    ///
+    /// The sum is not guaranteed to be normalized.
+    ///
+    /// Note that addition is not the same as combining the rotations represented by the
+    /// two quaternions! That corresponds to multiplication.
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -14,7 +14,7 @@ use core::arch::x86_64::*;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::ops::{Add, Deref, DerefMut, Div, Mul, MulAssign, Neg, Sub};
+use core::ops::{Add, AddAssign, Deref, DerefMut, Div, Mul, MulAssign, Neg, Sub};
 
 #[repr(C)]
 union UnionCast {
@@ -909,6 +909,19 @@ impl Add<Quat> for Quat {
     #[inline]
     fn add(self, rhs: Self) -> Self {
         Self::from_vec4(Vec4::from(self) + Vec4::from(rhs))
+    }
+}
+
+impl AddAssign<Quat> for Quat {
+    /// Adds two quaternions.
+    ///
+    /// The sum is not guaranteed to be normalized.
+    ///
+    /// Note that addition is not the same as combining the rotations represented by the
+    /// two quaternions! That corresponds to multiplication.
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/src/f32/wasm32/quat.rs
+++ b/src/f32/wasm32/quat.rs
@@ -11,7 +11,7 @@ use core::arch::wasm32::*;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::ops::{Add, Deref, DerefMut, Div, Mul, MulAssign, Neg, Sub};
+use core::ops::{Add, AddAssign, Deref, DerefMut, Div, Mul, MulAssign, Neg, Sub};
 
 /// Creates a quaternion from `x`, `y`, `z` and `w` values.
 ///
@@ -881,6 +881,19 @@ impl Add<Quat> for Quat {
     #[inline]
     fn add(self, rhs: Self) -> Self {
         Self::from_vec4(Vec4::from(self) + Vec4::from(rhs))
+    }
+}
+
+impl AddAssign<Quat> for Quat {
+    /// Adds two quaternions.
+    ///
+    /// The sum is not guaranteed to be normalized.
+    ///
+    /// Note that addition is not the same as combining the rotations represented by the
+    /// two quaternions! That corresponds to multiplication.
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -8,7 +8,7 @@ use crate::{
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::ops::{Add, Div, Mul, MulAssign, Neg, Sub};
+use core::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub};
 
 /// Creates a quaternion from `x`, `y`, `z` and `w` values.
 ///
@@ -836,6 +836,19 @@ impl Add<DQuat> for DQuat {
     #[inline]
     fn add(self, rhs: Self) -> Self {
         Self::from_vec4(DVec4::from(self) + DVec4::from(rhs))
+    }
+}
+
+impl AddAssign<DQuat> for DQuat {
+    /// Adds two quaternions.
+    ///
+    /// The sum is not guaranteed to be normalized.
+    ///
+    /// Note that addition is not the same as combining the rotations represented by the
+    /// two quaternions! That corresponds to multiplication.
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/templates/quat.rs.tera
+++ b/templates/quat.rs.tera
@@ -69,7 +69,7 @@ use core::ops::{
     {% if not is_scalar %}
         Deref, DerefMut,
     {% endif %}
-    Add, Div, Mul, MulAssign, Neg, Sub
+    Add, AddAssign, Div, Mul, MulAssign, Neg, Sub
 };
 
 {% if is_sse2 or is_neon %}
@@ -1255,6 +1255,19 @@ impl Add<{{ self_t }}> for {{ self_t }} {
     #[inline]
     fn add(self, rhs: Self) -> Self {
         Self::from_vec4({{ vec4_t }}::from(self) + {{ vec4_t }}::from(rhs))
+    }
+}
+
+impl AddAssign<{{ self_t }}> for {{ self_t }} {
+    /// Adds two quaternions.
+    ///
+    /// The sum is not guaranteed to be normalized.
+    ///
+    /// Note that addition is not the same as combining the rotations represented by the
+    /// two quaternions! That corresponds to multiplication.
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -607,6 +607,19 @@ macro_rules! impl_quat_tests {
                 assert_approx_eq!(angle, angle2);
             }
         });
+
+        glam_test!(test_add_assign, {
+            {
+                // Normalization not needed for this test.
+                let q = $quat::from_xyzw(1.0, 2.0, 3.0, 4.0);
+                let p = $quat::from_xyzw(5.0, 6.0, 7.0, 8.0);
+
+                let mut pq = p;
+                pq += q;
+
+                assert_eq!(p + q, pq);
+            }
+        });
     };
 }
 


### PR DESCRIPTION
# Objective

`Quat` already implements `Add`, so having `AddAssign` is useful sometimes.

## Solution

Implement `AddAssign` for `Quat` by forwarding to the `Add` implementation.