### PR TITLE
Add default glob to codegen.json.

### DIFF
--- a/codegen.json
+++ b/codegen.json
@@ -1,6 +1,7 @@
 {
   "version": 1,
   "template_root": "templates",
+  "default_glob": "src/**",
   "templates": {
     "affine.rs.tera": {
       "properties": {

--- a/tools/ci/src/commands/codegen.rs
+++ b/tools/ci/src/commands/codegen.rs
@@ -11,7 +11,7 @@ pub struct Codegen {}
 
 impl Prepare for Codegen {
     fn prepare<'a>(&self, sh: &'a Shell, _args: &Args) -> Vec<PreparedCommand<'a>> {
-        let cmd = cmd!(sh, "cargo run --release -p codegen -- --check");
+        let cmd = cmd!(sh, "cargo run --release -p codegen -- --check **");
         vec![PreparedCommand {
             name: "codegen".into(),
             command: cmd,


### PR DESCRIPTION
Avoids generating tests by default which almost never change.
