### PR TITLE
Don't use bytemuck derive on spirv.

### DIFF
--- a/src/f32/affine2.rs
+++ b/src/f32/affine2.rs
@@ -6,11 +6,18 @@ use core::ops::{Deref, DerefMut, Mul, MulAssign};
 /// A 2D affine transform, which can represent translation, rotation, scaling and shear.
 #[derive(Copy, Clone)]
 #[cfg_attr(
-    all(feature = "bytemuck", not(feature = "scalar-math")),
+    all(
+        feature = "bytemuck",
+        not(any(feature = "scalar-math", target_arch = "spirv"))
+    ),
     derive(bytemuck::AnyBitPattern)
 )]
 #[cfg_attr(
-    all(feature = "bytemuck", feature = "scalar-math"),
+    all(
+        feature = "bytemuck",
+        feature = "scalar-math",
+        not(target_arch = "spirv")
+    ),
     derive(bytemuck::Pod, bytemuck::Zeroable)
 )]
 #[repr(C)]

--- a/src/f32/affine3a.rs
+++ b/src/f32/affine3a.rs
@@ -7,7 +7,10 @@ use core::ops::{Deref, DerefMut, Mul, MulAssign};
 ///
 /// This type is 16 byte aligned.
 #[derive(Copy, Clone)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::AnyBitPattern)
