### PR TITLE
Use a more precise threshold for DQuat::is_near_identity.

### DIFF
--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -602,7 +602,6 @@ impl Quat {
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        let threshold_angle = 0.002_847_144_6;
         // Because of floating point precision, we cannot represent very small rotations.
         // The closest f32 to 1.0 that is not 1.0 itself yields:
         // 0.99999994.acos() * 2.0  = 0.000690533954 rad
@@ -616,8 +615,12 @@ impl Quat {
         // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
         // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
         // the shortest path.
+        //
+        // For f64 we're using a threshhold of
+        // (1.0 - 1e-14).acos() * 2.0
+        const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
         let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < threshold_angle
+        positive_w_angle < THRESHOLD_ANGLE
     }
 
     /// Returns the angle (in radians) for the minimal rotation

--- a/src/f32/neon/quat.rs
+++ b/src/f32/neon/quat.rs
@@ -614,7 +614,6 @@ impl Quat {
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        let threshold_angle = 0.002_847_144_6;
         // Because of floating point precision, we cannot represent very small rotations.
         // The closest f32 to 1.0 that is not 1.0 itself yields:
         // 0.99999994.acos() * 2.0  = 0.000690533954 rad
@@ -628,8 +627,12 @@ impl Quat {
         // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
         // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
         // the shortest path.
+        //
+        // For f64 we're using a threshhold of
+        // (1.0 - 1e-14).acos() * 2.0
+        const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
         let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < threshold_angle
+        positive_w_angle < THRESHOLD_ANGLE
     }
 
     /// Returns the angle (in radians) for the minimal rotation

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -616,7 +616,6 @@ impl Quat {
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        let threshold_angle = 0.002_847_144_6;
         // Because of floating point precision, we cannot represent very small rotations.
         // The closest f32 to 1.0 that is not 1.0 itself yields:
         // 0.99999994.acos() * 2.0  = 0.000690533954 rad
@@ -630,8 +629,12 @@ impl Quat {
         // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
         // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
         // the shortest path.
+        //
+        // For f64 we're using a threshhold of
+        // (1.0 - 1e-14).acos() * 2.0
+        const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
         let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < threshold_angle
+        positive_w_angle < THRESHOLD_ANGLE
     }
 
     /// Returns the angle (in radians) for the minimal rotation

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -617,7 +617,6 @@ impl Quat {
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        let threshold_angle = 0.002_847_144_6;
         // Because of floating point precision, we cannot represent very small rotations.
         // The closest f32 to 1.0 that is not 1.0 itself yields:
         // 0.99999994.acos() * 2.0  = 0.000690533954 rad
@@ -631,8 +630,12 @@ impl Quat {
         // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
         // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
         // the shortest path.
+        //
+        // For f64 we're using a threshhold of
+        // (1.0 - 1e-14).acos() * 2.0
+        const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
         let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < threshold_angle
+        positive_w_angle < THRESHOLD_ANGLE
     }
 
     /// Returns the angle (in radians) for the minimal rotation

--- a/src/f32/wasm32/quat.rs
+++ b/src/f32/wasm32/quat.rs
@@ -609,7 +609,6 @@ impl Quat {
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        let threshold_angle = 0.002_847_144_6;
         // Because of floating point precision, we cannot represent very small rotations.
         // The closest f32 to 1.0 that is not 1.0 itself yields:
         // 0.99999994.acos() * 2.0  = 0.000690533954 rad
@@ -623,8 +622,12 @@ impl Quat {
         // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
         // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
         // the shortest path.
+        //
+        // For f64 we're using a threshhold of
+        // (1.0 - 1e-14).acos() * 2.0
+        const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
         let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < threshold_angle
+        positive_w_angle < THRESHOLD_ANGLE
     }
 
     /// Returns the angle (in radians) for the minimal rotation

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -601,7 +601,6 @@ impl DQuat {
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        let threshold_angle = 0.002_847_144_6;
         // Because of floating point precision, we cannot represent very small rotations.
         // The closest f32 to 1.0 that is not 1.0 itself yields:
         // 0.99999994.acos() * 2.0  = 0.000690533954 rad
@@ -615,8 +614,12 @@ impl DQuat {
         // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
         // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
         // the shortest path.
+        //
+        // For f64 we're using a threshhold of
+        // (1.0 - 1e-14).acos() * 2.0
+        const THRESHOLD_ANGLE: f64 = 2.827_296_549_232_347_4e-7;
         let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < threshold_angle
+        positive_w_angle < THRESHOLD_ANGLE
     }
 
     /// Returns the angle (in radians) for the minimal rotation

--- a/templates/quat.rs.tera
+++ b/templates/quat.rs.tera
@@ -754,7 +754,6 @@ impl {{ self_t }} {
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        let threshold_angle = 0.002_847_144_6;
         // Because of floating point precision, we cannot represent very small rotations.
         // The closest f32 to 1.0 that is not 1.0 itself yields:
         // 0.99999994.acos() * 2.0  = 0.000690533954 rad
@@ -768,8 +767,16 @@ impl {{ self_t }} {
         // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
         // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
         // the shortest path.
+        //
+        // For f64 we're using a threshhold of
+        // (1.0 - 1e-14).acos() * 2.0
+        {%- if scalar_t == 'f32' %}
+            const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
+        {%- elif scalar_t == 'f64' %}
+            const THRESHOLD_ANGLE: f64 = 2.827_296_549_232_347_4e-7;
+        {%- endif %}
         let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < threshold_angle
+        positive_w_angle < THRESHOLD_ANGLE
     }
 
     /// Returns the angle (in radians) for the minimal rotation


### PR DESCRIPTION
# Objective

- Fixes #656 

## Solution

- Use a more precise threshold of `(1.0 - 1e-14).acos() * 2.0` for `DQuat::is_near_identity()`