### PR TITLE
Add `encase` trait implementations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       # run clippy to verify we have no warnings
       - run: cargo fetch
       - name: cargo clippy
-        run: cargo clippy --workspace --all-targets --features std,debug-glam-assert,approx,bytemuck,mint,rand,serde,rkyv,speedy -- -D warnings
+        run: cargo clippy --workspace --all-targets --features std,debug-glam-assert,approx,bytemuck,mint,rand,serde,rkyv,speedy,encase -- -D warnings
 
       # check that codegen output matches committed source files
       - name: codegen
@@ -29,7 +29,7 @@ jobs:
       - name: Build-test documentation
         env:
           RUSTDOCFLAGS: -Dwarnings
-        run: cargo doc --all --no-deps --document-private-items --features std,debug-glam-assert,approx,bytemuck,mint,rand,serde,rkyv,speedy,rkyv/pointer_width_32
+        run: cargo doc --all --no-deps --document-private-items --features std,debug-glam-assert,approx,bytemuck,mint,rand,serde,rkyv,speedy,rkyv/pointer_width_32,encase
 
   test:
     name: Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog], and this project adheres to
 [Semantic Versioning].
 
+## Unreleased
+
+### Added
+
+* Added `encase` feature, providing `encase` trait implementations for `glam` types.
+
 ## [0.30.5] - 2025-07-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ serde = { version = "1.0", optional = true, default-features = false }
 rkyv = { version = "0.8", optional = true, default-features = false }
 libm = { version = "0.2", optional = true, default-features = false }
 speedy = { version = "0.8", optional = true, default-features = false }
