### PR TITLE
Fix typo in 'glFrustum'

### DIFF
--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -876,7 +876,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
     ///
-    /// This is the same as the OpenGL `glFurstum` function.
+    /// This is the same as the OpenGL `glFrustum` function.
     ///
     /// See <https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glFrustum.xml>
     #[inline]

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -888,7 +888,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
     ///
-    /// This is the same as the OpenGL `glFurstum` function.
+    /// This is the same as the OpenGL `glFrustum` function.
     ///
     /// See <https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glFrustum.xml>
     #[inline]

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -799,7 +799,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
     ///
-    /// This is the same as the OpenGL `glFurstum` function.
+    /// This is the same as the OpenGL `glFrustum` function.
     ///
     /// See <https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glFrustum.xml>
     #[inline]

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -892,7 +892,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
     ///
-    /// This is the same as the OpenGL `glFurstum` function.
+    /// This is the same as the OpenGL `glFrustum` function.
     ///
     /// See <https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glFrustum.xml>
     #[inline]

--- a/src/f32/wasm32/mat4.rs
+++ b/src/f32/wasm32/mat4.rs
@@ -883,7 +883,7 @@ impl Mat4 {
 
     /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
     ///
-    /// This is the same as the OpenGL `glFurstum` function.
+    /// This is the same as the OpenGL `glFrustum` function.
     ///
     /// See <https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glFrustum.xml>
     #[inline]

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -787,7 +787,7 @@ impl DMat4 {
 
     /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
     ///
-    /// This is the same as the OpenGL `glFurstum` function.
+    /// This is the same as the OpenGL `glFrustum` function.
     ///
     /// See <https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glFrustum.xml>
     #[inline]

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -1817,7 +1817,7 @@ impl {{ self_t }} {
 
     /// Creates a right-handed perspective projection matrix with [-1,1] depth range.
     ///
-    /// This is the same as the OpenGL `glFurstum` function.
+    /// This is the same as the OpenGL `glFrustum` function.
     ///
     /// See <https://registry.khronos.org/OpenGL-Refpages/gl2.1/xhtml/glFrustum.xml>
     #[inline]


### PR DESCRIPTION
# Objective

Fix typo (`glFurstum` -> `glFrustum`)

## Solution

Fix the spelling in generator template

## Code generation

- Most code in glam is generated by an offline tool.
- Are you modify generated code? Yes, but the generator did it
- Have you modified the templates and run the code generator? Yes

## Testing and linting

No code changes
