### PR TITLE
Use self for vector and quat methods and &self for matrix and affine.

### DIFF
--- a/src/bool/bvec2.rs
+++ b/src/bool/bvec2.rs
@@ -77,7 +77,7 @@ impl BVec2 {
     /// Panics if `index` is greater than 1.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         match index {
             0 => self.x,
             1 => self.y,

--- a/src/bool/bvec3.rs
+++ b/src/bool/bvec3.rs
@@ -78,7 +78,7 @@ impl BVec3 {
     /// Panics if `index` is greater than 2.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         match index {
             0 => self.x,
             1 => self.y,

--- a/src/bool/bvec4.rs
+++ b/src/bool/bvec4.rs
@@ -79,7 +79,7 @@ impl BVec4 {
     /// Panics if `index` is greater than 3.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         match index {
             0 => self.x,
             1 => self.y,

--- a/src/bool/coresimd/bvec3a.rs
+++ b/src/bool/coresimd/bvec3a.rs
@@ -89,7 +89,7 @@ impl BVec3A {
     /// Panics if `index` is greater than 2.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         assert!(index < 3, "index out of bounds");
         self.0.test(index)
     }

--- a/src/bool/coresimd/bvec4a.rs
+++ b/src/bool/coresimd/bvec4a.rs
@@ -94,7 +94,7 @@ impl BVec4A {
     /// Panics if `index` is greater than 3.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         assert!(index < 4, "index out of bounds");
         self.0.test(index)
     }

--- a/src/bool/neon/bvec3a.rs
+++ b/src/bool/neon/bvec3a.rs
@@ -98,7 +98,7 @@ impl BVec3A {
     /// Panics if `index` is greater than 2.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         match index {
             0 => (self.bitmask() & (1 << 0)) != 0,
             1 => (self.bitmask() & (1 << 1)) != 0,

--- a/src/bool/neon/bvec4a.rs
+++ b/src/bool/neon/bvec4a.rs
@@ -101,7 +101,7 @@ impl BVec4A {
     /// Panics if `index` is greater than 3.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         match index {
             0 => (self.bitmask() & (1 << 0)) != 0,
             1 => (self.bitmask() & (1 << 1)) != 0,

--- a/src/bool/scalar/bvec3a.rs
+++ b/src/bool/scalar/bvec3a.rs
@@ -82,7 +82,7 @@ impl BVec3A {
     /// Panics if `index` is greater than 2.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         match index {
             0 => (self.x & 0x1) != 0,
             1 => (self.y & 0x1) != 0,

--- a/src/bool/scalar/bvec4a.rs
+++ b/src/bool/scalar/bvec4a.rs
@@ -84,7 +84,7 @@ impl BVec4A {
     /// Panics if `index` is greater than 3.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         match index {
             0 => (self.x & 0x1) != 0,
             1 => (self.y & 0x1) != 0,

--- a/src/bool/sse2/bvec3a.rs
+++ b/src/bool/sse2/bvec3a.rs
@@ -92,7 +92,7 @@ impl BVec3A {
     /// Panics if `index` is greater than 2.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         match index {
             0 => (self.bitmask() & (1 << 0)) != 0,
             1 => (self.bitmask() & (1 << 1)) != 0,

--- a/src/bool/sse2/bvec4a.rs
+++ b/src/bool/sse2/bvec4a.rs
@@ -97,7 +97,7 @@ impl BVec4A {
     /// Panics if `index` is greater than 3.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         match index {
             0 => (self.bitmask() & (1 << 0)) != 0,
             1 => (self.bitmask() & (1 << 1)) != 0,

--- a/src/bool/wasm32/bvec3a.rs
+++ b/src/bool/wasm32/bvec3a.rs
@@ -83,7 +83,7 @@ impl BVec3A {
     /// Panics if `index` is greater than 2.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         match index {
             0 => (self.bitmask() & (1 << 0)) != 0,
             1 => (self.bitmask() & (1 << 1)) != 0,

--- a/src/bool/wasm32/bvec4a.rs
+++ b/src/bool/wasm32/bvec4a.rs
@@ -83,7 +83,7 @@ impl BVec4A {
     /// Panics if `index` is greater than 3.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         match index {
             0 => (self.bitmask() & (1 << 0)) != 0,
             1 => (self.bitmask() & (1 << 1)) != 0,

--- a/src/f32/affine2.rs
+++ b/src/f32/affine2.rs
@@ -126,7 +126,7 @@ impl Affine2 {
     ///
     /// Panics if `slice` is less than 6 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         self.matrix2.write_cols_to_slice(&mut slice[0..4]);
         self.translation.write_to_slice(&mut slice[4..6]);
     }
@@ -247,7 +247,7 @@ impl Affine2 {
     /// vector contains any zero elements when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn to_scale_angle_translation(self) -> (Vec2, f32, Vec2) {
+    pub fn to_scale_angle_translation(&self) -> (Vec2, f32, Vec2) {
         use crate::f32::math;
         let det = self.matrix2.determinant();
         glam_assert!(det != 0.0);

--- a/src/f32/affine3a.rs
+++ b/src/f32/affine3a.rs
@@ -121,7 +121,7 @@ impl Affine3A {
     ///
     /// Panics if `slice` is less than 12 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         self.matrix3.write_cols_to_slice(&mut slice[0..9]);
         self.translation.write_to_slice(&mut slice[9..12]);
     }

--- a/src/f32/coresimd/mat2.rs
+++ b/src/f32/coresimd/mat2.rs
@@ -187,7 +187,7 @@ impl Mat2 {
     ///
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.y_axis.x;

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -476,7 +476,7 @@ impl Mat3A {
     ///
     /// Panics if `slice` is less than 9 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -520,7 +520,7 @@ impl Mat4 {
     ///
     /// Panics if `slice` is less than 16 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -492,7 +492,7 @@ impl Quat {
     /// `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(&self) -> [f32; 4] {
+    pub fn to_array(self) -> [f32; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -651,7 +651,7 @@ impl Quat {
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn rotate_towards(&self, rhs: Self, max_angle: f32) -> Self {
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -135,8 +135,8 @@ impl Vec3A {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 3] {
-        unsafe { *(self as *const Self as *const [f32; 3]) }
+    pub const fn to_array(self) -> [f32; 3] {
+        unsafe { *(&self as *const Self as *const [f32; 3]) }
     }
 
     /// Creates a vector from the first 3 values in `slice`.
@@ -826,13 +826,13 @@ impl Vec3A {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1003,7 +1003,7 @@ impl Vec3A {
     /// [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     #[must_use]
-    pub fn any_orthogonal_vector(&self) -> Self {
+    pub fn any_orthogonal_vector(self) -> Self {
         // This can probably be optimized
         if math::abs(self.x) > math::abs(self.y) {
             Self::new(-self.z, 0.0, self.x) // self.cross(Self::Y)
@@ -1021,7 +1021,7 @@ impl Vec3A {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_vector(&self) -> Self {
+    pub fn any_orthonormal_vector(self) -> Self {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1038,7 +1038,7 @@ impl Vec3A {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_pair(&self) -> (Self, Self) {
+    pub fn any_orthonormal_pair(self) -> (Self, Self) {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1096,70 +1096,70 @@ impl Vec3A {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 }

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -137,8 +137,8 @@ impl Vec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 4] {
-        unsafe { *(self as *const Self as *const [f32; 4]) }
+    pub const fn to_array(self) -> [f32; 4] {
+        unsafe { *(&self as *const Self as *const [f32; 4]) }
     }
 
     /// Creates a vector from the first 4 values in `slice`.
@@ -819,13 +819,13 @@ impl Vec4 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -961,70 +961,70 @@ impl Vec4 {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -409,7 +409,7 @@ impl Mat3 {
     ///
     /// Panics if `slice` is less than 9 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f32/neon/mat2.rs
+++ b/src/f32/neon/mat2.rs
@@ -203,7 +203,7 @@ impl Mat2 {
     ///
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.y_axis.x;

--- a/src/f32/neon/mat3a.rs
+++ b/src/f32/neon/mat3a.rs
@@ -476,7 +476,7 @@ impl Mat3A {
     ///
     /// Panics if `slice` is less than 9 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -520,7 +520,7 @@ impl Mat4 {
     ///
     /// Panics if `slice` is less than 16 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f32/neon/quat.rs
+++ b/src/f32/neon/quat.rs
@@ -497,7 +497,7 @@ impl Quat {
     /// `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(&self) -> [f32; 4] {
+    pub fn to_array(self) -> [f32; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -656,7 +656,7 @@ impl Quat {
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn rotate_towards(&self, rhs: Self, max_angle: f32) -> Self {
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -140,8 +140,8 @@ impl Vec3A {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 3] {
-        unsafe { *(self as *const Self as *const [f32; 3]) }
+    pub const fn to_array(self) -> [f32; 3] {
+        unsafe { *(&self as *const Self as *const [f32; 3]) }
     }
 
     /// Creates a vector from the first 3 values in `slice`.
@@ -868,13 +868,13 @@ impl Vec3A {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1045,7 +1045,7 @@ impl Vec3A {
     /// [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     #[must_use]
-    pub fn any_orthogonal_vector(&self) -> Self {
+    pub fn any_orthogonal_vector(self) -> Self {
         // This can probably be optimized
         if math::abs(self.x) > math::abs(self.y) {
             Self::new(-self.z, 0.0, self.x) // self.cross(Self::Y)
@@ -1063,7 +1063,7 @@ impl Vec3A {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_vector(&self) -> Self {
+    pub fn any_orthonormal_vector(self) -> Self {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1080,7 +1080,7 @@ impl Vec3A {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_pair(&self) -> (Self, Self) {
+    pub fn any_orthonormal_pair(self) -> (Self, Self) {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1138,70 +1138,70 @@ impl Vec3A {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 }

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -142,8 +142,8 @@ impl Vec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 4] {
-        unsafe { *(self as *const Self as *const [f32; 4]) }
+    pub const fn to_array(self) -> [f32; 4] {
+        unsafe { *(&self as *const Self as *const [f32; 4]) }
     }
 
     /// Creates a vector from the first 4 values in `slice`.
@@ -848,13 +848,13 @@ impl Vec4 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -990,70 +990,70 @@ impl Vec4 {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/f32/scalar/mat2.rs
+++ b/src/f32/scalar/mat2.rs
@@ -192,7 +192,7 @@ impl Mat2 {
     ///
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.y_axis.x;

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -477,7 +477,7 @@ impl Mat3A {
     ///
     /// Panics if `slice` is less than 9 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -532,7 +532,7 @@ impl Mat4 {
     ///
     /// Panics if `slice` is less than 16 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -498,7 +498,7 @@ impl Quat {
     /// `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(&self) -> [f32; 4] {
+    pub fn to_array(self) -> [f32; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -661,7 +661,7 @@ impl Quat {
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn rotate_towards(&self, rhs: Self, max_angle: f32) -> Self {
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -142,7 +142,7 @@ impl Vec3A {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 3] {
+    pub const fn to_array(self) -> [f32; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -869,13 +869,13 @@ impl Vec3A {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1050,7 +1050,7 @@ impl Vec3A {
     /// [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     #[must_use]
-    pub fn any_orthogonal_vector(&self) -> Self {
+    pub fn any_orthogonal_vector(self) -> Self {
         // This can probably be optimized
         if math::abs(self.x) > math::abs(self.y) {
             Self::new(-self.z, 0.0, self.x) // self.cross(Self::Y)
@@ -1068,7 +1068,7 @@ impl Vec3A {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_vector(&self) -> Self {
+    pub fn any_orthonormal_vector(self) -> Self {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1085,7 +1085,7 @@ impl Vec3A {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_pair(&self) -> (Self, Self) {
+    pub fn any_orthonormal_pair(self) -> (Self, Self) {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1143,70 +1143,70 @@ impl Vec3A {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 }

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -161,7 +161,7 @@ impl Vec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 4] {
+    pub const fn to_array(self) -> [f32; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -927,13 +927,13 @@ impl Vec4 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1074,70 +1074,70 @@ impl Vec4 {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/f32/sse2/mat2.rs
+++ b/src/f32/sse2/mat2.rs
@@ -206,7 +206,7 @@ impl Mat2 {
     ///
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.y_axis.x;

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -479,7 +479,7 @@ impl Mat3A {
     ///
     /// Panics if `slice` is less than 9 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -523,7 +523,7 @@ impl Mat4 {
     ///
     /// Panics if `slice` is less than 16 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -500,7 +500,7 @@ impl Quat {
     /// `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(&self) -> [f32; 4] {
+    pub fn to_array(self) -> [f32; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -659,7 +659,7 @@ impl Quat {
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn rotate_towards(&self, rhs: Self, max_angle: f32) -> Self {
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -148,8 +148,8 @@ impl Vec3A {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 3] {
-        unsafe { *(self as *const Self as *const [f32; 3]) }
+    pub const fn to_array(self) -> [f32; 3] {
+        unsafe { *(&self as *const Self as *const [f32; 3]) }
     }
 
     /// Creates a vector from the first 3 values in `slice`.
@@ -867,13 +867,13 @@ impl Vec3A {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1053,7 +1053,7 @@ impl Vec3A {
     /// [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     #[must_use]
-    pub fn any_orthogonal_vector(&self) -> Self {
+    pub fn any_orthogonal_vector(self) -> Self {
         // This can probably be optimized
         if math::abs(self.x) > math::abs(self.y) {
             Self::new(-self.z, 0.0, self.x) // self.cross(Self::Y)
@@ -1071,7 +1071,7 @@ impl Vec3A {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_vector(&self) -> Self {
+    pub fn any_orthonormal_vector(self) -> Self {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1088,7 +1088,7 @@ impl Vec3A {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_pair(&self) -> (Self, Self) {
+    pub fn any_orthonormal_pair(self) -> (Self, Self) {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1146,70 +1146,70 @@ impl Vec3A {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 }

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -150,8 +150,8 @@ impl Vec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 4] {
-        unsafe { *(self as *const Self as *const [f32; 4]) }
+    pub const fn to_array(self) -> [f32; 4] {
+        unsafe { *(&self as *const Self as *const [f32; 4]) }
     }
 
     /// Creates a vector from the first 4 values in `slice`.
@@ -856,13 +856,13 @@ impl Vec4 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1008,70 +1008,70 @@ impl Vec4 {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -126,7 +126,7 @@ impl Vec2 {
     /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 2] {
+    pub const fn to_array(self) -> [f32; 2] {
         [self.x, self.y]
     }
 
@@ -776,13 +776,13 @@ impl Vec2 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1001,81 +1001,81 @@ impl Vec2 {
     /// rotates towards the exact opposite of `rhs`. Will not go past the target.
     #[inline]
     #[must_use]
-    pub fn rotate_towards(&self, rhs: Self, max_angle: f32) -> Self {
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         let a = self.angle_to(rhs);
         let abs_a = math::abs(a);
         // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(abs_a - core::f32::consts::PI, abs_a) * math::signum(a);
-        Self::from_angle(angle).rotate(*self)
+        Self::from_angle(angle).rotate(self)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec2(&self) -> crate::DVec2 {
+    pub fn as_dvec2(self) -> crate::DVec2 {
         crate::DVec2::new(self.x as f64, self.y as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec2(&self) -> crate::I8Vec2 {
+    pub fn as_i8vec2(self) -> crate::I8Vec2 {
         crate::I8Vec2::new(self.x as i8, self.y as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec2(&self) -> crate::U8Vec2 {
+    pub fn as_u8vec2(self) -> crate::U8Vec2 {
         crate::U8Vec2::new(self.x as u8, self.y as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec2(&self) -> crate::I16Vec2 {
+    pub fn as_i16vec2(self) -> crate::I16Vec2 {
         crate::I16Vec2::new(self.x as i16, self.y as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec2(&self) -> crate::U16Vec2 {
+    pub fn as_u16vec2(self) -> crate::U16Vec2 {
         crate::U16Vec2::new(self.x as u16, self.y as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec2(&self) -> crate::IVec2 {
+    pub fn as_ivec2(self) -> crate::IVec2 {
         crate::IVec2::new(self.x as i32, self.y as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec2(&self) -> crate::UVec2 {
+    pub fn as_uvec2(self) -> crate::UVec2 {
         crate::UVec2::new(self.x as u32, self.y as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec2(&self) -> crate::I64Vec2 {
+    pub fn as_i64vec2(self) -> crate::I64Vec2 {
         crate::I64Vec2::new(self.x as i64, self.y as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec2(&self) -> crate::U64Vec2 {
+    pub fn as_u64vec2(self) -> crate::U64Vec2 {
         crate::U64Vec2::new(self.x as u64, self.y as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec2(&self) -> crate::USizeVec2 {
+    pub fn as_usizevec2(self) -> crate::USizeVec2 {
         crate::USizeVec2::new(self.x as usize, self.y as usize)
     }
 }

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -133,7 +133,7 @@ impl Vec3 {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 3] {
+    pub const fn to_array(self) -> [f32; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -859,13 +859,13 @@ impl Vec3 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1040,7 +1040,7 @@ impl Vec3 {
     /// [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     #[must_use]
-    pub fn any_orthogonal_vector(&self) -> Self {
+    pub fn any_orthogonal_vector(self) -> Self {
         // This can probably be optimized
         if math::abs(self.x) > math::abs(self.y) {
             Self::new(-self.z, 0.0, self.x) // self.cross(Self::Y)
@@ -1058,7 +1058,7 @@ impl Vec3 {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_vector(&self) -> Self {
+    pub fn any_orthonormal_vector(self) -> Self {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1075,7 +1075,7 @@ impl Vec3 {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_pair(&self) -> (Self, Self) {
+    pub fn any_orthonormal_pair(self) -> (Self, Self) {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1133,70 +1133,70 @@ impl Vec3 {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 }

--- a/src/f32/wasm32/mat2.rs
+++ b/src/f32/wasm32/mat2.rs
@@ -187,7 +187,7 @@ impl Mat2 {
     ///
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.y_axis.x;

--- a/src/f32/wasm32/mat3a.rs
+++ b/src/f32/wasm32/mat3a.rs
@@ -476,7 +476,7 @@ impl Mat3A {
     ///
     /// Panics if `slice` is less than 9 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -520,7 +520,7 @@ impl Mat4 {
     ///
     /// Panics if `slice` is less than 16 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f32]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f32]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f32/wasm32/quat.rs
+++ b/src/f32/wasm32/quat.rs
@@ -492,7 +492,7 @@ impl Quat {
     /// `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(&self) -> [f32; 4] {
+    pub fn to_array(self) -> [f32; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -651,7 +651,7 @@ impl Quat {
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn rotate_towards(&self, rhs: Self, max_angle: f32) -> Self {
+    pub fn rotate_towards(self, rhs: Self, max_angle: f32) -> Self {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -134,8 +134,8 @@ impl Vec3A {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 3] {
-        unsafe { *(self as *const Self as *const [f32; 3]) }
+    pub const fn to_array(self) -> [f32; 3] {
+        unsafe { *(&self as *const Self as *const [f32; 3]) }
     }
 
     /// Creates a vector from the first 3 values in `slice`.
@@ -835,13 +835,13 @@ impl Vec3A {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1016,7 +1016,7 @@ impl Vec3A {
     /// [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     #[must_use]
-    pub fn any_orthogonal_vector(&self) -> Self {
+    pub fn any_orthogonal_vector(self) -> Self {
         // This can probably be optimized
         if math::abs(self.x) > math::abs(self.y) {
             Self::new(-self.z, 0.0, self.x) // self.cross(Self::Y)
@@ -1034,7 +1034,7 @@ impl Vec3A {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_vector(&self) -> Self {
+    pub fn any_orthonormal_vector(self) -> Self {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1051,7 +1051,7 @@ impl Vec3A {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_pair(&self) -> (Self, Self) {
+    pub fn any_orthonormal_pair(self) -> (Self, Self) {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1109,70 +1109,70 @@ impl Vec3A {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 }

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -136,8 +136,8 @@ impl Vec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f32; 4] {
-        unsafe { *(self as *const Self as *const [f32; 4]) }
+    pub const fn to_array(self) -> [f32; 4] {
+        unsafe { *(&self as *const Self as *const [f32; 4]) }
     }
 
     /// Creates a vector from the first 4 values in `slice`.
@@ -828,13 +828,13 @@ impl Vec4 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f32) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f32) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -975,70 +975,70 @@ impl Vec4 {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/f64/daffine2.rs
+++ b/src/f64/daffine2.rs
@@ -115,7 +115,7 @@ impl DAffine2 {
     ///
     /// Panics if `slice` is less than 6 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f64]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f64]) {
         self.matrix2.write_cols_to_slice(&mut slice[0..4]);
         self.translation.write_to_slice(&mut slice[4..6]);
     }
@@ -225,7 +225,7 @@ impl DAffine2 {
     /// vector contains any zero elements when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn to_scale_angle_translation(self) -> (DVec2, f64, DVec2) {
+    pub fn to_scale_angle_translation(&self) -> (DVec2, f64, DVec2) {
         use crate::f64::math;
         let det = self.matrix2.determinant();
         glam_assert!(det != 0.0);

--- a/src/f64/daffine3.rs
+++ b/src/f64/daffine3.rs
@@ -119,7 +119,7 @@ impl DAffine3 {
     ///
     /// Panics if `slice` is less than 12 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f64]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f64]) {
         self.matrix3.write_cols_to_slice(&mut slice[0..9]);
         self.translation.write_to_slice(&mut slice[9..12]);
     }

--- a/src/f64/dmat2.rs
+++ b/src/f64/dmat2.rs
@@ -158,7 +158,7 @@ impl DMat2 {
     ///
     /// Panics if `slice` is less than 4 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f64]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f64]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.y_axis.x;

--- a/src/f64/dmat3.rs
+++ b/src/f64/dmat3.rs
@@ -413,7 +413,7 @@ impl DMat3 {
     ///
     /// Panics if `slice` is less than 9 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f64]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f64]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -514,7 +514,7 @@ impl DMat4 {
     ///
     /// Panics if `slice` is less than 16 elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [f64]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [f64]) {
         slice[0] = self.x_axis.x;
         slice[1] = self.x_axis.y;
         slice[2] = self.x_axis.z;

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -480,7 +480,7 @@ impl DQuat {
     /// `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(&self) -> [f64; 4] {
+    pub fn to_array(self) -> [f64; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -643,7 +643,7 @@ impl DQuat {
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn rotate_towards(&self, rhs: Self, max_angle: f64) -> Self {
+    pub fn rotate_towards(self, rhs: Self, max_angle: f64) -> Self {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -126,7 +126,7 @@ impl DVec2 {
     /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f64; 2] {
+    pub const fn to_array(self) -> [f64; 2] {
         [self.x, self.y]
     }
 
@@ -776,13 +776,13 @@ impl DVec2 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f64) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f64) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1001,81 +1001,81 @@ impl DVec2 {
     /// rotates towards the exact opposite of `rhs`. Will not go past the target.
     #[inline]
     #[must_use]
-    pub fn rotate_towards(&self, rhs: Self, max_angle: f64) -> Self {
+    pub fn rotate_towards(self, rhs: Self, max_angle: f64) -> Self {
         let a = self.angle_to(rhs);
         let abs_a = math::abs(a);
         // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(abs_a - core::f64::consts::PI, abs_a) * math::signum(a);
-        Self::from_angle(angle).rotate(*self)
+        Self::from_angle(angle).rotate(self)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec2(&self) -> crate::Vec2 {
+    pub fn as_vec2(self) -> crate::Vec2 {
         crate::Vec2::new(self.x as f32, self.y as f32)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec2(&self) -> crate::I8Vec2 {
+    pub fn as_i8vec2(self) -> crate::I8Vec2 {
         crate::I8Vec2::new(self.x as i8, self.y as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec2(&self) -> crate::U8Vec2 {
+    pub fn as_u8vec2(self) -> crate::U8Vec2 {
         crate::U8Vec2::new(self.x as u8, self.y as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec2(&self) -> crate::I16Vec2 {
+    pub fn as_i16vec2(self) -> crate::I16Vec2 {
         crate::I16Vec2::new(self.x as i16, self.y as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec2(&self) -> crate::U16Vec2 {
+    pub fn as_u16vec2(self) -> crate::U16Vec2 {
         crate::U16Vec2::new(self.x as u16, self.y as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec2(&self) -> crate::IVec2 {
+    pub fn as_ivec2(self) -> crate::IVec2 {
         crate::IVec2::new(self.x as i32, self.y as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec2(&self) -> crate::UVec2 {
+    pub fn as_uvec2(self) -> crate::UVec2 {
         crate::UVec2::new(self.x as u32, self.y as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec2(&self) -> crate::I64Vec2 {
+    pub fn as_i64vec2(self) -> crate::I64Vec2 {
         crate::I64Vec2::new(self.x as i64, self.y as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec2(&self) -> crate::U64Vec2 {
+    pub fn as_u64vec2(self) -> crate::U64Vec2 {
         crate::U64Vec2::new(self.x as u64, self.y as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec2(&self) -> crate::USizeVec2 {
+    pub fn as_usizevec2(self) -> crate::USizeVec2 {
         crate::USizeVec2::new(self.x as usize, self.y as usize)
     }
 }

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -133,7 +133,7 @@ impl DVec3 {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f64; 3] {
+    pub const fn to_array(self) -> [f64; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -852,13 +852,13 @@ impl DVec3 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f64) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f64) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1033,7 +1033,7 @@ impl DVec3 {
     /// [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     #[must_use]
-    pub fn any_orthogonal_vector(&self) -> Self {
+    pub fn any_orthogonal_vector(self) -> Self {
         // This can probably be optimized
         if math::abs(self.x) > math::abs(self.y) {
             Self::new(-self.z, 0.0, self.x) // self.cross(Self::Y)
@@ -1051,7 +1051,7 @@ impl DVec3 {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_vector(&self) -> Self {
+    pub fn any_orthonormal_vector(self) -> Self {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1068,7 +1068,7 @@ impl DVec3 {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_pair(&self) -> (Self, Self) {
+    pub fn any_orthonormal_pair(self) -> (Self, Self) {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -1126,77 +1126,77 @@ impl DVec3 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3(&self) -> crate::Vec3 {
+    pub fn as_vec3(self) -> crate::Vec3 {
         crate::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3a(&self) -> crate::Vec3A {
+    pub fn as_vec3a(self) -> crate::Vec3A {
         crate::Vec3A::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 }

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -152,7 +152,7 @@ impl DVec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [f64; 4] {
+    pub const fn to_array(self) -> [f64; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -916,13 +916,13 @@ impl DVec4 {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: f64) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: f64) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d
+        self + a / len * d
     }
 
     /// Calculates the midpoint between `self` and `rhs`.
@@ -1063,70 +1063,70 @@ impl DVec4 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(self) -> crate::Vec4 {
         crate::Vec4::new(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -107,7 +107,7 @@ impl I16Vec2 {
     /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i16; 2] {
+    pub const fn to_array(self) -> [i16; 2] {
         [self.x, self.y]
     }
 
@@ -485,70 +485,70 @@ impl I16Vec2 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec2(&self) -> crate::Vec2 {
+    pub fn as_vec2(self) -> crate::Vec2 {
         crate::Vec2::new(self.x as f32, self.y as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec2(&self) -> crate::DVec2 {
+    pub fn as_dvec2(self) -> crate::DVec2 {
         crate::DVec2::new(self.x as f64, self.y as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec2(&self) -> crate::I8Vec2 {
+    pub fn as_i8vec2(self) -> crate::I8Vec2 {
         crate::I8Vec2::new(self.x as i8, self.y as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec2(&self) -> crate::U8Vec2 {
+    pub fn as_u8vec2(self) -> crate::U8Vec2 {
         crate::U8Vec2::new(self.x as u8, self.y as u8)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec2(&self) -> crate::U16Vec2 {
+    pub fn as_u16vec2(self) -> crate::U16Vec2 {
         crate::U16Vec2::new(self.x as u16, self.y as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec2(&self) -> crate::IVec2 {
+    pub fn as_ivec2(self) -> crate::IVec2 {
         crate::IVec2::new(self.x as i32, self.y as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec2(&self) -> crate::UVec2 {
+    pub fn as_uvec2(self) -> crate::UVec2 {
         crate::UVec2::new(self.x as u32, self.y as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec2(&self) -> crate::I64Vec2 {
+    pub fn as_i64vec2(self) -> crate::I64Vec2 {
         crate::I64Vec2::new(self.x as i64, self.y as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec2(&self) -> crate::U64Vec2 {
+    pub fn as_u64vec2(self) -> crate::U64Vec2 {
         crate::U64Vec2::new(self.x as u64, self.y as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec2(&self) -> crate::USizeVec2 {
+    pub fn as_usizevec2(self) -> crate::USizeVec2 {
         crate::USizeVec2::new(self.x as usize, self.y as usize)
     }
 

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -117,7 +117,7 @@ impl I16Vec3 {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i16; 3] {
+    pub const fn to_array(self) -> [i16; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -532,77 +532,77 @@ impl I16Vec3 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3(&self) -> crate::Vec3 {
+    pub fn as_vec3(self) -> crate::Vec3 {
         crate::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3a(&self) -> crate::Vec3A {
+    pub fn as_vec3a(self) -> crate::Vec3A {
         crate::Vec3A::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -135,7 +135,7 @@ impl I16Vec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i16; 4] {
+    pub const fn to_array(self) -> [i16; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -578,70 +578,70 @@ impl I16Vec4 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(self) -> crate::Vec4 {
         crate::Vec4::new(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -107,7 +107,7 @@ impl IVec2 {
     /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i32; 2] {
+    pub const fn to_array(self) -> [i32; 2] {
         [self.x, self.y]
     }
 
@@ -485,70 +485,70 @@ impl IVec2 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec2(&self) -> crate::Vec2 {
+    pub fn as_vec2(self) -> crate::Vec2 {
         crate::Vec2::new(self.x as f32, self.y as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec2(&self) -> crate::DVec2 {
+    pub fn as_dvec2(self) -> crate::DVec2 {
         crate::DVec2::new(self.x as f64, self.y as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec2(&self) -> crate::I8Vec2 {
+    pub fn as_i8vec2(self) -> crate::I8Vec2 {
         crate::I8Vec2::new(self.x as i8, self.y as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec2(&self) -> crate::U8Vec2 {
+    pub fn as_u8vec2(self) -> crate::U8Vec2 {
         crate::U8Vec2::new(self.x as u8, self.y as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec2(&self) -> crate::I16Vec2 {
+    pub fn as_i16vec2(self) -> crate::I16Vec2 {
         crate::I16Vec2::new(self.x as i16, self.y as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec2(&self) -> crate::U16Vec2 {
+    pub fn as_u16vec2(self) -> crate::U16Vec2 {
         crate::U16Vec2::new(self.x as u16, self.y as u16)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec2(&self) -> crate::UVec2 {
+    pub fn as_uvec2(self) -> crate::UVec2 {
         crate::UVec2::new(self.x as u32, self.y as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec2(&self) -> crate::I64Vec2 {
+    pub fn as_i64vec2(self) -> crate::I64Vec2 {
         crate::I64Vec2::new(self.x as i64, self.y as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec2(&self) -> crate::U64Vec2 {
+    pub fn as_u64vec2(self) -> crate::U64Vec2 {
         crate::U64Vec2::new(self.x as u64, self.y as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec2(&self) -> crate::USizeVec2 {
+    pub fn as_usizevec2(self) -> crate::USizeVec2 {
         crate::USizeVec2::new(self.x as usize, self.y as usize)
     }
 

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -117,7 +117,7 @@ impl IVec3 {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i32; 3] {
+    pub const fn to_array(self) -> [i32; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -532,77 +532,77 @@ impl IVec3 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3(&self) -> crate::Vec3 {
+    pub fn as_vec3(self) -> crate::Vec3 {
         crate::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3a(&self) -> crate::Vec3A {
+    pub fn as_vec3a(self) -> crate::Vec3A {
         crate::Vec3A::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -135,7 +135,7 @@ impl IVec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i32; 4] {
+    pub const fn to_array(self) -> [i32; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -578,70 +578,70 @@ impl IVec4 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(self) -> crate::Vec4 {
         crate::Vec4::new(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -107,7 +107,7 @@ impl I64Vec2 {
     /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i64; 2] {
+    pub const fn to_array(self) -> [i64; 2] {
         [self.x, self.y]
     }
 
@@ -485,70 +485,70 @@ impl I64Vec2 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec2(&self) -> crate::Vec2 {
+    pub fn as_vec2(self) -> crate::Vec2 {
         crate::Vec2::new(self.x as f32, self.y as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec2(&self) -> crate::DVec2 {
+    pub fn as_dvec2(self) -> crate::DVec2 {
         crate::DVec2::new(self.x as f64, self.y as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec2(&self) -> crate::I8Vec2 {
+    pub fn as_i8vec2(self) -> crate::I8Vec2 {
         crate::I8Vec2::new(self.x as i8, self.y as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec2(&self) -> crate::U8Vec2 {
+    pub fn as_u8vec2(self) -> crate::U8Vec2 {
         crate::U8Vec2::new(self.x as u8, self.y as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec2(&self) -> crate::I16Vec2 {
+    pub fn as_i16vec2(self) -> crate::I16Vec2 {
         crate::I16Vec2::new(self.x as i16, self.y as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec2(&self) -> crate::U16Vec2 {
+    pub fn as_u16vec2(self) -> crate::U16Vec2 {
         crate::U16Vec2::new(self.x as u16, self.y as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec2(&self) -> crate::IVec2 {
+    pub fn as_ivec2(self) -> crate::IVec2 {
         crate::IVec2::new(self.x as i32, self.y as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec2(&self) -> crate::UVec2 {
+    pub fn as_uvec2(self) -> crate::UVec2 {
         crate::UVec2::new(self.x as u32, self.y as u32)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec2(&self) -> crate::U64Vec2 {
+    pub fn as_u64vec2(self) -> crate::U64Vec2 {
         crate::U64Vec2::new(self.x as u64, self.y as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec2(&self) -> crate::USizeVec2 {
+    pub fn as_usizevec2(self) -> crate::USizeVec2 {
         crate::USizeVec2::new(self.x as usize, self.y as usize)
     }
 

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -117,7 +117,7 @@ impl I64Vec3 {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i64; 3] {
+    pub const fn to_array(self) -> [i64; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -532,77 +532,77 @@ impl I64Vec3 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3(&self) -> crate::Vec3 {
+    pub fn as_vec3(self) -> crate::Vec3 {
         crate::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3a(&self) -> crate::Vec3A {
+    pub fn as_vec3a(self) -> crate::Vec3A {
         crate::Vec3A::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -135,7 +135,7 @@ impl I64Vec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i64; 4] {
+    pub const fn to_array(self) -> [i64; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -578,70 +578,70 @@ impl I64Vec4 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(self) -> crate::Vec4 {
         crate::Vec4::new(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -107,7 +107,7 @@ impl I8Vec2 {
     /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i8; 2] {
+    pub const fn to_array(self) -> [i8; 2] {
         [self.x, self.y]
     }
 
@@ -485,70 +485,70 @@ impl I8Vec2 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec2(&self) -> crate::Vec2 {
+    pub fn as_vec2(self) -> crate::Vec2 {
         crate::Vec2::new(self.x as f32, self.y as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec2(&self) -> crate::DVec2 {
+    pub fn as_dvec2(self) -> crate::DVec2 {
         crate::DVec2::new(self.x as f64, self.y as f64)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec2(&self) -> crate::U8Vec2 {
+    pub fn as_u8vec2(self) -> crate::U8Vec2 {
         crate::U8Vec2::new(self.x as u8, self.y as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec2(&self) -> crate::I16Vec2 {
+    pub fn as_i16vec2(self) -> crate::I16Vec2 {
         crate::I16Vec2::new(self.x as i16, self.y as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec2(&self) -> crate::U16Vec2 {
+    pub fn as_u16vec2(self) -> crate::U16Vec2 {
         crate::U16Vec2::new(self.x as u16, self.y as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec2(&self) -> crate::IVec2 {
+    pub fn as_ivec2(self) -> crate::IVec2 {
         crate::IVec2::new(self.x as i32, self.y as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec2(&self) -> crate::UVec2 {
+    pub fn as_uvec2(self) -> crate::UVec2 {
         crate::UVec2::new(self.x as u32, self.y as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec2(&self) -> crate::I64Vec2 {
+    pub fn as_i64vec2(self) -> crate::I64Vec2 {
         crate::I64Vec2::new(self.x as i64, self.y as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec2(&self) -> crate::U64Vec2 {
+    pub fn as_u64vec2(self) -> crate::U64Vec2 {
         crate::U64Vec2::new(self.x as u64, self.y as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec2(&self) -> crate::USizeVec2 {
+    pub fn as_usizevec2(self) -> crate::USizeVec2 {
         crate::USizeVec2::new(self.x as usize, self.y as usize)
     }
 

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -117,7 +117,7 @@ impl I8Vec3 {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i8; 3] {
+    pub const fn to_array(self) -> [i8; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -532,77 +532,77 @@ impl I8Vec3 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3(&self) -> crate::Vec3 {
+    pub fn as_vec3(self) -> crate::Vec3 {
         crate::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3a(&self) -> crate::Vec3A {
+    pub fn as_vec3a(self) -> crate::Vec3A {
         crate::Vec3A::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -135,7 +135,7 @@ impl I8Vec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [i8; 4] {
+    pub const fn to_array(self) -> [i8; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -578,70 +578,70 @@ impl I8Vec4 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(self) -> crate::Vec4 {
         crate::Vec4::new(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -98,7 +98,7 @@ impl U16Vec2 {
     /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u16; 2] {
+    pub const fn to_array(self) -> [u16; 2] {
         [self.x, self.y]
     }
 
@@ -377,70 +377,70 @@ impl U16Vec2 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec2(&self) -> crate::Vec2 {
+    pub fn as_vec2(self) -> crate::Vec2 {
         crate::Vec2::new(self.x as f32, self.y as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec2(&self) -> crate::DVec2 {
+    pub fn as_dvec2(self) -> crate::DVec2 {
         crate::DVec2::new(self.x as f64, self.y as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec2(&self) -> crate::I8Vec2 {
+    pub fn as_i8vec2(self) -> crate::I8Vec2 {
         crate::I8Vec2::new(self.x as i8, self.y as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec2(&self) -> crate::U8Vec2 {
+    pub fn as_u8vec2(self) -> crate::U8Vec2 {
         crate::U8Vec2::new(self.x as u8, self.y as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec2(&self) -> crate::I16Vec2 {
+    pub fn as_i16vec2(self) -> crate::I16Vec2 {
         crate::I16Vec2::new(self.x as i16, self.y as i16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec2(&self) -> crate::IVec2 {
+    pub fn as_ivec2(self) -> crate::IVec2 {
         crate::IVec2::new(self.x as i32, self.y as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec2(&self) -> crate::UVec2 {
+    pub fn as_uvec2(self) -> crate::UVec2 {
         crate::UVec2::new(self.x as u32, self.y as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec2(&self) -> crate::I64Vec2 {
+    pub fn as_i64vec2(self) -> crate::I64Vec2 {
         crate::I64Vec2::new(self.x as i64, self.y as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec2(&self) -> crate::U64Vec2 {
+    pub fn as_u64vec2(self) -> crate::U64Vec2 {
         crate::U64Vec2::new(self.x as u64, self.y as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec2(&self) -> crate::USizeVec2 {
+    pub fn as_usizevec2(self) -> crate::USizeVec2 {
         crate::USizeVec2::new(self.x as usize, self.y as usize)
     }
 

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -105,7 +105,7 @@ impl U16Vec3 {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u16; 3] {
+    pub const fn to_array(self) -> [u16; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -442,77 +442,77 @@ impl U16Vec3 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3(&self) -> crate::Vec3 {
+    pub fn as_vec3(self) -> crate::Vec3 {
         crate::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3a(&self) -> crate::Vec3A {
+    pub fn as_vec3a(self) -> crate::Vec3A {
         crate::Vec3A::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -120,7 +120,7 @@ impl U16Vec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u16; 4] {
+    pub const fn to_array(self) -> [u16; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -480,70 +480,70 @@ impl U16Vec4 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(self) -> crate::Vec4 {
         crate::Vec4::new(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -98,7 +98,7 @@ impl UVec2 {
     /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u32; 2] {
+    pub const fn to_array(self) -> [u32; 2] {
         [self.x, self.y]
     }
 
@@ -377,70 +377,70 @@ impl UVec2 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec2(&self) -> crate::Vec2 {
+    pub fn as_vec2(self) -> crate::Vec2 {
         crate::Vec2::new(self.x as f32, self.y as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec2(&self) -> crate::DVec2 {
+    pub fn as_dvec2(self) -> crate::DVec2 {
         crate::DVec2::new(self.x as f64, self.y as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec2(&self) -> crate::I8Vec2 {
+    pub fn as_i8vec2(self) -> crate::I8Vec2 {
         crate::I8Vec2::new(self.x as i8, self.y as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec2(&self) -> crate::U8Vec2 {
+    pub fn as_u8vec2(self) -> crate::U8Vec2 {
         crate::U8Vec2::new(self.x as u8, self.y as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec2(&self) -> crate::I16Vec2 {
+    pub fn as_i16vec2(self) -> crate::I16Vec2 {
         crate::I16Vec2::new(self.x as i16, self.y as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec2(&self) -> crate::U16Vec2 {
+    pub fn as_u16vec2(self) -> crate::U16Vec2 {
         crate::U16Vec2::new(self.x as u16, self.y as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec2(&self) -> crate::IVec2 {
+    pub fn as_ivec2(self) -> crate::IVec2 {
         crate::IVec2::new(self.x as i32, self.y as i32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec2(&self) -> crate::I64Vec2 {
+    pub fn as_i64vec2(self) -> crate::I64Vec2 {
         crate::I64Vec2::new(self.x as i64, self.y as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec2(&self) -> crate::U64Vec2 {
+    pub fn as_u64vec2(self) -> crate::U64Vec2 {
         crate::U64Vec2::new(self.x as u64, self.y as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec2(&self) -> crate::USizeVec2 {
+    pub fn as_usizevec2(self) -> crate::USizeVec2 {
         crate::USizeVec2::new(self.x as usize, self.y as usize)
     }
 

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -105,7 +105,7 @@ impl UVec3 {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u32; 3] {
+    pub const fn to_array(self) -> [u32; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -442,77 +442,77 @@ impl UVec3 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3(&self) -> crate::Vec3 {
+    pub fn as_vec3(self) -> crate::Vec3 {
         crate::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3a(&self) -> crate::Vec3A {
+    pub fn as_vec3a(self) -> crate::Vec3A {
         crate::Vec3A::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -120,7 +120,7 @@ impl UVec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u32; 4] {
+    pub const fn to_array(self) -> [u32; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -480,70 +480,70 @@ impl UVec4 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(self) -> crate::Vec4 {
         crate::Vec4::new(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -98,7 +98,7 @@ impl U64Vec2 {
     /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u64; 2] {
+    pub const fn to_array(self) -> [u64; 2] {
         [self.x, self.y]
     }
 
@@ -377,70 +377,70 @@ impl U64Vec2 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec2(&self) -> crate::Vec2 {
+    pub fn as_vec2(self) -> crate::Vec2 {
         crate::Vec2::new(self.x as f32, self.y as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec2(&self) -> crate::DVec2 {
+    pub fn as_dvec2(self) -> crate::DVec2 {
         crate::DVec2::new(self.x as f64, self.y as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec2(&self) -> crate::I8Vec2 {
+    pub fn as_i8vec2(self) -> crate::I8Vec2 {
         crate::I8Vec2::new(self.x as i8, self.y as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec2(&self) -> crate::U8Vec2 {
+    pub fn as_u8vec2(self) -> crate::U8Vec2 {
         crate::U8Vec2::new(self.x as u8, self.y as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec2(&self) -> crate::I16Vec2 {
+    pub fn as_i16vec2(self) -> crate::I16Vec2 {
         crate::I16Vec2::new(self.x as i16, self.y as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec2(&self) -> crate::U16Vec2 {
+    pub fn as_u16vec2(self) -> crate::U16Vec2 {
         crate::U16Vec2::new(self.x as u16, self.y as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec2(&self) -> crate::IVec2 {
+    pub fn as_ivec2(self) -> crate::IVec2 {
         crate::IVec2::new(self.x as i32, self.y as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec2(&self) -> crate::UVec2 {
+    pub fn as_uvec2(self) -> crate::UVec2 {
         crate::UVec2::new(self.x as u32, self.y as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec2(&self) -> crate::I64Vec2 {
+    pub fn as_i64vec2(self) -> crate::I64Vec2 {
         crate::I64Vec2::new(self.x as i64, self.y as i64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec2(&self) -> crate::USizeVec2 {
+    pub fn as_usizevec2(self) -> crate::USizeVec2 {
         crate::USizeVec2::new(self.x as usize, self.y as usize)
     }
 

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -105,7 +105,7 @@ impl U64Vec3 {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u64; 3] {
+    pub const fn to_array(self) -> [u64; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -442,77 +442,77 @@ impl U64Vec3 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3(&self) -> crate::Vec3 {
+    pub fn as_vec3(self) -> crate::Vec3 {
         crate::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3a(&self) -> crate::Vec3A {
+    pub fn as_vec3a(self) -> crate::Vec3A {
         crate::Vec3A::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -120,7 +120,7 @@ impl U64Vec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u64; 4] {
+    pub const fn to_array(self) -> [u64; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -480,70 +480,70 @@ impl U64Vec4 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(self) -> crate::Vec4 {
         crate::Vec4::new(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -98,7 +98,7 @@ impl U8Vec2 {
     /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u8; 2] {
+    pub const fn to_array(self) -> [u8; 2] {
         [self.x, self.y]
     }
 
@@ -377,70 +377,70 @@ impl U8Vec2 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec2(&self) -> crate::Vec2 {
+    pub fn as_vec2(self) -> crate::Vec2 {
         crate::Vec2::new(self.x as f32, self.y as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec2(&self) -> crate::DVec2 {
+    pub fn as_dvec2(self) -> crate::DVec2 {
         crate::DVec2::new(self.x as f64, self.y as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec2(&self) -> crate::I8Vec2 {
+    pub fn as_i8vec2(self) -> crate::I8Vec2 {
         crate::I8Vec2::new(self.x as i8, self.y as i8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec2(&self) -> crate::I16Vec2 {
+    pub fn as_i16vec2(self) -> crate::I16Vec2 {
         crate::I16Vec2::new(self.x as i16, self.y as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec2(&self) -> crate::U16Vec2 {
+    pub fn as_u16vec2(self) -> crate::U16Vec2 {
         crate::U16Vec2::new(self.x as u16, self.y as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec2(&self) -> crate::IVec2 {
+    pub fn as_ivec2(self) -> crate::IVec2 {
         crate::IVec2::new(self.x as i32, self.y as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec2(&self) -> crate::UVec2 {
+    pub fn as_uvec2(self) -> crate::UVec2 {
         crate::UVec2::new(self.x as u32, self.y as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec2(&self) -> crate::I64Vec2 {
+    pub fn as_i64vec2(self) -> crate::I64Vec2 {
         crate::I64Vec2::new(self.x as i64, self.y as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec2(&self) -> crate::U64Vec2 {
+    pub fn as_u64vec2(self) -> crate::U64Vec2 {
         crate::U64Vec2::new(self.x as u64, self.y as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec2(&self) -> crate::USizeVec2 {
+    pub fn as_usizevec2(self) -> crate::USizeVec2 {
         crate::USizeVec2::new(self.x as usize, self.y as usize)
     }
 

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -105,7 +105,7 @@ impl U8Vec3 {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u8; 3] {
+    pub const fn to_array(self) -> [u8; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -442,77 +442,77 @@ impl U8Vec3 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3(&self) -> crate::Vec3 {
+    pub fn as_vec3(self) -> crate::Vec3 {
         crate::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3a(&self) -> crate::Vec3A {
+    pub fn as_vec3a(self) -> crate::Vec3A {
         crate::Vec3A::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
 

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -120,7 +120,7 @@ impl U8Vec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [u8; 4] {
+    pub const fn to_array(self) -> [u8; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -480,70 +480,70 @@ impl U8Vec4 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(self) -> crate::Vec4 {
         crate::Vec4::new(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(
             self.x as usize,
             self.y as usize,

--- a/src/usize/usizevec2.rs
+++ b/src/usize/usizevec2.rs
@@ -98,7 +98,7 @@ impl USizeVec2 {
     /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [usize; 2] {
+    pub const fn to_array(self) -> [usize; 2] {
         [self.x, self.y]
     }
 
@@ -377,70 +377,70 @@ impl USizeVec2 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec2(&self) -> crate::Vec2 {
+    pub fn as_vec2(self) -> crate::Vec2 {
         crate::Vec2::new(self.x as f32, self.y as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec2(&self) -> crate::DVec2 {
+    pub fn as_dvec2(self) -> crate::DVec2 {
         crate::DVec2::new(self.x as f64, self.y as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec2(&self) -> crate::I8Vec2 {
+    pub fn as_i8vec2(self) -> crate::I8Vec2 {
         crate::I8Vec2::new(self.x as i8, self.y as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec2(&self) -> crate::U8Vec2 {
+    pub fn as_u8vec2(self) -> crate::U8Vec2 {
         crate::U8Vec2::new(self.x as u8, self.y as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec2(&self) -> crate::I16Vec2 {
+    pub fn as_i16vec2(self) -> crate::I16Vec2 {
         crate::I16Vec2::new(self.x as i16, self.y as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec2(&self) -> crate::U16Vec2 {
+    pub fn as_u16vec2(self) -> crate::U16Vec2 {
         crate::U16Vec2::new(self.x as u16, self.y as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec2(&self) -> crate::IVec2 {
+    pub fn as_ivec2(self) -> crate::IVec2 {
         crate::IVec2::new(self.x as i32, self.y as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec2(&self) -> crate::UVec2 {
+    pub fn as_uvec2(self) -> crate::UVec2 {
         crate::UVec2::new(self.x as u32, self.y as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec2(&self) -> crate::I64Vec2 {
+    pub fn as_i64vec2(self) -> crate::I64Vec2 {
         crate::I64Vec2::new(self.x as i64, self.y as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec2(&self) -> crate::U64Vec2 {
+    pub fn as_u64vec2(self) -> crate::U64Vec2 {
         crate::U64Vec2::new(self.x as u64, self.y as u64)
     }
 

--- a/src/usize/usizevec3.rs
+++ b/src/usize/usizevec3.rs
@@ -105,7 +105,7 @@ impl USizeVec3 {
     /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [usize; 3] {
+    pub const fn to_array(self) -> [usize; 3] {
         [self.x, self.y, self.z]
     }
 
@@ -442,77 +442,77 @@ impl USizeVec3 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3(&self) -> crate::Vec3 {
+    pub fn as_vec3(self) -> crate::Vec3 {
         crate::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3a(&self) -> crate::Vec3A {
+    pub fn as_vec3a(self) -> crate::Vec3A {
         crate::Vec3A::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
 

--- a/src/usize/usizevec4.rs
+++ b/src/usize/usizevec4.rs
@@ -120,7 +120,7 @@ impl USizeVec4 {
     /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [usize; 4] {
+    pub const fn to_array(self) -> [usize; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -480,70 +480,70 @@ impl USizeVec4 {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(self) -> crate::Vec4 {
         crate::Vec4::new(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
     }
 
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
 
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
 
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
 
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
 
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
 
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
 
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
 
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
 
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
 

--- a/templates/affine.rs.tera
+++ b/templates/affine.rs.tera
@@ -203,7 +203,7 @@ impl {{ self_t }} {
     ///
     /// Panics if `slice` is less than {{ size }} elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [{{ scalar_t }}]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [{{ scalar_t }}]) {
         self.matrix{{ dim }}.write_cols_to_slice(&mut slice[0..{{ dim * dim }}]);
         self.translation.write_to_slice(&mut slice[{{ dim * dim }}..{{ size }}]);
     }
@@ -334,7 +334,7 @@ impl {{ self_t }} {
     /// vector contains any zero elements when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn to_scale_angle_translation(self) -> ({{ vec2_t }}, {{ scalar_t }}, {{ vec2_t }}) {
+    pub fn to_scale_angle_translation(&self) -> ({{ vec2_t }}, {{ scalar_t }}, {{ vec2_t }}) {
         use crate::{{ scalar_t }}::math;
         let det = self.matrix2.determinant();
         glam_assert!(det != 0.0);

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -1011,7 +1011,7 @@ impl {{ self_t }} {
     ///
     /// Panics if `slice` is less than {{ size }} elements long.
     #[inline]
-    pub fn write_cols_to_slice(self, slice: &mut [{{ scalar_t }}]) {
+    pub fn write_cols_to_slice(&self, slice: &mut [{{ scalar_t }}]) {
         {% for i in range(end = dim) %}
             {%- for j in range(end = dim) %}
                 slice[{{ i * dim + j }}] = self.{{ axes[i] }}.{{ components[j] }};

--- a/templates/quat.rs.tera
+++ b/templates/quat.rs.tera
@@ -618,7 +618,7 @@ impl {{ self_t }} {
     /// `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(&self) -> [{{ scalar_t }}; 4] {
+    pub fn to_array(self) -> [{{ scalar_t }}; 4] {
         [self.x, self.y, self.z, self.w]
     }
 
@@ -792,7 +792,7 @@ impl {{ self_t }} {
     /// Will panic if `self` or `rhs` are not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn rotate_towards(&self, rhs: Self, max_angle: {{ scalar_t }}) -> Self {
+    pub fn rotate_towards(self, rhs: Self, max_angle: {{ scalar_t }}) -> Self {
         glam_assert!(self.is_normalized() && rhs.is_normalized());
         let angle = self.angle_between(rhs);
         if angle <= 1e-4 {

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -535,7 +535,7 @@ impl {{ self_t }} {
     /// Converts `self` to `[{{ components | join(sep=", ") }}]`
     #[inline]
     #[must_use]
-    pub const fn to_array(&self) -> [{{ scalar_t }}; {{ dim }}] {
+    pub const fn to_array(self) -> [{{ scalar_t }}; {{ dim }}] {
         {% if is_scalar %}
             [
                 {% for c in components %}
@@ -543,7 +543,7 @@ impl {{ self_t }} {
                 {% endfor %}
             ]
         {% else %}
-            unsafe { *(self as *const Self as *const [{{ scalar_t }}; {{ dim }}]) }
+            unsafe { *(&self as *const Self as *const [{{ scalar_t }}; {{ dim }}]) }
         {% endif %}
     }
 
@@ -2088,13 +2088,13 @@ impl {{ self_t }} {
     /// `self.distance(rhs)`, the result will be equal to `rhs`. Will not go past `rhs`.
     #[inline]
     #[must_use]
-    pub fn move_towards(&self, rhs: Self, d: {{ scalar_t }}) -> Self {
-        let a = rhs - *self;
+    pub fn move_towards(self, rhs: Self, d: {{ scalar_t }}) -> Self {
+        let a = rhs - self;
         let len = a.length();
         if len <= d || len <= 1e-4 {
             return rhs;
         }
-        *self + a / len * d 
+        self + a / len * d 
     }
 
     /// Calculates the midpoint between `self` and `rhs`. 
@@ -2325,7 +2325,7 @@ impl {{ self_t }} {
     /// [`Self::any_orthonormal_vector()`] instead.
     #[inline]
     #[must_use]
-    pub fn any_orthogonal_vector(&self) -> Self {
+    pub fn any_orthogonal_vector(self) -> Self {
         // This can probably be optimized
         if math::abs(self.x) > math::abs(self.y) {
             Self::new(-self.z, 0.0, self.x) // self.cross(Self::Y)
@@ -2343,7 +2343,7 @@ impl {{ self_t }} {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_vector(&self) -> Self {
+    pub fn any_orthonormal_vector(self) -> Self {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -2360,7 +2360,7 @@ impl {{ self_t }} {
     /// Will panic if `self` is not normalized when `glam_assert` is enabled.
     #[inline]
     #[must_use]
-    pub fn any_orthonormal_pair(&self) -> (Self, Self) {
+    pub fn any_orthonormal_pair(self) -> (Self, Self) {
         glam_assert!(self.is_normalized());
         // From https://graphics.pixar.com/library/OrthonormalB/paper.pdf
         let sign = math::signum(self.z);
@@ -2515,12 +2515,12 @@ impl {{ self_t }} {
     /// rotates towards the exact opposite of `rhs`. Will not go past the target.
     #[inline]
     #[must_use]
-    pub fn rotate_towards(&self, rhs: Self, max_angle: {{ scalar_t }}) -> Self {
+    pub fn rotate_towards(self, rhs: Self, max_angle: {{ scalar_t }}) -> Self {
         let a = self.angle_to(rhs);
         let abs_a = math::abs(a);
         // When `max_angle < 0`, rotate no further than `PI` radians away
         let angle = max_angle.clamp(abs_a - core::{{ scalar_t }}::consts::PI, abs_a) * math::signum(a);
-        Self::from_angle(angle).rotate(*self)
+        Self::from_angle(angle).rotate(self)
     }
 {% endif %}
 
@@ -2529,28 +2529,28 @@ impl {{ self_t }} {
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec2(&self) -> crate::Vec2 {
+    pub fn as_vec2(self) -> crate::Vec2 {
         crate::Vec2::new(self.x as f32, self.y as f32)
     }
     {% elif dim == 3 %}
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3(&self) -> crate::Vec3 {
+    pub fn as_vec3(self) -> crate::Vec3 {
         crate::Vec3::new(self.x as f32, self.y as f32, self.z as f32)
     }
 
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec3a(&self) -> crate::Vec3A {
+    pub fn as_vec3a(self) -> crate::Vec3A {
         crate::Vec3A::new(self.x as f32, self.y as f32, self.z as f32)
     }
     {% elif dim == 4 %}
     /// Casts all elements of `self` to `f32`.
     #[inline]
     #[must_use]
-    pub fn as_vec4(&self) -> crate::Vec4 {
+    pub fn as_vec4(self) -> crate::Vec4 {
         crate::Vec4::new(self.x as f32, self.y as f32, self.z as f32, self.w as f32)
     }
     {% endif %}
@@ -2560,21 +2560,21 @@ impl {{ self_t }} {
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec2(&self) -> crate::DVec2 {
+    pub fn as_dvec2(self) -> crate::DVec2 {
         crate::DVec2::new(self.x as f64, self.y as f64)
     }
     {% elif dim == 3 %}
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec3(&self) -> crate::DVec3 {
+    pub fn as_dvec3(self) -> crate::DVec3 {
         crate::DVec3::new(self.x as f64, self.y as f64, self.z as f64)
     }
     {% elif dim == 4 %}
     /// Casts all elements of `self` to `f64`.
     #[inline]
     #[must_use]
-    pub fn as_dvec4(&self) -> crate::DVec4 {
+    pub fn as_dvec4(self) -> crate::DVec4 {
         crate::DVec4::new(self.x as f64, self.y as f64, self.z as f64, self.w as f64)
     }
     {% endif %}
@@ -2584,21 +2584,21 @@ impl {{ self_t }} {
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec2(&self) -> crate::I8Vec2 {
+    pub fn as_i8vec2(self) -> crate::I8Vec2 {
         crate::I8Vec2::new(self.x as i8, self.y as i8)
     }
     {% elif dim == 3 %}
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec3(&self) -> crate::I8Vec3 {
+    pub fn as_i8vec3(self) -> crate::I8Vec3 {
         crate::I8Vec3::new(self.x as i8, self.y as i8, self.z as i8)
     }
     {% elif dim == 4 %}
     /// Casts all elements of `self` to `i8`.
     #[inline]
     #[must_use]
-    pub fn as_i8vec4(&self) -> crate::I8Vec4 {
+    pub fn as_i8vec4(self) -> crate::I8Vec4 {
         crate::I8Vec4::new(self.x as i8, self.y as i8, self.z as i8, self.w as i8)
     }
     {% endif %}
@@ -2608,21 +2608,21 @@ impl {{ self_t }} {
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec2(&self) -> crate::U8Vec2 {
+    pub fn as_u8vec2(self) -> crate::U8Vec2 {
         crate::U8Vec2::new(self.x as u8, self.y as u8)
     }
     {% elif dim == 3 %}
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec3(&self) -> crate::U8Vec3 {
+    pub fn as_u8vec3(self) -> crate::U8Vec3 {
         crate::U8Vec3::new(self.x as u8, self.y as u8, self.z as u8)
     }
     {% elif dim == 4 %}
     /// Casts all elements of `self` to `u8`.
     #[inline]
     #[must_use]
-    pub fn as_u8vec4(&self) -> crate::U8Vec4 {
+    pub fn as_u8vec4(self) -> crate::U8Vec4 {
         crate::U8Vec4::new(self.x as u8, self.y as u8, self.z as u8, self.w as u8)
     }
     {% endif %}
@@ -2632,21 +2632,21 @@ impl {{ self_t }} {
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec2(&self) -> crate::I16Vec2 {
+    pub fn as_i16vec2(self) -> crate::I16Vec2 {
         crate::I16Vec2::new(self.x as i16, self.y as i16)
     }
     {% elif dim == 3 %}
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec3(&self) -> crate::I16Vec3 {
+    pub fn as_i16vec3(self) -> crate::I16Vec3 {
         crate::I16Vec3::new(self.x as i16, self.y as i16, self.z as i16)
     }
     {% elif dim == 4 %}
     /// Casts all elements of `self` to `i16`.
     #[inline]
     #[must_use]
-    pub fn as_i16vec4(&self) -> crate::I16Vec4 {
+    pub fn as_i16vec4(self) -> crate::I16Vec4 {
         crate::I16Vec4::new(self.x as i16, self.y as i16, self.z as i16, self.w as i16)
     }
     {% endif %}
@@ -2656,21 +2656,21 @@ impl {{ self_t }} {
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec2(&self) -> crate::U16Vec2 {
+    pub fn as_u16vec2(self) -> crate::U16Vec2 {
         crate::U16Vec2::new(self.x as u16, self.y as u16)
     }
     {% elif dim == 3 %}
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec3(&self) -> crate::U16Vec3 {
+    pub fn as_u16vec3(self) -> crate::U16Vec3 {
         crate::U16Vec3::new(self.x as u16, self.y as u16, self.z as u16)
     }
     {% elif dim == 4 %}
     /// Casts all elements of `self` to `u16`.
     #[inline]
     #[must_use]
-    pub fn as_u16vec4(&self) -> crate::U16Vec4 {
+    pub fn as_u16vec4(self) -> crate::U16Vec4 {
         crate::U16Vec4::new(self.x as u16, self.y as u16, self.z as u16, self.w as u16)
     }
     {% endif %}
@@ -2680,21 +2680,21 @@ impl {{ self_t }} {
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec2(&self) -> crate::IVec2 {
+    pub fn as_ivec2(self) -> crate::IVec2 {
         crate::IVec2::new(self.x as i32, self.y as i32)
     }
     {% elif dim == 3 %}
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec3(&self) -> crate::IVec3 {
+    pub fn as_ivec3(self) -> crate::IVec3 {
         crate::IVec3::new(self.x as i32, self.y as i32, self.z as i32)
     }
     {% elif dim == 4 %}
     /// Casts all elements of `self` to `i32`.
     #[inline]
     #[must_use]
-    pub fn as_ivec4(&self) -> crate::IVec4 {
+    pub fn as_ivec4(self) -> crate::IVec4 {
         crate::IVec4::new(self.x as i32, self.y as i32, self.z as i32, self.w as i32)
     }
     {% endif %}
@@ -2704,21 +2704,21 @@ impl {{ self_t }} {
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec2(&self) -> crate::UVec2 {
+    pub fn as_uvec2(self) -> crate::UVec2 {
         crate::UVec2::new(self.x as u32, self.y as u32)
     }
     {% elif dim == 3 %}
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec3(&self) -> crate::UVec3 {
+    pub fn as_uvec3(self) -> crate::UVec3 {
         crate::UVec3::new(self.x as u32, self.y as u32, self.z as u32)
     }
     {% elif dim == 4 %}
     /// Casts all elements of `self` to `u32`.
     #[inline]
     #[must_use]
-    pub fn as_uvec4(&self) -> crate::UVec4 {
+    pub fn as_uvec4(self) -> crate::UVec4 {
         crate::UVec4::new(self.x as u32, self.y as u32, self.z as u32, self.w as u32)
     }
     {% endif %}
@@ -2728,21 +2728,21 @@ impl {{ self_t }} {
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec2(&self) -> crate::I64Vec2 {
+    pub fn as_i64vec2(self) -> crate::I64Vec2 {
         crate::I64Vec2::new(self.x as i64, self.y as i64)
     }
     {% elif dim == 3 %}
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec3(&self) -> crate::I64Vec3 {
+    pub fn as_i64vec3(self) -> crate::I64Vec3 {
         crate::I64Vec3::new(self.x as i64, self.y as i64, self.z as i64)
     }
     {% elif dim == 4 %}
     /// Casts all elements of `self` to `i64`.
     #[inline]
     #[must_use]
-    pub fn as_i64vec4(&self) -> crate::I64Vec4 {
+    pub fn as_i64vec4(self) -> crate::I64Vec4 {
         crate::I64Vec4::new(self.x as i64, self.y as i64, self.z as i64, self.w as i64)
     }
     {% endif %}
@@ -2752,21 +2752,21 @@ impl {{ self_t }} {
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec2(&self) -> crate::U64Vec2 {
+    pub fn as_u64vec2(self) -> crate::U64Vec2 {
         crate::U64Vec2::new(self.x as u64, self.y as u64)
     }
     {% elif dim == 3 %}
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec3(&self) -> crate::U64Vec3 {
+    pub fn as_u64vec3(self) -> crate::U64Vec3 {
         crate::U64Vec3::new(self.x as u64, self.y as u64, self.z as u64)
     }
     {% elif dim == 4 %}
     /// Casts all elements of `self` to `u64`.
     #[inline]
     #[must_use]
-    pub fn as_u64vec4(&self) -> crate::U64Vec4 {
+    pub fn as_u64vec4(self) -> crate::U64Vec4 {
         crate::U64Vec4::new(self.x as u64, self.y as u64, self.z as u64, self.w as u64)
     }
     {% endif %}
@@ -2776,21 +2776,21 @@ impl {{ self_t }} {
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec2(&self) -> crate::USizeVec2 {
+    pub fn as_usizevec2(self) -> crate::USizeVec2 {
         crate::USizeVec2::new(self.x as usize, self.y as usize)
     }
     {% elif dim == 3 %}
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec3(&self) -> crate::USizeVec3 {
+    pub fn as_usizevec3(self) -> crate::USizeVec3 {
         crate::USizeVec3::new(self.x as usize, self.y as usize, self.z as usize)
     }
     {% elif dim == 4 %}
     /// Casts all elements of `self` to `usize`.
     #[inline]
     #[must_use]
-    pub fn as_usizevec4(&self) -> crate::USizeVec4 {
+    pub fn as_usizevec4(self) -> crate::USizeVec4 {
         crate::USizeVec4::new(self.x as usize, self.y as usize, self.z as usize, self.w as usize)
     }
     {% endif %}

--- a/templates/vec_mask.rs.tera
+++ b/templates/vec_mask.rs.tera
@@ -280,7 +280,7 @@ impl {{ self_t }} {
     /// Panics if `index` is greater than {{ dim  - 1 }}.
     #[inline]
     #[must_use]
-    pub fn test(&self, index: usize) -> bool {
+    pub fn test(self, index: usize) -> bool {
         {% if is_coresimd %}
             assert!(index < {{ dim }}, "index out of bounds");
             self.0.test(index)


### PR DESCRIPTION
# Objective

- Consistency pass on the use of self and &self in methods
- Mostly glam uses self for vector and quat methods and &self for matrix and affine types
- Fixes #646
