### PR TITLE
Specify that cross product is right handed in docs

### DIFF
--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -222,7 +222,7 @@ impl Vec3A {
         Self(dot3_into_f32x4(self.0, rhs.0))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -228,7 +228,7 @@ impl Vec3A {
         Self(unsafe { dot3_into_f32x4(self.0, rhs.0) })
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -233,7 +233,7 @@ impl Vec3A {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -235,7 +235,7 @@ impl Vec3A {
         Self(unsafe { dot3_into_m128(self.0, rhs.0) })
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -223,7 +223,7 @@ impl Vec3 {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -221,7 +221,7 @@ impl Vec3A {
         Self(dot3_into_v128(self.0, rhs.0))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -223,7 +223,7 @@ impl DVec3 {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -207,7 +207,7 @@ impl I16Vec3 {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -207,7 +207,7 @@ impl IVec3 {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -207,7 +207,7 @@ impl I64Vec3 {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -207,7 +207,7 @@ impl I8Vec3 {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -195,7 +195,7 @@ impl U16Vec3 {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -195,7 +195,7 @@ impl UVec3 {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -195,7 +195,7 @@ impl U64Vec3 {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -195,7 +195,7 @@ impl U8Vec3 {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/src/usize/usizevec3.rs
+++ b/src/usize/usizevec3.rs
@@ -195,7 +195,7 @@ impl USizeVec3 {
         Self::splat(self.dot(rhs))
     }
 
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -703,7 +703,7 @@ impl {{ self_t }} {
     }
 
 {% if dim == 3 %}
-    /// Computes the cross product of `self` and `rhs`.
+    /// Computes the right-handed cross product of `self` and `rhs`.
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {


### PR DESCRIPTION
# Objective

- Another part of #659 

## Solution

- Just document that its right-handed. I think cross product is probably used too often with the implicit right-handedness to bother specifying it as cross_rh. We should still point this out though.

## Code generation

- yar

## Testing and linting

- its docs

## Breaking changes

- its docs