+)]
 #[repr(C)]
 pub struct Affine3A {
     pub matrix3: Mat3A,

--- a/src/f32/coresimd/mat2.rs
+++ b/src/f32/coresimd/mat2.rs
@@ -20,7 +20,10 @@ pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Mat2(pub(crate) f32x4);
 

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -44,7 +44,10 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct Mat3A {
     pub x_axis: Vec3A,

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -50,7 +50,10 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// The resulting perspective project can be use to transform 3D vectors as points with
 /// perspective correction using the [`Self::project_point3()`] convenience method.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct Mat4 {
     pub x_axis: Vec4,

--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -35,7 +35,10 @@ pub const fn quat(x: f32, y: f32, z: f32, w: f32) -> Quat {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Quat(pub(crate) f32x4);
 

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -26,7 +26,10 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Vec3A(pub(crate) f32x4);
 

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -22,7 +22,10 @@ pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Vec4(pub(crate) f32x4);
 

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -42,7 +42,10 @@ pub const fn mat3(x_axis: Vec3, y_axis: Vec3, z_axis: Vec3) -> Mat3 {
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct Mat3 {
     pub x_axis: Vec3,

--- a/src/f32/neon/mat2.rs
+++ b/src/f32/neon/mat2.rs
@@ -26,7 +26,10 @@ pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Mat2(pub(crate) float32x4_t);
 

--- a/src/f32/neon/mat3a.rs
+++ b/src/f32/neon/mat3a.rs
@@ -44,7 +44,10 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct Mat3A {
     pub x_axis: Vec3A,

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -50,7 +50,10 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// The resulting perspective project can be use to transform 3D vectors as points with
 /// perspective correction using the [`Self::project_point3()`] convenience method.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct Mat4 {
     pub x_axis: Vec4,

--- a/src/f32/neon/quat.rs
+++ b/src/f32/neon/quat.rs
@@ -41,7 +41,10 @@ pub const fn quat(x: f32, y: f32, z: f32, w: f32) -> Quat {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Quat(pub(crate) float32x4_t);
 

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -31,7 +31,10 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Vec3A(pub(crate) float32x4_t);
 

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -27,7 +27,10 @@ pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Vec4(pub(crate) float32x4_t);
 

--- a/src/f32/scalar/mat2.rs
+++ b/src/f32/scalar/mat2.rs
@@ -14,7 +14,10 @@ pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
 
 /// A 2x2 column major matrix.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(
     not(any(feature = "scalar-math", target_arch = "spirv")),
     repr(align(16))

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -42,7 +42,10 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::AnyBitPattern)
+)]
 #[repr(C)]
 pub struct Mat3A {
     pub x_axis: Vec3A,

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -47,7 +47,10 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// The resulting perspective project can be use to transform 3D vectors as points with
 /// perspective correction using the [`Self::project_point3()`] convenience method.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(
     any(
         not(any(feature = "scalar-math", target_arch = "spirv")),

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -26,7 +26,10 @@ pub const fn quat(x: f32, y: f32, z: f32, w: f32) -> Quat {
 /// floating point "error creep" which can occur when successive quaternion
 /// operations are applied.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(
     not(any(feature = "scalar-math", target_arch = "spirv")),
     repr(align(16))

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -23,7 +23,10 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::AnyBitPattern)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -20,7 +20,10 @@ pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {
 
 /// A 4-dimensional vector.
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(
     any(
         not(any(feature = "scalar-math", target_arch = "spirv")),

--- a/src/f32/sse2/mat2.rs
+++ b/src/f32/sse2/mat2.rs
@@ -29,7 +29,10 @@ pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Mat2(pub(crate) __m128);
 

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -47,7 +47,10 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct Mat3A {
     pub x_axis: Vec3A,

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -53,7 +53,10 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// The resulting perspective project can be use to transform 3D vectors as points with
 /// perspective correction using the [`Self::project_point3()`] convenience method.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct Mat4 {
     pub x_axis: Vec4,

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -44,7 +44,10 @@ pub const fn quat(x: f32, y: f32, z: f32, w: f32) -> Quat {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Quat(pub(crate) __m128);
 

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -34,7 +34,10 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Vec3A(pub(crate) __m128);
 

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -30,7 +30,10 @@ pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Vec4(pub(crate) __m128);
 

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -15,7 +15,10 @@ pub const fn vec2(x: f32, y: f32) -> Vec2 {
 
 /// A 2-dimensional vector.
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -15,7 +15,10 @@ pub const fn vec3(x: f32, y: f32, z: f32) -> Vec3 {
 
 /// A 3-dimensional vector.
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct Vec3 {

--- a/src/f32/wasm32/mat2.rs
+++ b/src/f32/wasm32/mat2.rs
@@ -20,7 +20,10 @@ pub const fn mat2(x_axis: Vec2, y_axis: Vec2) -> Mat2 {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Mat2(pub(crate) v128);
 

--- a/src/f32/wasm32/mat3a.rs
+++ b/src/f32/wasm32/mat3a.rs
@@ -44,7 +44,10 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct Mat3A {
     pub x_axis: Vec3A,

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -50,7 +50,10 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// The resulting perspective project can be use to transform 3D vectors as points with
 /// perspective correction using the [`Self::project_point3()`] convenience method.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct Mat4 {
     pub x_axis: Vec4,

--- a/src/f32/wasm32/quat.rs
+++ b/src/f32/wasm32/quat.rs
@@ -35,7 +35,10 @@ pub const fn quat(x: f32, y: f32, z: f32, w: f32) -> Quat {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Quat(pub(crate) v128);
 

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -25,7 +25,10 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Vec3A(pub(crate) v128);
 

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -21,7 +21,10 @@ pub const fn vec4(x: f32, y: f32, z: f32, w: f32) -> Vec4 {
 ///
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(transparent)]
 pub struct Vec4(pub(crate) v128);
 

--- a/src/f64/daffine2.rs
+++ b/src/f64/daffine2.rs
@@ -5,7 +5,10 @@ use core::ops::{Deref, DerefMut, Mul, MulAssign};
 
 /// A 2D affine transform, which can represent translation, rotation, scaling and shear.
 #[derive(Copy, Clone)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct DAffine2 {
     pub matrix2: DMat2,

--- a/src/f64/daffine3.rs
+++ b/src/f64/daffine3.rs
@@ -5,7 +5,10 @@ use core::ops::{Deref, DerefMut, Mul, MulAssign};
 
 /// A 3D affine transform, which can represent translation, rotation, scaling and shear.
 #[derive(Copy, Clone)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct DAffine3 {
     pub matrix3: DMat3,

--- a/src/f64/dmat2.rs
+++ b/src/f64/dmat2.rs
@@ -14,7 +14,10 @@ pub const fn dmat2(x_axis: DVec2, y_axis: DVec2) -> DMat2 {
 
 /// A 2x2 column major matrix.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[repr(C)]
 pub struct DMat2 {

--- a/src/f64/dmat3.rs
+++ b/src/f64/dmat3.rs
@@ -42,7 +42,10 @@ pub const fn dmat3(x_axis: DVec3, y_axis: DVec3, z_axis: DVec3) -> DMat3 {
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[repr(C)]
 pub struct DMat3 {
     pub x_axis: DVec3,

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -47,7 +47,10 @@ pub const fn dmat4(x_axis: DVec4, y_axis: DVec4, z_axis: DVec4, w_axis: DVec4) -
 /// The resulting perspective project can be use to transform 3D vectors as points with
 /// perspective correction using the [`Self::project_point3()`] convenience method.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[repr(C)]
 pub struct DMat4 {

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -26,7 +26,10 @@ pub const fn dquat(x: f64, y: f64, z: f64, w: f64) -> DQuat {
 /// floating point "error creep" which can occur when successive quaternion
 /// operations are applied.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct DQuat {

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -15,7 +15,10 @@ pub const fn dvec2(x: f64, y: f64) -> DVec2 {
 
 /// A 2-dimensional vector.
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -15,7 +15,10 @@ pub const fn dvec3(x: f64, y: f64, z: f64) -> DVec3 {
 
 /// A 3-dimensional vector.
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct DVec3 {

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -17,7 +17,10 @@ pub const fn dvec4(x: f64, y: f64, z: f64, w: f64) -> DVec4 {
 
 /// A 4-dimensional vector.
 #[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/features/impl_bytemuck.rs
+++ b/src/features/impl_bytemuck.rs
@@ -1,3 +1,119 @@
+#[cfg(target_arch = "spirv")]
+mod spirv {
+    use crate::{
+        Affine2, Affine3A, DAffine2, DAffine3, DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4,
+        I16Vec2, I16Vec3, I16Vec4, I64Vec2, I64Vec3, I64Vec4, I8Vec2, I8Vec3, I8Vec4, IVec2, IVec3,
+        IVec4, Mat2, Mat3, Mat3A, Mat4, Quat, U16Vec2, U16Vec3, U16Vec4, U64Vec2, U64Vec3, U64Vec4,
+        U8Vec2, U8Vec3, U8Vec4, UVec2, UVec3, UVec4, Vec2, Vec3, Vec3A, Vec4,
+    };
+    use bytemuck::{AnyBitPattern, Pod, Zeroable};
+
+    // Affine2 contains internal padding due to Mat2 using SIMD
+    unsafe impl AnyBitPattern for Affine2 {}
+    unsafe impl Zeroable for Affine2 {}
+    unsafe impl AnyBitPattern for Affine3A {}
+    unsafe impl Zeroable for Affine3A {}
+
+    unsafe impl Pod for Mat2 {}
+    unsafe impl Zeroable for Mat2 {}
+    unsafe impl Pod for Mat3 {}
+    unsafe impl Zeroable for Mat3 {}
+    unsafe impl AnyBitPattern for Mat3A {}
+    unsafe impl Zeroable for Mat3A {}
+    unsafe impl Pod for Mat4 {}
+    unsafe impl Zeroable for Mat4 {}
+
+    unsafe impl Pod for Quat {}
+    unsafe impl Zeroable for Quat {}
+
+    unsafe impl Pod for Vec2 {}
+    unsafe impl Zeroable for Vec2 {}
+    unsafe impl Pod for Vec3 {}
+    unsafe impl Zeroable for Vec3 {}
+    unsafe impl AnyBitPattern for Vec3A {}
+    unsafe impl Zeroable for Vec3A {}
+    unsafe impl Pod for Vec4 {}
+    unsafe impl Zeroable for Vec4 {}
+
+    unsafe impl Pod for DAffine2 {}
+    unsafe impl Zeroable for DAffine2 {}
+    unsafe impl Pod for DAffine3 {}
+    unsafe impl Zeroable for DAffine3 {}
+
+    unsafe impl Pod for DMat2 {}
+    unsafe impl Zeroable for DMat2 {}
+    unsafe impl Pod for DMat3 {}
+    unsafe impl Zeroable for DMat3 {}
+    unsafe impl Pod for DMat4 {}
+    unsafe impl Zeroable for DMat4 {}
+
+    unsafe impl Pod for DQuat {}
+    unsafe impl Zeroable for DQuat {}
+
+    unsafe impl Pod for DVec2 {}
+    unsafe impl Zeroable for DVec2 {}
+    unsafe impl Pod for DVec3 {}
+    unsafe impl Zeroable for DVec3 {}
+    unsafe impl Pod for DVec4 {}
+    unsafe impl Zeroable for DVec4 {}
+
+    unsafe impl Pod for I8Vec2 {}
+    unsafe impl Zeroable for I8Vec2 {}
+    unsafe impl Pod for I8Vec3 {}
+    unsafe impl Zeroable for I8Vec3 {}
+    unsafe impl Pod for I8Vec4 {}
+    unsafe impl Zeroable for I8Vec4 {}
+
+    unsafe impl Pod for U8Vec2 {}
+    unsafe impl Zeroable for U8Vec2 {}
+    unsafe impl Pod for U8Vec3 {}
+    unsafe impl Zeroable for U8Vec3 {}
+    unsafe impl Pod for U8Vec4 {}
+    unsafe impl Zeroable for U8Vec4 {}
+
+    unsafe impl Pod for I16Vec2 {}
+    unsafe impl Zeroable for I16Vec2 {}
+    unsafe impl Pod for I16Vec3 {}
+    unsafe impl Zeroable for I16Vec3 {}
+    unsafe impl Pod for I16Vec4 {}
+    unsafe impl Zeroable for I16Vec4 {}
+
+    unsafe impl Pod for U16Vec2 {}
+    unsafe impl Zeroable for U16Vec2 {}
+    unsafe impl Pod for U16Vec3 {}
+    unsafe impl Zeroable for U16Vec3 {}
+    unsafe impl Pod for U16Vec4 {}
+    unsafe impl Zeroable for U16Vec4 {}
+
+    unsafe impl Pod for IVec2 {}
+    unsafe impl Zeroable for IVec2 {}
+    unsafe impl Pod for IVec3 {}
+    unsafe impl Zeroable for IVec3 {}
+    unsafe impl Pod for IVec4 {}
+    unsafe impl Zeroable for IVec4 {}
+
+    unsafe impl Pod for UVec2 {}
+    unsafe impl Zeroable for UVec2 {}
+    unsafe impl Pod for UVec3 {}
+    unsafe impl Zeroable for UVec3 {}
+    unsafe impl Pod for UVec4 {}
+    unsafe impl Zeroable for UVec4 {}
+
+    unsafe impl Pod for I64Vec2 {}
+    unsafe impl Zeroable for I64Vec2 {}
+    unsafe impl Pod for I64Vec3 {}
+    unsafe impl Zeroable for I64Vec3 {}
+    unsafe impl Pod for I64Vec4 {}
+    unsafe impl Zeroable for I64Vec4 {}
+
+    unsafe impl Pod for U64Vec2 {}
+    unsafe impl Zeroable for U64Vec2 {}
+    unsafe impl Pod for U64Vec3 {}
+    unsafe impl Zeroable for U64Vec3 {}
+    unsafe impl Pod for U64Vec4 {}
+    unsafe impl Zeroable for U64Vec4 {}
+}
+
 #[cfg(test)]
 mod test {
     use crate::{

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -16,7 +16,10 @@ pub const fn i16vec2(x: i16, y: i16) -> I16Vec2 {
 /// A 2-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(4)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -19,7 +19,10 @@ pub const fn i16vec3(x: i16, y: i16, z: i16) -> I16Vec3 {
 /// A 3-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct I16Vec3 {

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -20,7 +20,10 @@ pub const fn i16vec4(x: i16, y: i16, z: i16, w: i16) -> I16Vec4 {
 /// A 4-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -16,7 +16,10 @@ pub const fn ivec2(x: i32, y: i32) -> IVec2 {
 /// A 2-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -19,7 +19,10 @@ pub const fn ivec3(x: i32, y: i32, z: i32) -> IVec3 {
 /// A 3-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct IVec3 {

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -20,7 +20,10 @@ pub const fn ivec4(x: i32, y: i32, z: i32, w: i32) -> IVec4 {
 /// A 4-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -16,7 +16,10 @@ pub const fn i64vec2(x: i64, y: i64) -> I64Vec2 {
 /// A 2-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -19,7 +19,10 @@ pub const fn i64vec3(x: i64, y: i64, z: i64) -> I64Vec3 {
 /// A 3-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct I64Vec3 {

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -20,7 +20,10 @@ pub const fn i64vec4(x: i64, y: i64, z: i64, w: i64) -> I64Vec4 {
 /// A 4-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -16,7 +16,10 @@ pub const fn i8vec2(x: i8, y: i8) -> I8Vec2 {
 /// A 2-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(2)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -19,7 +19,10 @@ pub const fn i8vec3(x: i8, y: i8, z: i8) -> I8Vec3 {
 /// A 3-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct I8Vec3 {

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -20,7 +20,10 @@ pub const fn i8vec4(x: i8, y: i8, z: i8, w: i8) -> I8Vec4 {
 /// A 4-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(4)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -16,7 +16,10 @@ pub const fn u16vec2(x: u16, y: u16) -> U16Vec2 {
 /// A 2-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(4)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -19,7 +19,10 @@ pub const fn u16vec3(x: u16, y: u16, z: u16) -> U16Vec3 {
 /// A 3-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct U16Vec3 {

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -20,7 +20,10 @@ pub const fn u16vec4(x: u16, y: u16, z: u16, w: u16) -> U16Vec4 {
 /// A 4-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -16,7 +16,10 @@ pub const fn uvec2(x: u32, y: u32) -> UVec2 {
 /// A 2-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(8)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -19,7 +19,10 @@ pub const fn uvec3(x: u32, y: u32, z: u32) -> UVec3 {
 /// A 3-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct UVec3 {

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -20,7 +20,10 @@ pub const fn uvec4(x: u32, y: u32, z: u32, w: u32) -> UVec4 {
 /// A 4-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -16,7 +16,10 @@ pub const fn u64vec2(x: u64, y: u64) -> U64Vec2 {
 /// A 2-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -19,7 +19,10 @@ pub const fn u64vec3(x: u64, y: u64, z: u64) -> U64Vec3 {
 /// A 3-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct U64Vec3 {

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -20,7 +20,10 @@ pub const fn u64vec4(x: u64, y: u64, z: u64, w: u64) -> U64Vec4 {
 /// A 4-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -16,7 +16,10 @@ pub const fn u8vec2(x: u8, y: u8) -> U8Vec2 {
 /// A 2-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(2)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -19,7 +19,10 @@ pub const fn u8vec3(x: u8, y: u8, z: u8) -> U8Vec3 {
 /// A 3-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct U8Vec3 {

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -20,7 +20,10 @@ pub const fn u8vec4(x: u8, y: u8, z: u8, w: u8) -> U8Vec4 {
 /// A 4-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(4)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/usize/usizevec2.rs
+++ b/src/usize/usizevec2.rs
@@ -16,7 +16,10 @@ pub const fn usizevec2(x: usize, y: usize) -> USizeVec2 {
 /// A 2-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/src/usize/usizevec3.rs
+++ b/src/usize/usizevec3.rs
@@ -19,7 +19,10 @@ pub const fn usizevec3(x: usize, y: usize, z: usize) -> USizeVec3 {
 /// A 3-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]
 pub struct USizeVec3 {

--- a/src/usize/usizevec4.rs
+++ b/src/usize/usizevec4.rs
@@ -20,7 +20,10 @@ pub const fn usizevec4(x: usize, y: usize, z: usize, w: usize) -> USizeVec4 {
 /// A 4-dimensional vector.
 #[cfg_attr(not(target_arch = "spirv"), derive(Hash))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(
+    all(feature = "bytemuck", not(target_arch = "spirv")),
+    derive(bytemuck::Pod, bytemuck::Zeroable)
+)]
 #[cfg_attr(feature = "cuda", repr(align(16)))]
 #[cfg_attr(not(target_arch = "spirv"), repr(C))]
 #[cfg_attr(target_arch = "spirv", repr(simd))]

--- a/templates/affine.rs.tera
+++ b/templates/affine.rs.tera
@@ -62,12 +62,12 @@ use core::ops::{Deref, DerefMut, Mul, MulAssign};
 {%- endif %}
 #[derive(Copy, Clone)]
 {%- if self_t == "Affine2" %}
-#[cfg_attr(all(feature = "bytemuck", not(feature = "scalar-math")), derive(bytemuck::AnyBitPattern))]
-#[cfg_attr(all(feature = "bytemuck", feature = "scalar-math"), derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(all(feature = "bytemuck", not(any(feature = "scalar-math", target_arch = "spirv"))), derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(all(feature = "bytemuck", feature = "scalar-math", not(target_arch = "spirv")), derive(bytemuck::Pod, bytemuck::Zeroable))]
 {%- elif self_t == "Affine3A" and is_scalar %}
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(all(feature = "bytemuck", not(target_arch = "spirv")), derive(bytemuck::AnyBitPattern))]
 {%- else %}
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(all(feature = "bytemuck", not(target_arch = "spirv")), derive(bytemuck::Pod, bytemuck::Zeroable))]
 {%- endif %}
 #[repr(C)]
 pub struct {{ self_t }} {

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -201,9 +201,9 @@ pub const fn {{ self_t | lower }}(
 {%- endif %}
 #[derive(Clone, Copy)]
 {%- if self_t == "Mat3A" and is_scalar %}
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(all(feature = "bytemuck", not(target_arch = "spirv")), derive(bytemuck::AnyBitPattern))]
 {%- else %}
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(all(feature = "bytemuck", not(target_arch = "spirv")), derive(bytemuck::Pod, bytemuck::Zeroable))]
 {%- endif %}
 {%- if self_t == "Mat4" and is_scalar %}
 #[cfg_attr(

--- a/templates/quat.rs.tera
+++ b/templates/quat.rs.tera
@@ -104,7 +104,7 @@ pub const fn {{ self_t | lower }}(x: {{ scalar_t }}, y: {{ scalar_t }}, z: {{ sc
 /// This type is 16 byte aligned.
 {%- endif %}
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(all(feature = "bytemuck", not(target_arch = "spirv")), derive(bytemuck::Pod, bytemuck::Zeroable))]
 {%- if is_scalar %}
 {%- if scalar_t == "f32" %}
 #[cfg_attr(not(any(feature = "scalar-math", target_arch = "spirv")), repr(align(16)))]

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -312,9 +312,9 @@ pub const fn {{ self_t | lower }}(
     {% endif %}
 )]
 {%- if self_t == "Vec3A" and is_scalar %}
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(all(feature = "bytemuck", not(target_arch = "spirv")), derive(bytemuck::AnyBitPattern))]
 {%- else %}
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
+#[cfg_attr(all(feature = "bytemuck", not(target_arch = "spirv")), derive(bytemuck::Pod, bytemuck::Zeroable))]
 {%- endif %}
 {%- if self_t == "Vec3A" and is_scalar %}
 #[cfg_attr(not(target_arch = "spirv"), repr(align(16)))]


### PR DESCRIPTION
Restore the old bytemuck trait impls for spirv only.

# Objective

- Restore the old bytemuck trait impls just for spirv
- Fixes #658 

## Solution

- We want to keep using bytemuck derive on other platforms for the checks.

