### PR TITLE
Issue 514

### DIFF
--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -645,8 +645,8 @@ impl Quat {
         positive_w_angle < THRESHOLD_ANGLE
     }
 
-    /// Returns the angle (in radians) for the minimal rotation
-    /// for transforming this quaternion into another.
+    /// Returns the angle (in radians) for the minimal rotation between two quaternions
+    /// in the range `[0, +π]`.
     ///
     /// Both quaternions must be normalized.
     ///

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -1070,6 +1070,9 @@ impl Vec3A {
 
     /// Returns the angle (in radians) between two vectors in the range `[0, +π]`.
     ///
+    /// For the full rotation between two vectors as a quaternion, see
+    /// [`Quat::from_rotation_arc`].
+    ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     #[inline]
     #[must_use]

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -543,6 +543,12 @@ impl Vec3A {
         dot.sqrt()[0]
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.
@@ -1077,6 +1083,8 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::acos_approx(
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
@@ -1102,6 +1110,8 @@ impl Vec3A {
     #[must_use]
     pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
         glam_assert!(axis.is_normalized());
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
     }
 

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -1080,6 +1080,10 @@ impl Vec3A {
     /// [`Quat::from_rotation_arc`].
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
@@ -1105,6 +1109,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[doc(alias = "signed_angle")]
     #[inline]
     #[must_use]

--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -1083,6 +1083,28 @@ impl Vec3A {
         )
     }
 
+    /// Returns the signed angle (in radians) from `self` to `rhs` around `axis`
+    /// in the range `[-π, +π]`.
+    ///
+    /// The `axis` must be a unit vector. The angle follows the right-hand rule
+    /// around `axis` and can be used with [`Self::rotate_axis`], e.g.
+    /// `self.rotate_axis(axis, self.angle_to(rhs, axis))` will be equal to `rhs`.
+    ///
+    /// For the unsigned angle without a reference axis, see [`Self::angle_between`].
+    ///
+    /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    #[doc(alias = "signed_angle")]
+    #[inline]
+    #[must_use]
+    pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
+        glam_assert!(axis.is_normalized());
+        math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
+    }
+
     /// Rotates around the x axis by `angle` (in radians).
     #[inline]
     #[must_use]

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -522,6 +522,12 @@ impl Vec4 {
         dot.sqrt()[0]
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.

--- a/src/f32/neon/quat.rs
+++ b/src/f32/neon/quat.rs
@@ -657,8 +657,8 @@ impl Quat {
         positive_w_angle < THRESHOLD_ANGLE
     }
 
-    /// Returns the angle (in radians) for the minimal rotation
-    /// for transforming this quaternion into another.
+    /// Returns the angle (in radians) for the minimal rotation between two quaternions
+    /// in the range `[0, +π]`.
     ///
     /// Both quaternions must be normalized.
     ///

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -594,6 +594,12 @@ impl Vec3A {
         math::sqrt(self.dot(self))
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.
@@ -1126,6 +1132,8 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::acos_approx(
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
@@ -1151,6 +1159,8 @@ impl Vec3A {
     #[must_use]
     pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
         glam_assert!(axis.is_normalized());
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
     }
 

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -1119,6 +1119,9 @@ impl Vec3A {
 
     /// Returns the angle (in radians) between two vectors in the range `[0, +π]`.
     ///
+    /// For the full rotation between two vectors as a quaternion, see
+    /// [`Quat::from_rotation_arc`].
+    ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     #[inline]
     #[must_use]

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -1132,6 +1132,28 @@ impl Vec3A {
         )
     }
 
+    /// Returns the signed angle (in radians) from `self` to `rhs` around `axis`
+    /// in the range `[-π, +π]`.
+    ///
+    /// The `axis` must be a unit vector. The angle follows the right-hand rule
+    /// around `axis` and can be used with [`Self::rotate_axis`], e.g.
+    /// `self.rotate_axis(axis, self.angle_to(rhs, axis))` will be equal to `rhs`.
+    ///
+    /// For the unsigned angle without a reference axis, see [`Self::angle_between`].
+    ///
+    /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    #[doc(alias = "signed_angle")]
+    #[inline]
+    #[must_use]
+    pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
+        glam_assert!(axis.is_normalized());
+        math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
+    }
+
     /// Rotates around the x axis by `angle` (in radians).
     #[inline]
     #[must_use]

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -1129,6 +1129,10 @@ impl Vec3A {
     /// [`Quat::from_rotation_arc`].
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
@@ -1154,6 +1158,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[doc(alias = "signed_angle")]
     #[inline]
     #[must_use]

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -560,6 +560,12 @@ impl Vec4 {
         math::sqrt(self.dot(self))
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -659,8 +659,8 @@ impl Quat {
         positive_w_angle < THRESHOLD_ANGLE
     }
 
-    /// Returns the angle (in radians) for the minimal rotation
-    /// for transforming this quaternion into another.
+    /// Returns the angle (in radians) for the minimal rotation between two quaternions
+    /// in the range `[0, +π]`.
     ///
     /// Both quaternions must be normalized.
     ///

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -1135,6 +1135,10 @@ impl Vec3A {
     /// [`Quat::from_rotation_arc`].
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
@@ -1160,6 +1164,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[doc(alias = "signed_angle")]
     #[inline]
     #[must_use]

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -1125,6 +1125,9 @@ impl Vec3A {
 
     /// Returns the angle (in radians) between two vectors in the range `[0, +π]`.
     ///
+    /// For the full rotation between two vectors as a quaternion, see
+    /// [`Quat::from_rotation_arc`].
+    ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     #[inline]
     #[must_use]

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -576,6 +576,12 @@ impl Vec3A {
         math::sqrt(self.dot(self))
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.
@@ -1132,6 +1138,8 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::acos_approx(
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
@@ -1157,6 +1165,8 @@ impl Vec3A {
     #[must_use]
     pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
         glam_assert!(axis.is_normalized());
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
     }
 

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -1138,6 +1138,28 @@ impl Vec3A {
         )
     }
 
+    /// Returns the signed angle (in radians) from `self` to `rhs` around `axis`
+    /// in the range `[-π, +π]`.
+    ///
+    /// The `axis` must be a unit vector. The angle follows the right-hand rule
+    /// around `axis` and can be used with [`Self::rotate_axis`], e.g.
+    /// `self.rotate_axis(axis, self.angle_to(rhs, axis))` will be equal to `rhs`.
+    ///
+    /// For the unsigned angle without a reference axis, see [`Self::angle_between`].
+    ///
+    /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    #[doc(alias = "signed_angle")]
+    #[inline]
+    #[must_use]
+    pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
+        glam_assert!(axis.is_normalized());
+        math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
+    }
+
     /// Rotates around the x axis by `angle` (in radians).
     #[inline]
     #[must_use]

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -613,6 +613,12 @@ impl Vec4 {
         math::sqrt(self.dot(self))
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -660,8 +660,8 @@ impl Quat {
         positive_w_angle < THRESHOLD_ANGLE
     }
 
-    /// Returns the angle (in radians) for the minimal rotation
-    /// for transforming this quaternion into another.
+    /// Returns the angle (in radians) for the minimal rotation between two quaternions
+    /// in the range `[0, +π]`.
     ///
     /// Both quaternions must be normalized.
     ///

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -1142,6 +1142,10 @@ impl Vec3A {
     /// [`Quat::from_rotation_arc`].
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
@@ -1167,6 +1171,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[doc(alias = "signed_angle")]
     #[inline]
     #[must_use]

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -1132,6 +1132,9 @@ impl Vec3A {
 
     /// Returns the angle (in radians) between two vectors in the range `[0, +π]`.
     ///
+    /// For the full rotation between two vectors as a quaternion, see
+    /// [`Quat::from_rotation_arc`].
+    ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     #[inline]
     #[must_use]

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -1145,6 +1145,28 @@ impl Vec3A {
         )
     }
 
+    /// Returns the signed angle (in radians) from `self` to `rhs` around `axis`
+    /// in the range `[-π, +π]`.
+    ///
+    /// The `axis` must be a unit vector. The angle follows the right-hand rule
+    /// around `axis` and can be used with [`Self::rotate_axis`], e.g.
+    /// `self.rotate_axis(axis, self.angle_to(rhs, axis))` will be equal to `rhs`.
+    ///
+    /// For the unsigned angle without a reference axis, see [`Self::angle_between`].
+    ///
+    /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    #[doc(alias = "signed_angle")]
+    #[inline]
+    #[must_use]
+    pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
+        glam_assert!(axis.is_normalized());
+        math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
+    }
+
     /// Rotates around the x axis by `angle` (in radians).
     #[inline]
     #[must_use]

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -592,6 +592,12 @@ impl Vec3A {
         }
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.
@@ -1139,6 +1145,8 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::acos_approx(
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
@@ -1164,6 +1172,8 @@ impl Vec3A {
     #[must_use]
     pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
         glam_assert!(axis.is_normalized());
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
     }
 

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -567,6 +567,12 @@ impl Vec4 {
         }
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -1029,9 +1029,8 @@ impl Vec2 {
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     ///
-    /// The returned angle can be used with [`from_angle()`][Self::from_angle] and
-    /// [`rotate()`][Self::rotate], e.g.
-    /// `Vec2::from_angle(self.angle_to(rhs)).rotate(self)` will be equal to `rhs`.
+    /// The returned angle can be used with [`rotate_angle()`][Self::rotate_angle], e.g.
+    /// `self.rotate_angle(self.angle_to(rhs))` will be equal to `rhs`.
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> f32 {
@@ -1077,6 +1076,14 @@ impl Vec2 {
             x: self.x * rhs.x - self.y * rhs.y,
             y: self.y * rhs.x + self.x * rhs.y,
         }
+    }
+
+    /// Rotates `self` by `angle` (in radians), equivalent to
+    /// `self.rotate(Vec2::from_angle(angle))`.
+    #[inline]
+    #[must_use]
+    pub fn rotate_angle(self, angle: f32) -> Self {
+        self.rotate(Self::from_angle(angle))
     }
 
     /// Rotates towards `rhs` up to `max_angle` (in radians).

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -1037,6 +1037,10 @@ impl Vec2 {
     ///
     /// The returned angle can be used with [`rotate_angle()`][Self::rotate_angle], e.g.
     /// `self.rotate_angle(self.angle_to(rhs))` will be equal to `rhs`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> f32 {

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -474,6 +474,12 @@ impl Vec2 {
         math::sqrt(self.dot(self))
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.
@@ -1034,6 +1040,8 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> f32 {
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         let angle = math::acos_approx(
             self.dot(rhs) / math::sqrt(self.length_squared() * rhs.length_squared()),
         );

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -1028,6 +1028,10 @@ impl Vec2 {
     /// Returns the angle of rotation (in radians) from `self` to `rhs` in the range `[-π, +π]`.
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// The returned angle can be used with [`from_angle()`][Self::from_angle] and
+    /// [`rotate()`][Self::rotate], e.g.
+    /// `Vec2::from_angle(self.angle_to(rhs)).rotate(self)` will be equal to `rhs`.
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> f32 {

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -1128,6 +1128,10 @@ impl Vec3 {
     /// [`Quat::from_rotation_arc`].
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
@@ -1153,6 +1157,7 @@ impl Vec3 {
     /// # Panics
     ///
     /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[doc(alias = "signed_angle")]
     #[inline]
     #[must_use]

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -1118,6 +1118,9 @@ impl Vec3 {
 
     /// Returns the angle (in radians) between two vectors in the range `[0, +π]`.
     ///
+    /// For the full rotation between two vectors as a quaternion, see
+    /// [`Quat::from_rotation_arc`].
+    ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     #[inline]
     #[must_use]

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -1131,6 +1131,28 @@ impl Vec3 {
         )
     }
 
+    /// Returns the signed angle (in radians) from `self` to `rhs` around `axis`
+    /// in the range `[-π, +π]`.
+    ///
+    /// The `axis` must be a unit vector. The angle follows the right-hand rule
+    /// around `axis` and can be used with [`Self::rotate_axis`], e.g.
+    /// `self.rotate_axis(axis, self.angle_to(rhs, axis))` will be equal to `rhs`.
+    ///
+    /// For the unsigned angle without a reference axis, see [`Self::angle_between`].
+    ///
+    /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    #[doc(alias = "signed_angle")]
+    #[inline]
+    #[must_use]
+    pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
+        glam_assert!(axis.is_normalized());
+        math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
+    }
+
     /// Rotates around the x axis by `angle` (in radians).
     #[inline]
     #[must_use]

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -569,6 +569,12 @@ impl Vec3 {
         math::sqrt(self.dot(self))
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.
@@ -1125,6 +1131,8 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::acos_approx(
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
@@ -1150,6 +1158,8 @@ impl Vec3 {
     #[must_use]
     pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
         glam_assert!(axis.is_normalized());
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
     }
 

--- a/src/f32/wasm/quat.rs
+++ b/src/f32/wasm/quat.rs
@@ -655,8 +655,8 @@ impl Quat {
         positive_w_angle < THRESHOLD_ANGLE
     }
 
-    /// Returns the angle (in radians) for the minimal rotation
-    /// for transforming this quaternion into another.
+    /// Returns the angle (in radians) for the minimal rotation between two quaternions
+    /// in the range `[0, +π]`.
     ///
     /// Both quaternions must be normalized.
     ///

--- a/src/f32/wasm/vec3a.rs
+++ b/src/f32/wasm/vec3a.rs
@@ -562,6 +562,12 @@ impl Vec3A {
         f32x4_extract_lane::<0>(f32x4_sqrt(dot))
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.
@@ -1100,6 +1106,8 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::acos_approx(
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
@@ -1125,6 +1133,8 @@ impl Vec3A {
     #[must_use]
     pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
         glam_assert!(axis.is_normalized());
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
     }
 

--- a/src/f32/wasm/vec3a.rs
+++ b/src/f32/wasm/vec3a.rs
@@ -1106,6 +1106,28 @@ impl Vec3A {
         )
     }
 
+    /// Returns the signed angle (in radians) from `self` to `rhs` around `axis`
+    /// in the range `[-π, +π]`.
+    ///
+    /// The `axis` must be a unit vector. The angle follows the right-hand rule
+    /// around `axis` and can be used with [`Self::rotate_axis`], e.g.
+    /// `self.rotate_axis(axis, self.angle_to(rhs, axis))` will be equal to `rhs`.
+    ///
+    /// For the unsigned angle without a reference axis, see [`Self::angle_between`].
+    ///
+    /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    #[doc(alias = "signed_angle")]
+    #[inline]
+    #[must_use]
+    pub fn angle_to(self, rhs: Self, axis: Self) -> f32 {
+        glam_assert!(axis.is_normalized());
+        math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
+    }
+
     /// Rotates around the x axis by `angle` (in radians).
     #[inline]
     #[must_use]

--- a/src/f32/wasm/vec3a.rs
+++ b/src/f32/wasm/vec3a.rs
@@ -1103,6 +1103,10 @@ impl Vec3A {
     /// [`Quat::from_rotation_arc`].
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f32 {
@@ -1128,6 +1132,7 @@ impl Vec3A {
     /// # Panics
     ///
     /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[doc(alias = "signed_angle")]
     #[inline]
     #[must_use]

--- a/src/f32/wasm/vec3a.rs
+++ b/src/f32/wasm/vec3a.rs
@@ -1093,6 +1093,9 @@ impl Vec3A {
 
     /// Returns the angle (in radians) between two vectors in the range `[0, +π]`.
     ///
+    /// For the full rotation between two vectors as a quaternion, see
+    /// [`Quat::from_rotation_arc`].
+    ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     #[inline]
     #[must_use]

--- a/src/f32/wasm/vec4.rs
+++ b/src/f32/wasm/vec4.rs
@@ -541,6 +541,12 @@ impl Vec4 {
         f32x4_extract_lane::<0>(f32x4_sqrt(dot))
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -641,8 +641,8 @@ impl DQuat {
         positive_w_angle < THRESHOLD_ANGLE
     }
 
-    /// Returns the angle (in radians) for the minimal rotation
-    /// for transforming this quaternion into another.
+    /// Returns the angle (in radians) for the minimal rotation between two quaternions
+    /// in the range `[0, +π]`.
     ///
     /// Both quaternions must be normalized.
     ///

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -482,6 +482,12 @@ impl DVec2 {
         math::sqrt(self.dot(self))
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.
@@ -1042,6 +1048,8 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> f64 {
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         let angle = math::acos_approx(
             self.dot(rhs) / math::sqrt(self.length_squared() * rhs.length_squared()),
         );

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -1036,6 +1036,10 @@ impl DVec2 {
     /// Returns the angle of rotation (in radians) from `self` to `rhs` in the range `[-π, +π]`.
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// The returned angle can be used with [`from_angle()`][Self::from_angle] and
+    /// [`rotate()`][Self::rotate], e.g.
+    /// `DVec2::from_angle(self.angle_to(rhs)).rotate(self)` will be equal to `rhs`.
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> f64 {

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -1037,9 +1037,8 @@ impl DVec2 {
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     ///
-    /// The returned angle can be used with [`from_angle()`][Self::from_angle] and
-    /// [`rotate()`][Self::rotate], e.g.
-    /// `DVec2::from_angle(self.angle_to(rhs)).rotate(self)` will be equal to `rhs`.
+    /// The returned angle can be used with [`rotate_angle()`][Self::rotate_angle], e.g.
+    /// `self.rotate_angle(self.angle_to(rhs))` will be equal to `rhs`.
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> f64 {
@@ -1085,6 +1084,14 @@ impl DVec2 {
             x: self.x * rhs.x - self.y * rhs.y,
             y: self.y * rhs.x + self.x * rhs.y,
         }
+    }
+
+    /// Rotates `self` by `angle` (in radians), equivalent to
+    /// `self.rotate(DVec2::from_angle(angle))`.
+    #[inline]
+    #[must_use]
+    pub fn rotate_angle(self, angle: f64) -> Self {
+        self.rotate(Self::from_angle(angle))
     }
 
     /// Rotates towards `rhs` up to `max_angle` (in radians).

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -1045,6 +1045,10 @@ impl DVec2 {
     ///
     /// The returned angle can be used with [`rotate_angle()`][Self::rotate_angle], e.g.
     /// `self.rotate_angle(self.angle_to(rhs))` will be equal to `rhs`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> f64 {

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -570,6 +570,12 @@ impl DVec3 {
         math::sqrt(self.dot(self))
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.
@@ -1126,6 +1132,8 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f64 {
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::acos_approx(
             self.dot(rhs)
                 .div(math::sqrt(self.length_squared().mul(rhs.length_squared()))),
@@ -1151,6 +1159,8 @@ impl DVec3 {
     #[must_use]
     pub fn angle_to(self, rhs: Self, axis: Self) -> f64 {
         glam_assert!(axis.is_normalized());
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
     }
 

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -1132,6 +1132,28 @@ impl DVec3 {
         )
     }
 
+    /// Returns the signed angle (in radians) from `self` to `rhs` around `axis`
+    /// in the range `[-π, +π]`.
+    ///
+    /// The `axis` must be a unit vector. The angle follows the right-hand rule
+    /// around `axis` and can be used with [`Self::rotate_axis`], e.g.
+    /// `self.rotate_axis(axis, self.angle_to(rhs, axis))` will be equal to `rhs`.
+    ///
+    /// For the unsigned angle without a reference axis, see [`Self::angle_between`].
+    ///
+    /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    #[doc(alias = "signed_angle")]
+    #[inline]
+    #[must_use]
+    pub fn angle_to(self, rhs: Self, axis: Self) -> f64 {
+        glam_assert!(axis.is_normalized());
+        math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
+    }
+
     /// Rotates around the x axis by `angle` (in radians).
     #[inline]
     #[must_use]

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -1119,6 +1119,9 @@ impl DVec3 {
 
     /// Returns the angle (in radians) between two vectors in the range `[0, +π]`.
     ///
+    /// For the full rotation between two vectors as a quaternion, see
+    /// [`DQuat::from_rotation_arc`].
+    ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     #[inline]
     #[must_use]

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -1129,6 +1129,10 @@ impl DVec3 {
     /// [`DQuat::from_rotation_arc`].
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> f64 {
@@ -1154,6 +1158,7 @@ impl DVec3 {
     /// # Panics
     ///
     /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[doc(alias = "signed_angle")]
     #[inline]
     #[must_use]

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -614,6 +614,12 @@ impl DVec4 {
         math::sqrt(self.dot(self))
     }
 
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
+
     /// Computes the squared length of `self`.
     ///
     /// This is faster than `length()` as it avoids a square root operation.

--- a/templates/quat.rs.tera
+++ b/templates/quat.rs.tera
@@ -798,8 +798,8 @@ impl {{ self_t }} {
         positive_w_angle < THRESHOLD_ANGLE
     }
 
-    /// Returns the angle (in radians) for the minimal rotation
-    /// for transforming this quaternion into another.
+    /// Returns the angle (in radians) for the minimal rotation between two quaternions
+    /// in the range `[0, +π]`.
     ///
     /// Both quaternions must be normalized.
     ///

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -2478,6 +2478,10 @@ impl {{ self_t }} {
     /// Returns the angle of rotation (in radians) from `self` to `rhs` in the range `[-π, +π]`.
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// The returned angle can be used with [`from_angle()`][Self::from_angle] and
+    /// [`rotate()`][Self::rotate], e.g.
+    /// `{{ vec2_t }}::from_angle(self.angle_to(rhs)).rotate(self)` will be equal to `rhs`.
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> {{ scalar_t }} {
@@ -2499,6 +2503,28 @@ impl {{ self_t }} {
         math::acos_approx(
             self.dot(rhs).div(
                 math::sqrt(self.length_squared().mul(rhs.length_squared()))))
+    }
+
+    /// Returns the signed angle (in radians) from `self` to `rhs` around `axis`
+    /// in the range `[-π, +π]`.
+    ///
+    /// The `axis` must be a unit vector. The angle follows the right-hand rule
+    /// around `axis` and can be used with [`Self::rotate_axis`], e.g.
+    /// `self.rotate_axis(axis, self.angle_to(rhs, axis))` will be equal to `rhs`.
+    ///
+    /// For the unsigned angle without a reference axis, see [`Self::angle_between`].
+    ///
+    /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    #[doc(alias = "signed_angle")]
+    #[inline]
+    #[must_use]
+    pub fn angle_to(self, rhs: Self, axis: Self) -> {{ scalar_t }} {
+        glam_assert!(axis.is_normalized());
+        math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
     }
 
     /// Rotates around the x axis by `angle` (in radians).

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -1733,6 +1733,12 @@ impl {{ self_t }} {
             dot.sqrt()[0]
         {% endif %}
     }
+
+    /// Returns `true` if the vector is not the zero vector (also rejects NaN).
+    #[allow(dead_code)]
+    fn is_non_zero(self) -> bool {
+        self.length_squared() > 0.0
+    }
 {% endif %}
 
     /// Computes the squared length of `self`.
@@ -2484,6 +2490,8 @@ impl {{ self_t }} {
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> {{ scalar_t }} {
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         let angle = math::acos_approx(
             self.dot(rhs) / math::sqrt(self.length_squared() * rhs.length_squared()));
 
@@ -2499,6 +2507,8 @@ impl {{ self_t }} {
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> {{ scalar_t }} {
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::acos_approx(
             self.dot(rhs).div(
                 math::sqrt(self.length_squared().mul(rhs.length_squared()))))
@@ -2523,6 +2533,8 @@ impl {{ self_t }} {
     #[must_use]
     pub fn angle_to(self, rhs: Self, axis: Self) -> {{ scalar_t }} {
         glam_assert!(axis.is_normalized());
+        glam_assert!(self.is_non_zero());
+        glam_assert!(rhs.is_non_zero());
         math::atan2(self.cross(rhs).dot(axis), self.dot(rhs))
     }
 

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -2489,6 +2489,9 @@ impl {{ self_t }} {
 {% elif dim == 3 %}
     /// Returns the angle (in radians) between two vectors in the range `[0, +π]`.
     ///
+    /// For the full rotation between two vectors as a quaternion, see
+    /// [`{{ quat_t }}::from_rotation_arc`].
+    ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     #[inline]
     #[must_use]

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -2487,6 +2487,10 @@ impl {{ self_t }} {
     ///
     /// The returned angle can be used with [`rotate_angle()`][Self::rotate_angle], e.g.
     /// `self.rotate_angle(self.angle_to(rhs))` will be equal to `rhs`.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> {{ scalar_t }} {
@@ -2504,6 +2508,10 @@ impl {{ self_t }} {
     /// [`{{ quat_t }}::from_rotation_arc`].
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[inline]
     #[must_use]
     pub fn angle_between(self, rhs: Self) -> {{ scalar_t }} {
@@ -2528,6 +2536,7 @@ impl {{ self_t }} {
     /// # Panics
     ///
     /// Will panic if `axis` is not normalized when `glam_assert` is enabled.
+    /// Will panic if `self` or `rhs` has zero length when `glam_assert` is enabled.
     #[doc(alias = "signed_angle")]
     #[inline]
     #[must_use]

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -2479,9 +2479,8 @@ impl {{ self_t }} {
     ///
     /// The inputs do not need to be unit vectors however they must be non-zero.
     ///
-    /// The returned angle can be used with [`from_angle()`][Self::from_angle] and
-    /// [`rotate()`][Self::rotate], e.g.
-    /// `{{ vec2_t }}::from_angle(self.angle_to(rhs)).rotate(self)` will be equal to `rhs`.
+    /// The returned angle can be used with [`rotate_angle()`][Self::rotate_angle], e.g.
+    /// `self.rotate_angle(self.angle_to(rhs))` will be equal to `rhs`.
     #[inline]
     #[must_use]
     pub fn angle_to(self, rhs: Self) -> {{ scalar_t }} {
@@ -2795,6 +2794,14 @@ impl {{ self_t }} {
 {% endif %}
 
 {% if is_signed and is_float and dim == 2 %}
+    /// Rotates `self` by `angle` (in radians), equivalent to
+    /// `self.rotate({{ vec2_t }}::from_angle(angle))`.
+    #[inline]
+    #[must_use]
+    pub fn rotate_angle(self, angle: {{ scalar_t }}) -> Self {
+        self.rotate(Self::from_angle(angle))
+    }
+
     /// Rotates towards `rhs` up to `max_angle` (in radians).
     ///
     /// When `max_angle` is `0.0`, the result will be equal to `self`. When `max_angle` is equal to

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -1646,6 +1646,9 @@ macro_rules! impl_vec2_float_tests {
             // the angle returned by angle_to should rotate the input vector to the
             // destination vector
             assert_approx_eq!($vec2::X.rotate_angle($vec2::X.angle_to($vec2::Y)), $vec2::Y);
+
+            should_glam_assert!({ $vec2::ZERO.angle_to($vec2::X) });
+            should_glam_assert!({ $vec2::X.angle_to($vec2::ZERO) });
         });
 
         glam_test!(test_rotate_angle, {

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -1645,9 +1645,25 @@ macro_rules! impl_vec2_float_tests {
 
             // the angle returned by angle_to should rotate the input vector to the
             // destination vector
+            assert_approx_eq!($vec2::X.rotate_angle($vec2::X.angle_to($vec2::Y)), $vec2::Y);
+        });
+
+        glam_test!(test_rotate_angle, {
+            use core::$t::consts::{FRAC_PI_2, PI};
+
+            // rotate_angle is equivalent to self.rotate(Vec2::from_angle(angle))
+            assert_approx_eq!($vec2::Y, $vec2::X.rotate_angle(FRAC_PI_2), 1e-6);
+            assert_approx_eq!($vec2::NEG_X, $vec2::X.rotate_angle(PI), 1e-6);
+            assert_approx_eq!($vec2::NEG_Y, $vec2::X.rotate_angle(3.0 * FRAC_PI_2), 1e-6);
+
+            // Zero rotation is identity
+            assert_approx_eq!($vec2::X, $vec2::X.rotate_angle(0.0), 1e-6);
+
+            // Equivalent to rotate(Vec2::from_angle(angle))
             assert_approx_eq!(
-                $vec2::from_angle($vec2::X.angle_to($vec2::Y)).rotate($vec2::X),
-                $vec2::Y
+                $vec2::X.rotate_angle(FRAC_PI_2),
+                $vec2::X.rotate($vec2::from_angle(FRAC_PI_2)),
+                1e-6
             );
         });
 

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -1949,6 +1949,41 @@ macro_rules! impl_vec3_float_tests {
             assert_approx_eq!(2.0 * core::$t::consts::FRAC_PI_3, angle, 1e-6);
         });
 
+        glam_test!(test_angle_to, {
+            use core::$t::consts::{FRAC_PI_2, PI};
+
+            // X to Y around Z axis is +PI/2
+            assert_approx_eq!(FRAC_PI_2, $vec3::X.angle_to($vec3::Y, $vec3::Z), 1e-6);
+
+            // Using angle_to with rotate_axis should reach the target
+            assert_approx_eq!(
+                $vec3::Y,
+                $vec3::X.rotate_axis($vec3::Z, $vec3::X.angle_to($vec3::Y, $vec3::Z)),
+                1e-6
+            );
+            assert_approx_eq!(
+                $vec3::X,
+                $vec3::Y.rotate_axis($vec3::Z, $vec3::Y.angle_to($vec3::X, $vec3::Z)),
+                1e-6
+            );
+
+            // Flipping the axis negates the angle
+            assert_approx_eq!(-FRAC_PI_2, $vec3::X.angle_to($vec3::Y, -$vec3::Z), 1e-6);
+
+            // Self to self is zero
+            assert_approx_eq!(0.0, $vec3::X.angle_to($vec3::X, $vec3::Z), 1e-6);
+
+            // Opposite directions
+            assert_approx_eq!(PI, $vec3::X.angle_to(-$vec3::X, $vec3::Z), 1e-6);
+
+            // Non-unit vectors
+            assert_approx_eq!(
+                FRAC_PI_2,
+                $vec3::new(5.0, 0.0, 0.0).angle_to($vec3::new(0.0, 5.0, 0.0), $vec3::Z),
+                1e-6
+            );
+        });
+
         glam_test!(test_clamp_length, {
             // Too long gets shortened
             assert_eq!(

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -1947,6 +1947,9 @@ macro_rules! impl_vec3_float_tests {
 
             let angle = $vec3::new(-1.0, 0.0, -1.0).angle_between($vec3::new(1.0, -1.0, 0.0));
             assert_approx_eq!(2.0 * core::$t::consts::FRAC_PI_3, angle, 1e-6);
+
+            should_glam_assert!({ $vec3::ZERO.angle_between($vec3::X) });
+            should_glam_assert!({ $vec3::X.angle_between($vec3::ZERO) });
         });
 
         glam_test!(test_angle_to, {
@@ -1982,6 +1985,9 @@ macro_rules! impl_vec3_float_tests {
                 $vec3::new(5.0, 0.0, 0.0).angle_to($vec3::new(0.0, 5.0, 0.0), $vec3::Z),
                 1e-6
             );
+
+            should_glam_assert!({ $vec3::ZERO.angle_to($vec3::X, $vec3::Z) });
+            should_glam_assert!({ $vec3::X.angle_to($vec3::ZERO, $vec3::Z) });
         });
 
         glam_test!(test_clamp_length, {


### PR DESCRIPTION
# Objective

- Made a Vec3::angle_to equivalent to Vec2::angle_to which takes an axis of rotation and returns a signed angle, this can be used in Vec3::rotate_axis
- Added Vec2::rotate_angle as a convenience for `self.rotate(Vec2::from_angle(angle))`
- Improved docs
- Fixes #514 
