### PR TITLE
feat: add `is_negative_mask` to vector types #748

### DIFF
--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -491,6 +491,16 @@ impl Vec3A {
         (self.0.is_sign_negative().to_bitmask() & 0x7) as u32
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3A {
+        BVec3A(self.0.is_sign_negative())
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -470,6 +470,16 @@ impl Vec4 {
         self.0.is_sign_negative().to_bitmask() as u32
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec4A {
+        BVec4A(self.0.is_sign_negative())
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -543,6 +543,16 @@ impl Vec3A {
         }
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3A {
+        BVec3A(unsafe { vcltq_s32(vreinterpretq_s32_f32(self.0), vdupq_n_s32(0)) })
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -509,6 +509,16 @@ impl Vec4 {
         }
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec4A {
+        BVec4A(unsafe { vcltq_s32(vreinterpretq_s32_f32(self.0), vdupq_n_s32(0)) })
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -521,6 +521,20 @@ impl Vec3A {
             | ((self.z.is_sign_negative() as u32) << 2)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3A {
+        BVec3A::new(
+            self.x.is_sign_negative(),
+            self.y.is_sign_negative(),
+            self.z.is_sign_negative(),
+        )
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -547,6 +547,21 @@ impl Vec4 {
             | ((self.w.is_sign_negative() as u32) << 3)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec4A {
+        BVec4A::new(
+            self.x.is_sign_negative(),
+            self.y.is_sign_negative(),
+            self.z.is_sign_negative(),
+            self.w.is_sign_negative(),
+        )
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -533,6 +533,21 @@ impl Vec3A {
         unsafe { (_mm_movemask_ps(self.0) as u32) & 0x7 }
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3A {
+        BVec3A(unsafe {
+            _mm_castsi128_ps(_mm_cmplt_epi32(
+                _mm_castps_si128(self.0),
+                _mm_setzero_si128(),
+            ))
+        })
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -508,6 +508,21 @@ impl Vec4 {
         unsafe { _mm_movemask_ps(self.0) as u32 }
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec4A {
+        BVec4A(unsafe {
+            _mm_castsi128_ps(_mm_cmplt_epi32(
+                _mm_castps_si128(self.0),
+                _mm_setzero_si128(),
+            ))
+        })
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -423,6 +423,16 @@ impl Vec2 {
         (self.x.is_sign_negative() as u32) | ((self.y.is_sign_negative() as u32) << 1)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec2 {
+        BVec2::new(self.x.is_sign_negative(), self.y.is_sign_negative())
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -514,6 +514,20 @@ impl Vec3 {
             | ((self.z.is_sign_negative() as u32) << 2)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3 {
+        BVec3::new(
+            self.x.is_sign_negative(),
+            self.y.is_sign_negative(),
+            self.z.is_sign_negative(),
+        )
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f32/wasm/vec3a.rs
+++ b/src/f32/wasm/vec3a.rs
@@ -510,6 +510,16 @@ impl Vec3A {
         (u32x4_bitmask(self.0) & 0x7) as u32
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3A {
+        BVec3A(i32x4_lt(self.0, i32x4_splat(0)))
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f32/wasm/vec4.rs
+++ b/src/f32/wasm/vec4.rs
@@ -489,6 +489,16 @@ impl Vec4 {
         u32x4_bitmask(self.0) as u32
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec4A {
+        BVec4A(i32x4_lt(self.0, i32x4_splat(0)))
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -431,6 +431,16 @@ impl DVec2 {
         (self.x.is_sign_negative() as u32) | ((self.y.is_sign_negative() as u32) << 1)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec2 {
+        BVec2::new(self.x.is_sign_negative(), self.y.is_sign_negative())
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -515,6 +515,20 @@ impl DVec3 {
             | ((self.z.is_sign_negative() as u32) << 2)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3 {
+        BVec3::new(
+            self.x.is_sign_negative(),
+            self.y.is_sign_negative(),
+            self.z.is_sign_negative(),
+        )
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -548,6 +548,21 @@ impl DVec4 {
             | ((self.w.is_sign_negative() as u32) << 3)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec4 {
+        BVec4::new(
+            self.x.is_sign_negative(),
+            self.y.is_sign_negative(),
+            self.z.is_sign_negative(),
+            self.w.is_sign_negative(),
+        )
+    }
+
     /// Returns `true` if, and only if, all elements are finite.  If any element is either
     /// `NaN`, positive or negative infinity, this will return `false`.
     #[inline]

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -403,6 +403,16 @@ impl I16Vec2 {
         (self.x.is_negative() as u32) | ((self.y.is_negative() as u32) << 1)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec2 {
+        BVec2::new(self.x.is_negative(), self.y.is_negative())
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -467,6 +467,20 @@ impl I16Vec3 {
             | ((self.z.is_negative() as u32) << 2)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3 {
+        BVec3::new(
+            self.x.is_negative(),
+            self.y.is_negative(),
+            self.z.is_negative(),
+        )
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -507,6 +507,21 @@ impl I16Vec4 {
             | ((self.w.is_negative() as u32) << 3)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec4 {
+        BVec4::new(
+            self.x.is_negative(),
+            self.y.is_negative(),
+            self.z.is_negative(),
+            self.w.is_negative(),
+        )
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -403,6 +403,16 @@ impl IVec2 {
         (self.x.is_negative() as u32) | ((self.y.is_negative() as u32) << 1)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec2 {
+        BVec2::new(self.x.is_negative(), self.y.is_negative())
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -467,6 +467,20 @@ impl IVec3 {
             | ((self.z.is_negative() as u32) << 2)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3 {
+        BVec3::new(
+            self.x.is_negative(),
+            self.y.is_negative(),
+            self.z.is_negative(),
+        )
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -507,6 +507,21 @@ impl IVec4 {
             | ((self.w.is_negative() as u32) << 3)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec4 {
+        BVec4::new(
+            self.x.is_negative(),
+            self.y.is_negative(),
+            self.z.is_negative(),
+            self.w.is_negative(),
+        )
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -403,6 +403,16 @@ impl I64Vec2 {
         (self.x.is_negative() as u32) | ((self.y.is_negative() as u32) << 1)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec2 {
+        BVec2::new(self.x.is_negative(), self.y.is_negative())
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -467,6 +467,20 @@ impl I64Vec3 {
             | ((self.z.is_negative() as u32) << 2)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3 {
+        BVec3::new(
+            self.x.is_negative(),
+            self.y.is_negative(),
+            self.z.is_negative(),
+        )
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -507,6 +507,21 @@ impl I64Vec4 {
             | ((self.w.is_negative() as u32) << 3)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec4 {
+        BVec4::new(
+            self.x.is_negative(),
+            self.y.is_negative(),
+            self.z.is_negative(),
+            self.w.is_negative(),
+        )
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -403,6 +403,16 @@ impl I8Vec2 {
         (self.x.is_negative() as u32) | ((self.y.is_negative() as u32) << 1)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec2 {
+        BVec2::new(self.x.is_negative(), self.y.is_negative())
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -467,6 +467,20 @@ impl I8Vec3 {
             | ((self.z.is_negative() as u32) << 2)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3 {
+        BVec3::new(
+            self.x.is_negative(),
+            self.y.is_negative(),
+            self.z.is_negative(),
+        )
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -507,6 +507,21 @@ impl I8Vec4 {
             | ((self.w.is_negative() as u32) << 3)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec4 {
+        BVec4::new(
+            self.x.is_negative(),
+            self.y.is_negative(),
+            self.z.is_negative(),
+            self.w.is_negative(),
+        )
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/isize/isizevec2.rs
+++ b/src/isize/isizevec2.rs
@@ -403,6 +403,16 @@ impl ISizeVec2 {
         (self.x.is_negative() as u32) | ((self.y.is_negative() as u32) << 1)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec2 {
+        BVec2::new(self.x.is_negative(), self.y.is_negative())
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/isize/isizevec3.rs
+++ b/src/isize/isizevec3.rs
@@ -467,6 +467,20 @@ impl ISizeVec3 {
             | ((self.z.is_negative() as u32) << 2)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec3 {
+        BVec3::new(
+            self.x.is_negative(),
+            self.y.is_negative(),
+            self.z.is_negative(),
+        )
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/src/isize/isizevec4.rs
+++ b/src/isize/isizevec4.rs
@@ -507,6 +507,21 @@ impl ISizeVec4 {
             | ((self.w.is_negative() as u32) << 3)
     }
 
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> BVec4 {
+        BVec4::new(
+            self.x.is_negative(),
+            self.y.is_negative(),
+            self.z.is_negative(),
+            self.w.is_negative(),
+        )
+    }
+
     /// Computes the squared length of `self`.
     #[doc(alias = "magnitude2")]
     #[inline]

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -1597,6 +1597,46 @@ impl {{ self_t }} {
             unimplemented!()
         {% endif %}
     }
+
+    /// Returns a mask indicating which components are negative.
+    ///
+    /// An element is negative if it has a negative sign, including -0.0, NaNs with negative sign
+    /// bit and negative infinity.
+    #[inline]
+    #[must_use]
+    pub fn is_negative_mask(self) -> {{ mask_t }} {
+        {% if is_scalar and is_float %}
+            {{ mask_t }}::new(
+                {% for c in components %}
+                    self.{{ c }}.is_sign_negative(),
+                {%- endfor %}
+            )
+        {% elif is_scalar %}
+            {{ mask_t }}::new(
+                {% for c in components %}
+                    self.{{ c }}.is_negative(),
+                {%- endfor %}
+            )
+        {% elif is_sse2 %}
+            {{ mask_t }}(unsafe {
+                _mm_castsi128_ps(_mm_cmplt_epi32(_mm_castps_si128(self.0), _mm_setzero_si128()))
+            })
+        {% elif is_wasm %}
+            {{ mask_t }}(
+                i32x4_lt(self.0, i32x4_splat(0))
+            )
+        {% elif is_coresimd %}
+            {{ mask_t }}(
+                self.0.is_sign_negative()
+            )
+        {% elif is_neon %}
+            {{ mask_t }}(unsafe {
+                vcltq_s32(vreinterpretq_s32_f32(self.0), vdupq_n_s32(0))
+            })
+        {% else %}
+            unimplemented!()
+        {% endif %}
+    }
 {% endif %}
 
 {% if is_float %}

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -835,6 +835,28 @@ macro_rules! impl_vec2_signed_tests {
             assert_eq!($vec2::new(-2 as $t, -6 as $t).is_negative_bitmask(), 0b11);
         });
 
+        glam_test!(test_is_negative_mask, {
+            assert_eq!($vec2::ZERO.is_negative_mask(), $mask::new(false, false));
+            assert_eq!($vec2::ONE.is_negative_mask(), $mask::new(false, false));
+            assert_eq!((-$vec2::ONE).is_negative_mask(), $mask::new(true, true));
+            assert_eq!(
+                $vec2::new(-1 as $t, 2 as $t).is_negative_mask(),
+                $mask::new(true, false)
+            );
+            assert_eq!(
+                $vec2::new(8 as $t, 3 as $t).is_negative_mask(),
+                $mask::new(false, false)
+            );
+            assert_eq!(
+                $vec2::new(3 as $t, -4 as $t).is_negative_mask(),
+                $mask::new(false, true)
+            );
+            assert_eq!(
+                $vec2::new(-2 as $t, -6 as $t).is_negative_mask(),
+                $mask::new(true, true)
+            );
+        });
+
         glam_test!(test_abs, {
             assert_eq!($vec2::ZERO.abs(), $vec2::ZERO);
             assert_eq!($vec2::ONE.abs(), $vec2::ONE);
@@ -1316,6 +1338,29 @@ macro_rules! impl_vec2_float_tests {
             assert_eq!($vec2::new(8.0, 3.0).is_negative_bitmask(), 0b00);
             assert_eq!($vec2::new(3.0, -4.0).is_negative_bitmask(), 0b10);
             assert_eq!($vec2::new(-2.0, -6.0).is_negative_bitmask(), 0b11);
+        });
+
+        glam_test!(test_float_is_negative_mask, {
+            assert_eq!($vec2::ZERO.is_negative_mask(), $mask::new(false, false));
+            assert_eq!((-$vec2::ZERO).is_negative_mask(), $mask::new(true, true));
+            assert_eq!($vec2::ONE.is_negative_mask(), $mask::new(false, false));
+            assert_eq!((-$vec2::ONE).is_negative_mask(), $mask::new(true, true));
+            assert_eq!(
+                $vec2::new(-1.0, 2.0).is_negative_mask(),
+                $mask::new(true, false)
+            );
+            assert_eq!(
+                $vec2::new(8.0, 3.0).is_negative_mask(),
+                $mask::new(false, false)
+            );
+            assert_eq!(
+                $vec2::new(3.0, -4.0).is_negative_mask(),
+                $mask::new(false, true)
+            );
+            assert_eq!(
+                $vec2::new(-2.0, -6.0).is_negative_mask(),
+                $mask::new(true, true)
+            );
         });
 
         glam_test!(test_round, {

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -981,6 +981,41 @@ macro_rules! impl_vec3_signed_tests {
             );
         });
 
+        glam_test!(test_is_negative_mask, {
+            assert_eq!(
+                $vec3::ZERO.is_negative_mask(),
+                $mask::new(false, false, false)
+            );
+            assert_eq!(
+                $vec3::ONE.is_negative_mask(),
+                $mask::new(false, false, false)
+            );
+            assert_eq!(
+                (-$vec3::ONE).is_negative_mask(),
+                $mask::new(true, true, true)
+            );
+            assert_eq!(
+                $vec3::new(-1 as $t, 2 as $t, 3 as $t).is_negative_mask(),
+                $mask::new(true, false, false)
+            );
+            assert_eq!(
+                $vec3::new(8 as $t, 3 as $t, 1 as $t).is_negative_mask(),
+                $mask::new(false, false, false)
+            );
+            assert_eq!(
+                $vec3::new(1 as $t, 5 as $t, -3 as $t).is_negative_mask(),
+                $mask::new(false, false, true)
+            );
+            assert_eq!(
+                $vec3::new(3 as $t, -4 as $t, 1 as $t).is_negative_mask(),
+                $mask::new(false, true, false)
+            );
+            assert_eq!(
+                $vec3::new(-2 as $t, 6 as $t, -5 as $t).is_negative_mask(),
+                $mask::new(true, false, true)
+            );
+        });
+
         glam_test!(test_abs, {
             assert_eq!($vec3::ZERO.abs(), $vec3::ZERO);
             assert_eq!($vec3::ONE.abs(), $vec3::ONE);
@@ -1488,6 +1523,45 @@ macro_rules! impl_vec3_float_tests {
             assert_eq!($vec3::new(1.0, 5.0, -3.0).is_negative_bitmask(), 0b100);
             assert_eq!($vec3::new(3.0, -4.0, 1.0).is_negative_bitmask(), 0b010);
             assert_eq!($vec3::new(-2.0, 6.0, -5.0).is_negative_bitmask(), 0b101);
+        });
+
+        glam_test!(test_float_is_negative_mask, {
+            assert_eq!(
+                $vec3::ZERO.is_negative_mask(),
+                $mask::new(false, false, false)
+            );
+            assert_eq!(
+                (-$vec3::ZERO).is_negative_mask(),
+                $mask::new(true, true, true)
+            );
+            assert_eq!(
+                $vec3::ONE.is_negative_mask(),
+                $mask::new(false, false, false)
+            );
+            assert_eq!(
+                (-$vec3::ONE).is_negative_mask(),
+                $mask::new(true, true, true)
+            );
+            assert_eq!(
+                $vec3::new(-1.0, 2.0, 3.0).is_negative_mask(),
+                $mask::new(true, false, false)
+            );
+            assert_eq!(
+                $vec3::new(8.0, 3.0, 1.0).is_negative_mask(),
+                $mask::new(false, false, false)
+            );
+            assert_eq!(
+                $vec3::new(1.0, 5.0, -3.0).is_negative_mask(),
+                $mask::new(false, false, true)
+            );
+            assert_eq!(
+                $vec3::new(3.0, -4.0, 1.0).is_negative_mask(),
+                $mask::new(false, true, false)
+            );
+            assert_eq!(
+                $vec3::new(-2.0, 6.0, -5.0).is_negative_mask(),
+                $mask::new(true, false, true)
+            );
         });
 
         glam_test!(test_round, {

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1138,6 +1138,37 @@ macro_rules! impl_vec4_signed_tests {
             );
         });
 
+        glam_test!(test_is_negative_mask, {
+            assert_eq!(
+                $vec4::ZERO.is_negative_mask(),
+                $mask::new(false, false, false, false)
+            );
+            assert_eq!(
+                $vec4::ONE.is_negative_mask(),
+                $mask::new(false, false, false, false)
+            );
+            assert_eq!(
+                (-$vec4::ONE).is_negative_mask(),
+                $mask::new(true, true, true, true)
+            );
+            assert_eq!(
+                $vec4::new(-1 as $t, 2 as $t, 3 as $t, -4 as $t).is_negative_mask(),
+                $mask::new(true, false, false, true)
+            );
+            assert_eq!(
+                $vec4::new(1 as $t, 5 as $t, -3 as $t, 7 as $t).is_negative_mask(),
+                $mask::new(false, false, true, false)
+            );
+            assert_eq!(
+                $vec4::new(3 as $t, -4 as $t, 1 as $t, 6 as $t).is_negative_mask(),
+                $mask::new(false, true, false, false)
+            );
+            assert_eq!(
+                $vec4::new(2 as $t, -6 as $t, 5 as $t, -3 as $t).is_negative_mask(),
+                $mask::new(false, true, false, true)
+            );
+        });
+
         glam_test!(test_abs, {
             assert_eq!($vec4::ZERO.abs(), $vec4::ZERO);
             assert_eq!($vec4::ONE.abs(), $vec4::ONE);
@@ -1672,6 +1703,45 @@ macro_rules! impl_vec4_float_tests {
             assert_eq!(
                 $vec4::new(2.0, -6.0, 5.0, -3.0).is_negative_bitmask(),
                 0b1010
+            );
+        });
+
+        glam_test!(test_float_is_negative_mask, {
+            assert_eq!(
+                $vec4::ZERO.is_negative_mask(),
+                $mask::new(false, false, false, false)
+            );
+            assert_eq!(
+                (-$vec4::ZERO).is_negative_mask(),
+                $mask::new(true, true, true, true)
+            );
+            assert_eq!(
+                $vec4::ONE.is_negative_mask(),
+                $mask::new(false, false, false, false)
+            );
+            assert_eq!(
+                (-$vec4::ONE).is_negative_mask(),
+                $mask::new(true, true, true, true)
+            );
+            assert_eq!(
+                $vec4::new(-1.0, 2.0, 3.0, -4.0).is_negative_mask(),
+                $mask::new(true, false, false, true)
+            );
+            assert_eq!(
+                $vec4::new(8.0, 3.0, 1.0, -0.0).is_negative_mask(),
+                $mask::new(false, false, false, true)
+            );
+            assert_eq!(
+                $vec4::new(1.0, 5.0, -3.0, 7.0).is_negative_mask(),
+                $mask::new(false, false, true, false)
+            );
+            assert_eq!(
+                $vec4::new(3.0, -4.0, 1.0, 6.0).is_negative_mask(),
+                $mask::new(false, true, false, false)
+            );
+            assert_eq!(
+                $vec4::new(2.0, -6.0, 5.0, -3.0).is_negative_mask(),
+                $mask::new(false, true, false, true)
             );
         });
 


### PR DESCRIPTION
# Objective

- Implements the `.is_negative_mask()` method for all relevant vector types (`f32`, `f64`, and signed integers) to match the return type conventions of other comparison methods like `cmplt`.
- Fixes #748 

## Solution

- Added the base logic to `templates/vec.rs.tera` to generate the implementations.
- Utilized `.is_sign_negative()` for scalar floats.
- For SIMD paths, utilized integer bitcasting and sign-bit extraction (e.g., `_mm_cmplt_epi32` with `_mm_castps_si128` for SSE2, and `vcltq_s32` with `vreinterpretq_s32_f32` for NEON) to capture `-0.0` and negative NaNs without branching.

## Code generation

- [ ] Are you modify generated code?
- [x] Have you modified the templates and run the code generator?

Yes, all changes were made in `templates/vec.rs.tera` and generated via `cargo run --release -p codegen`.

## Testing and linting

- [x] Added `test_is_negative_mask` and `test_float_is_negative_mask` blocks to the manual test files (`tests/vec2.rs`, `tests/vec3.rs`, `tests/vec4.rs`).
- [x] Ran `cargo run -p ci` locally. All tests and Clippy checks pass cleanly.
