### PR TITLE
Added convenience methods for homogenous coordinates.

### DIFF
--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -184,6 +184,25 @@ impl Vec3A {
         self.xy()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `v.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn from_homogeneous(v: Vec4) -> Self {
+        glam_assert!(v.w != 0.0);
+        Self::from_vec4(v) / v.w
+    }
+
+    /// Creates a homogeneous coordinate from `self`, equivalent to `self.extend(1.0)`.
+    #[inline]
+    #[must_use]
+    pub fn to_homogeneous(self) -> Vec4 {
+        self.extend(1.0)
+    }
+
     // Converts `self` to a `Vec3`.
     #[inline]
     #[must_use]

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -172,6 +172,19 @@ impl Vec4 {
         self.xyz()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// To project to [`Vec3A`] use [`Vec3A::from_homogeneous()`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn project(self) -> Vec3 {
+        Vec3::from_homogeneous(self)
+    }
+
     /// Creates a 4D vector from `self` with the given value of `x`.
     #[inline]
     #[must_use]

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -196,6 +196,25 @@ impl Vec3A {
         self.xy()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `v.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn from_homogeneous(v: Vec4) -> Self {
+        glam_assert!(v.w != 0.0);
+        Self::from_vec4(v) / v.w
+    }
+
+    /// Creates a homogeneous coordinate from `self`, equivalent to `self.extend(1.0)`.
+    #[inline]
+    #[must_use]
+    pub fn to_homogeneous(self) -> Vec4 {
+        self.extend(1.0)
+    }
+
     // Converts `self` to a `Vec3`.
     #[inline]
     #[must_use]

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -187,6 +187,19 @@ impl Vec4 {
         self.xyz()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// To project to [`Vec3A`] use [`Vec3A::from_homogeneous()`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn project(self) -> Vec3 {
+        Vec3::from_homogeneous(self)
+    }
+
     /// Creates a 4D vector from `self` with the given value of `x`.
     #[inline]
     #[must_use]

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -199,6 +199,25 @@ impl Vec3A {
         self.xy()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `v.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn from_homogeneous(v: Vec4) -> Self {
+        glam_assert!(v.w != 0.0);
+        Self::from_vec4(v) / v.w
+    }
+
+    /// Creates a homogeneous coordinate from `self`, equivalent to `self.extend(1.0)`.
+    #[inline]
+    #[must_use]
+    pub fn to_homogeneous(self) -> Vec4 {
+        self.extend(1.0)
+    }
+
     // Converts `self` to a `Vec3`.
     #[inline]
     #[must_use]

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -197,6 +197,19 @@ impl Vec4 {
         self.xyz()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// To project to [`Vec3A`] use [`Vec3A::from_homogeneous()`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn project(self) -> Vec3 {
+        Vec3::from_homogeneous(self)
+    }
+
     /// Creates a 4D vector from `self` with the given value of `x`.
     #[inline]
     #[must_use]

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -204,6 +204,25 @@ impl Vec3A {
         self.xy()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `v.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn from_homogeneous(v: Vec4) -> Self {
+        glam_assert!(v.w != 0.0);
+        Self::from_vec4(v) / v.w
+    }
+
+    /// Creates a homogeneous coordinate from `self`, equivalent to `self.extend(1.0)`.
+    #[inline]
+    #[must_use]
+    pub fn to_homogeneous(self) -> Vec4 {
+        self.extend(1.0)
+    }
+
     // Converts `self` to a `Vec3`.
     #[inline]
     #[must_use]

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -195,6 +195,19 @@ impl Vec4 {
         self.xyz()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// To project to [`Vec3A`] use [`Vec3A::from_homogeneous()`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn project(self) -> Vec3 {
+        Vec3::from_homogeneous(self)
+    }
+
     /// Creates a 4D vector from `self` with the given value of `x`.
     #[inline]
     #[must_use]

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -192,6 +192,25 @@ impl Vec3 {
         self.xy()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `v.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn from_homogeneous(v: Vec4) -> Self {
+        glam_assert!(v.w != 0.0);
+        Self::from_vec4(v) / v.w
+    }
+
+    /// Creates a homogeneous coordinate from `self`, equivalent to `self.extend(1.0)`.
+    #[inline]
+    #[must_use]
+    pub fn to_homogeneous(self) -> Vec4 {
+        self.extend(1.0)
+    }
+
     // Converts `self` to a `Vec3A`.
     #[inline]
     #[must_use]

--- a/src/f32/wasm32/vec3a.rs
+++ b/src/f32/wasm32/vec3a.rs
@@ -190,6 +190,25 @@ impl Vec3A {
         self.xy()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `v.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn from_homogeneous(v: Vec4) -> Self {
+        glam_assert!(v.w != 0.0);
+        Self::from_vec4(v) / v.w
+    }
+
+    /// Creates a homogeneous coordinate from `self`, equivalent to `self.extend(1.0)`.
+    #[inline]
+    #[must_use]
+    pub fn to_homogeneous(self) -> Vec4 {
+        self.extend(1.0)
+    }
+
     // Converts `self` to a `Vec3`.
     #[inline]
     #[must_use]

--- a/src/f32/wasm32/vec4.rs
+++ b/src/f32/wasm32/vec4.rs
@@ -178,6 +178,19 @@ impl Vec4 {
         self.xyz()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// To project to [`Vec3A`] use [`Vec3A::from_homogeneous()`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn project(self) -> Vec3 {
+        Vec3::from_homogeneous(self)
+    }
+
     /// Creates a 4D vector from `self` with the given value of `x`.
     #[inline]
     #[must_use]

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -192,6 +192,25 @@ impl DVec3 {
         self.xy()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `v.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn from_homogeneous(v: DVec4) -> Self {
+        glam_assert!(v.w != 0.0);
+        Self::from_vec4(v) / v.w
+    }
+
+    /// Creates a homogeneous coordinate from `self`, equivalent to `self.extend(1.0)`.
+    #[inline]
+    #[must_use]
+    pub fn to_homogeneous(self) -> DVec4 {
+        self.extend(1.0)
+    }
+
     /// Creates a 3D vector from `self` with the given value of `x`.
     #[inline]
     #[must_use]

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -192,6 +192,17 @@ impl DVec4 {
         self.xyz()
     }
 
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn project(self) -> DVec3 {
+        DVec3::from_homogeneous(self)
+    }
+
     /// Creates a 4D vector from `self` with the given value of `x`.
     #[inline]
     #[must_use]

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -636,20 +636,59 @@ impl {{ self_t }} {
         use crate::swizzles::Vec3Swizzles;
         self.xy()
     }
+
+    {% if is_float %}
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `v.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn from_homogeneous(v: {{ vec4_t }}) -> Self {
+        glam_assert!(v.w != 0.0);
+        Self::from_vec4(v) / v.w
+    }
+    
+    /// Creates a homogeneous coordinate from `self`, equivalent to `self.extend(1.0)`.
+    #[inline]
+    #[must_use]
+    pub fn to_homogeneous(self) -> {{ vec4_t }} {
+        self.extend(1.0)
+    }
+    {% endif %}
+
 {% elif dim == 4 %}
     /// Creates a 3D vector from the `x`, `y` and `z` elements of `self`, discarding `w`.
     ///
     /// Truncation to [`{{ vec3_t }}`] may also be performed by using [`self.xyz()`][crate::swizzles::Vec4Swizzles::xyz()].
-{%- if scalar_t == "f32" %}
+    {%- if scalar_t == "f32" %}
     ///
     /// To truncate to [`Vec3A`] use [`Vec3A::from_vec4()`].
-{%- endif %}
+    {%- endif %}
     #[inline]
     #[must_use]
     pub fn truncate(self) -> {{ vec3_t }} {
         use crate::swizzles::Vec4Swizzles;
         self.xyz()
     }
+
+    {% if is_float %}
+    /// Projects a homogeneous coordinate to 3D space by performing perspective divide.
+    {%- if scalar_t == "f32" %}
+    ///
+    /// To project to [`Vec3A`] use [`Vec3A::from_homogeneous()`].
+    {%- endif %}
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self.w` is `0` when `glam_assert` is enabled.
+    #[inline]
+    #[must_use]
+    pub fn project(self) -> {{ vec3_t }} {
+        {{ vec3_t }}::from_homogeneous(self)
+    }
+    {% endif %}
 {% endif %}
 
 {% if self_t == "Vec3A" %}

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -1899,6 +1899,11 @@ macro_rules! impl_vec3_float_tests {
             assert_approx_eq!(incident.refract(normal, 1.5), $vec3::ZERO);
         });
 
+        glam_test!(test_homogeneous, {
+            let v = $vec3::new(1.0, 2.0, 3.0);
+            assert_approx_eq!(v, $vec3::from_homogeneous(v.to_homogeneous()));
+        });
+
         glam_test!(test_as, {
             use glam::{
                 DVec3, I16Vec3, I64Vec3, I8Vec3, IVec3, U16Vec3, U64Vec3, U8Vec3, USizeVec3, UVec3,

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1939,6 +1939,11 @@ macro_rules! impl_vec4_float_tests {
             let normal = $vec4::Y;
             assert_approx_eq!(incident.refract(normal, 1.5), $vec4::ZERO);
         });
+
+        glam_test!(test_homogeneous, {
+            let v = $vec4::new(1.0, 2.0, 3.0, 1.0);
+            assert_approx_eq!(v, v.project().to_homogeneous());
+        });
     };
 }
 


### PR DESCRIPTION
Adds the following methods

* 3D float vector `from_homogeneous` and `to_homogeneous`
* 4D float vector `project`

Fixes #366 
