### PR TITLE
Add `Vec3::to_vec3a` and `Vec3A::to_vec3` methods.

### DIFF
--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -132,7 +132,7 @@ impl Vec3A {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 3] {
@@ -185,6 +185,13 @@ impl Vec3A {
     pub fn truncate(self) -> Vec2 {
         use crate::swizzles::Vec3Swizzles;
         self.xy()
+    }
+
+    // Converts `self` to a `Vec3`.
+    #[inline]
+    #[must_use]
+    pub fn to_vec3(self) -> Vec3 {
+        Vec3::from(self)
     }
 
     /// Creates a 3D vector from `self` with the given value of `x`.

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -134,7 +134,7 @@ impl Vec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 4] {

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -137,7 +137,7 @@ impl Vec3A {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 3] {
@@ -190,6 +190,13 @@ impl Vec3A {
     pub fn truncate(self) -> Vec2 {
         use crate::swizzles::Vec3Swizzles;
         self.xy()
+    }
+
+    // Converts `self` to a `Vec3`.
+    #[inline]
+    #[must_use]
+    pub fn to_vec3(self) -> Vec3 {
+        Vec3::from(self)
     }
 
     /// Creates a 3D vector from `self` with the given value of `x`.

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -139,7 +139,7 @@ impl Vec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 4] {

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -139,7 +139,7 @@ impl Vec3A {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 3] {
@@ -196,6 +196,13 @@ impl Vec3A {
     pub fn truncate(self) -> Vec2 {
         use crate::swizzles::Vec3Swizzles;
         self.xy()
+    }
+
+    // Converts `self` to a `Vec3`.
+    #[inline]
+    #[must_use]
+    pub fn to_vec3(self) -> Vec3 {
+        Vec3::from(self)
     }
 
     /// Creates a 3D vector from `self` with the given value of `x`.

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -158,7 +158,7 @@ impl Vec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 4] {

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -145,7 +145,7 @@ impl Vec3A {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 3] {
@@ -198,6 +198,13 @@ impl Vec3A {
     pub fn truncate(self) -> Vec2 {
         use crate::swizzles::Vec3Swizzles;
         self.xy()
+    }
+
+    // Converts `self` to a `Vec3`.
+    #[inline]
+    #[must_use]
+    pub fn to_vec3(self) -> Vec3 {
+        Vec3::from(self)
     }
 
     /// Creates a 3D vector from `self` with the given value of `x`.

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -147,7 +147,7 @@ impl Vec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 4] {

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -123,7 +123,7 @@ impl Vec2 {
         Self::new(a[0], a[1])
     }
 
-    /// `[x, y]`
+    /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 2] {

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -1,6 +1,6 @@
 // Generated from vec.rs.tera template. Edit the template, not the generated file.
 
-use crate::{f32::math, BVec3, BVec3A, FloatExt, Quat, Vec2, Vec4};
+use crate::{f32::math, BVec3, BVec3A, FloatExt, Quat, Vec2, Vec3A, Vec4};
 
 use core::fmt;
 use core::iter::{Product, Sum};
@@ -130,7 +130,7 @@ impl Vec3 {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 3] {
@@ -186,6 +186,13 @@ impl Vec3 {
     pub fn truncate(self) -> Vec2 {
         use crate::swizzles::Vec3Swizzles;
         self.xy()
+    }
+
+    // Converts `self` to a `Vec3A`.
+    #[inline]
+    #[must_use]
+    pub fn to_vec3a(self) -> Vec3A {
+        Vec3A::from(self)
     }
 
     /// Creates a 3D vector from `self` with the given value of `x`.

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -131,7 +131,7 @@ impl Vec3A {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 3] {
@@ -184,6 +184,13 @@ impl Vec3A {
     pub fn truncate(self) -> Vec2 {
         use crate::swizzles::Vec3Swizzles;
         self.xy()
+    }
+
+    // Converts `self` to a `Vec3`.
+    #[inline]
+    #[must_use]
+    pub fn to_vec3(self) -> Vec3 {
+        Vec3::from(self)
     }
 
     /// Creates a 3D vector from `self` with the given value of `x`.

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -133,7 +133,7 @@ impl Vec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f32; 4] {

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -123,7 +123,7 @@ impl DVec2 {
         Self::new(a[0], a[1])
     }
 
-    /// `[x, y]`
+    /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f64; 2] {

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -130,7 +130,7 @@ impl DVec3 {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f64; 3] {

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -149,7 +149,7 @@ impl DVec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [f64; 4] {

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -104,7 +104,7 @@ impl I16Vec2 {
         Self::new(a[0], a[1])
     }
 
-    /// `[x, y]`
+    /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i16; 2] {

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -114,7 +114,7 @@ impl I16Vec3 {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i16; 3] {

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -132,7 +132,7 @@ impl I16Vec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i16; 4] {

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -104,7 +104,7 @@ impl IVec2 {
         Self::new(a[0], a[1])
     }
 
-    /// `[x, y]`
+    /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i32; 2] {

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -114,7 +114,7 @@ impl IVec3 {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i32; 3] {

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -132,7 +132,7 @@ impl IVec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i32; 4] {

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -104,7 +104,7 @@ impl I64Vec2 {
         Self::new(a[0], a[1])
     }
 
-    /// `[x, y]`
+    /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i64; 2] {

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -114,7 +114,7 @@ impl I64Vec3 {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i64; 3] {

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -132,7 +132,7 @@ impl I64Vec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i64; 4] {

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -104,7 +104,7 @@ impl I8Vec2 {
         Self::new(a[0], a[1])
     }
 
-    /// `[x, y]`
+    /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i8; 2] {

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -114,7 +114,7 @@ impl I8Vec3 {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i8; 3] {

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -132,7 +132,7 @@ impl I8Vec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [i8; 4] {

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -95,7 +95,7 @@ impl U16Vec2 {
         Self::new(a[0], a[1])
     }
 
-    /// `[x, y]`
+    /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u16; 2] {

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -102,7 +102,7 @@ impl U16Vec3 {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u16; 3] {

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -117,7 +117,7 @@ impl U16Vec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u16; 4] {

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -95,7 +95,7 @@ impl UVec2 {
         Self::new(a[0], a[1])
     }
 
-    /// `[x, y]`
+    /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u32; 2] {

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -102,7 +102,7 @@ impl UVec3 {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u32; 3] {

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -117,7 +117,7 @@ impl UVec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u32; 4] {

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -95,7 +95,7 @@ impl U64Vec2 {
         Self::new(a[0], a[1])
     }
 
-    /// `[x, y]`
+    /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u64; 2] {

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -102,7 +102,7 @@ impl U64Vec3 {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u64; 3] {

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -117,7 +117,7 @@ impl U64Vec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u64; 4] {

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -95,7 +95,7 @@ impl U8Vec2 {
         Self::new(a[0], a[1])
     }
 
-    /// `[x, y]`
+    /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u8; 2] {

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -102,7 +102,7 @@ impl U8Vec3 {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u8; 3] {

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -117,7 +117,7 @@ impl U8Vec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [u8; 4] {

--- a/src/usize/usizevec2.rs
+++ b/src/usize/usizevec2.rs
@@ -95,7 +95,7 @@ impl USizeVec2 {
         Self::new(a[0], a[1])
     }
 
-    /// `[x, y]`
+    /// Converts `self` to `[x, y]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [usize; 2] {

--- a/src/usize/usizevec3.rs
+++ b/src/usize/usizevec3.rs
@@ -102,7 +102,7 @@ impl USizeVec3 {
         Self::new(a[0], a[1], a[2])
     }
 
-    /// `[x, y, z]`
+    /// Converts `self` to `[x, y, z]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [usize; 3] {

--- a/src/usize/usizevec4.rs
+++ b/src/usize/usizevec4.rs
@@ -117,7 +117,7 @@ impl USizeVec4 {
         Self::new(a[0], a[1], a[2], a[3])
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [usize; 4] {

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -208,7 +208,7 @@
     {% if self_t != vec3_t %}
         {{ vec3_t }},
     {% endif %}
-    {% if self_t == "Vec4" %}
+    {% if self_t == "Vec3" or self_t == "Vec4" %}
         {{ vec3a_t }},
     {% endif %}
     {% if dim > 2 and self_t != vec4_t %}
@@ -532,7 +532,7 @@ impl {{ self_t }} {
         )
     }
 
-    /// `[{{ components | join(sep=", ") }}]`
+    /// Converts `self` to `[{{ components | join(sep=", ") }}]`
     #[inline]
     #[must_use]
     pub const fn to_array(&self) -> [{{ scalar_t }}; {{ dim }}] {
@@ -648,6 +648,21 @@ impl {{ self_t }} {
     }
 {% endif %}
 
+{% if self_t == "Vec3A" %}
+    // Converts `self` to a `Vec3`.
+    #[inline]
+    #[must_use]
+    pub fn to_vec3(self) -> Vec3 {
+        Vec3::from(self)
+    }
+{% elif self_t == "Vec3" %}
+    // Converts `self` to a `Vec3A`.
+    #[inline]
+    #[must_use]
+    pub fn to_vec3a(self) -> Vec3A {
+        Vec3A::from(self)
+    }
+{% endif %}
 
 {% for c in components %}
     /// Creates a {{ dim }}D vector from `self` with the given value of `{{ c }}`.


### PR DESCRIPTION
Fixes #655 