+encase = { version = "0.12", optional = true, default-features = false }
 
 [dev-dependencies]
 # rand_xoshiro is required for tests if rand is enabled

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ glam = { version = "0.30.5", default-features = false, features = ["nostd-libm"]
   without the `scalar-math` feature. It should work between all other builds of
   `glam`.  Endian conversion is currently not supported
 * [`bytecheck`] - to perform archive validation when using the `rkyv` feature
+* [`encase`] - `encase` trait implementations for `glam` types.
 
 [`approx`]: https://docs.rs/approx
 [`bytemuck`]: https://docs.rs/bytemuck
@@ -145,6 +146,7 @@ glam = { version = "0.30.5", default-features = false, features = ["nostd-libm"]
 [`speedy`]: https://docs.rs/speedy
 [`rkyv`]: https://github.com/rkyv/rkyv
 [`bytecheck`]: https://github.com/rkyv/bytecheck
+[`encase`]: https://github.com/teoxoy/encase
 
 ### Feature gates
 

--- a/deny.toml
+++ b/deny.toml
@@ -10,5 +10,7 @@ skip-tree = [
 allow = [
     "Apache-2.0",
     "MIT",
+    "MIT-0",
     "Unicode-3.0",
+    "Zlib",
 ]

--- a/src/features.rs
+++ b/src/features.rs
@@ -18,3 +18,6 @@ pub mod impl_speedy;
 
 #[cfg(feature = "rkyv")]
 pub mod impl_rkyv;
+
+#[cfg(feature = "encase")]
+pub mod impl_encase;

--- a/src/features/impl_encase.rs
+++ b/src/features/impl_encase.rs
@@ -1,0 +1,117 @@
+use crate::{IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4};
+use encase::{
+    matrix::{impl_matrix, AsMutMatrixParts, AsRefMatrixParts, FromMatrixParts, MatrixScalar},
+    vector::impl_vector,
+};
+
+impl_vector!(2, Vec2, f32; using AsRef AsMut From);
+impl_vector!(2, UVec2, u32; using AsRef AsMut From);
+impl_vector!(2, IVec2, i32; using AsRef AsMut From);
+
+impl_vector!(3, Vec3, f32; using AsRef AsMut From);
+impl_vector!(3, UVec3, u32; using AsRef AsMut From);
+impl_vector!(3, IVec3, i32; using AsRef AsMut From);
+
+impl_vector!(4, Vec4, f32; using AsRef AsMut From);
+impl_vector!(4, UVec4, u32; using AsRef AsMut From);
+impl_vector!(4, IVec4, i32; using AsRef AsMut From);
+
+macro_rules! impl_matrix_traits {
+    ($c:literal, $r:literal, $type:ty, $el_ty:ty) => {
+        impl AsRefMatrixParts<$el_ty, $c, $r> for $type
+        where
+            Self: AsRef<[$el_ty; $r * $c]>,
+            $el_ty: MatrixScalar,
+        {
+            fn as_ref_parts(&self) -> &[[$el_ty; $r]; $c] {
+                unsafe {
+                    ::core::mem::transmute::<&[$el_ty; $r * $c], &[[$el_ty; $r]; $c]>(self.as_ref())
+                }
+            }
+        }
+
+        impl AsMutMatrixParts<$el_ty, $c, $r> for $type
+        where
+            Self: AsMut<[$el_ty; $r * $c]>,
+            $el_ty: MatrixScalar,
+        {
+            fn as_mut_parts(&mut self) -> &mut [[$el_ty; $r]; $c] {
+                unsafe {
+                    ::core::mem::transmute::<&mut [$el_ty; $r * $c], &mut [[$el_ty; $r]; $c]>(
+                        self.as_mut(),
+                    )
+                }
+            }
+        }
+
+        impl FromMatrixParts<$el_ty, $c, $r> for $type {
+            fn from_parts(parts: [[$el_ty; $r]; $c]) -> Self {
+                Self::from_cols_array_2d(&parts)
+            }
+        }
+    };
+}
+
+impl_matrix_traits!(2, 2, Mat2, f32);
+impl_matrix_traits!(3, 3, Mat3, f32);
+impl_matrix_traits!(4, 4, Mat4, f32);
+
+impl_matrix!(2, 2, Mat2, f32);
+impl_matrix!(3, 3, Mat3, f32);
+impl_matrix!(4, 4, Mat4, f32);
+
+#[cfg(test)]
+mod test {
+    use crate::{Mat3, Vec3};
+    use encase::StorageBuffer;
+
+    #[test]
+    fn vec3() {
+        let v = Vec3::new(1.12, 3.04, 6.75);
+
+        let mut buf = [255u8; 12];
+        let mut s_buf = StorageBuffer::new(&mut buf);
+
+        s_buf.write(&v).unwrap();
+        assert_eq!(&s_buf.as_ref()[0..][..4], &v.x.to_le_bytes());
+        assert_eq!(&s_buf.as_ref()[4..][..4], &v.y.to_le_bytes());
+        assert_eq!(&s_buf.as_ref()[8..][..4], &v.z.to_le_bytes());
+
+        let mut v_out = Vec3::ZERO;
+        s_buf.read(&mut v_out).unwrap();
+        assert_eq!(v, v_out);
+
+        assert_eq!(v, s_buf.create().unwrap());
+    }
+
+    #[test]
+    fn mat3() {
+        let m = Mat3::from_cols(
+            [1.12, 3.04, 6.75].into(),
+            [8.65, 2.34, 94.6].into(),
+            [5.45, 6.34, 89.41].into(),
+        );
+
+        let mut buf = [255u8; 48];
+        let mut s_buf = StorageBuffer::new(&mut buf);
+
+        s_buf.write(&m).unwrap();
+        assert_eq!(&s_buf.as_ref()[0..][..4], &m.x_axis.x.to_le_bytes());
+        assert_eq!(&s_buf.as_ref()[4..][..4], &m.x_axis.y.to_le_bytes());
+        assert_eq!(&s_buf.as_ref()[8..][..4], &m.x_axis.z.to_le_bytes());
+
+        assert_eq!(&s_buf.as_ref()[16..][..4], &m.y_axis.x.to_le_bytes());
+        assert_eq!(&s_buf.as_ref()[20..][..4], &m.y_axis.y.to_le_bytes());
+        assert_eq!(&s_buf.as_ref()[24..][..4], &m.y_axis.z.to_le_bytes());
+
+        assert_eq!(&s_buf.as_ref()[32..][..4], &m.z_axis.x.to_le_bytes());
+        assert_eq!(&s_buf.as_ref()[36..][..4], &m.z_axis.y.to_le_bytes());
+        assert_eq!(&s_buf.as_ref()[40..][..4], &m.z_axis.z.to_le_bytes());
+
+        let mut m_out = Mat3::ZERO;
+        s_buf.read(&mut m_out).unwrap();
+        assert_eq!(m, m_out);
+
+        assert_eq!(m, s_buf.create().unwrap());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,6 +238,7 @@ and benchmarks.
   `scalar-math` feature. It should work between all other builds of `glam`.
   Endian conversion is currently not supported
 * `bytecheck` - to perform archive validation when using the `rkyv` feature
+* `encase` - `encase` trait implementations for `glam` types.
 * `serde` - implementations of `Serialize` and `Deserialize` for all `glam`
   types. Note that serialization should work between builds of `glam` with and without SIMD enabled
 * `speedy` - implementations of `speedy`'s `Readable` and `Writable` for all `glam` types.


### PR DESCRIPTION
# Objective

- Resolves https://github.com/bitshifter/glam-rs/issues/631.

## Solution

- Adds trait implementations.

## Testing

- I've added 2 tests for `Vec3` and `Mat3` since the other types use the same code paths - but let me know if you want me to expand the tests.
