### PR TITLE
feat: make `Quat::to_array` a const fn

### DIFF
--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -508,11 +508,11 @@ impl Quat {
         self.to_euler_angles(order)
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(self) -> [f32; 4] {
-        [self.x, self.y, self.z, self.w]
+    pub const fn to_array(&self) -> [f32; 4] {
+        unsafe { *(self as *const Self as *const [f32; 4]) }
     }
 
     /// Returns the vector part of the quaternion.

--- a/src/f32/neon/quat.rs
+++ b/src/f32/neon/quat.rs
@@ -520,11 +520,11 @@ impl Quat {
         self.to_euler_angles(order)
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(self) -> [f32; 4] {
-        [self.x, self.y, self.z, self.w]
+    pub const fn to_array(&self) -> [f32; 4] {
+        unsafe { *(self as *const Self as *const [f32; 4]) }
     }
 
     /// Returns the vector part of the quaternion.

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -518,10 +518,10 @@ impl Quat {
         self.to_euler_angles(order)
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(self) -> [f32; 4] {
+    pub const fn to_array(&self) -> [f32; 4] {
         [self.x, self.y, self.z, self.w]
     }
 

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -523,11 +523,11 @@ impl Quat {
         self.to_euler_angles(order)
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(self) -> [f32; 4] {
-        [self.x, self.y, self.z, self.w]
+    pub const fn to_array(&self) -> [f32; 4] {
+        unsafe { *(self as *const Self as *const [f32; 4]) }
     }
 
     /// Returns the vector part of the quaternion.

--- a/src/f32/wasm/quat.rs
+++ b/src/f32/wasm/quat.rs
@@ -518,11 +518,11 @@ impl Quat {
         self.to_euler_angles(order)
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(self) -> [f32; 4] {
-        [self.x, self.y, self.z, self.w]
+    pub const fn to_array(&self) -> [f32; 4] {
+        unsafe { *(self as *const Self as *const [f32; 4]) }
     }
 
     /// Returns the vector part of the quaternion.

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -500,10 +500,10 @@ impl DQuat {
         self.to_euler_angles(order)
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(self) -> [f64; 4] {
+    pub const fn to_array(&self) -> [f64; 4] {
         [self.x, self.y, self.z, self.w]
     }
 

--- a/templates/quat.rs.tera
+++ b/templates/quat.rs.tera
@@ -637,11 +637,15 @@ impl {{ self_t }} {
         self.to_euler_angles(order)
     }
 
-    /// `[x, y, z, w]`
+    /// Converts `self` to `[x, y, z, w]`
     #[inline]
     #[must_use]
-    pub fn to_array(self) -> [{{ scalar_t }}; 4] {
-        [self.x, self.y, self.z, self.w]
+    pub const fn to_array(&self) -> [{{ scalar_t }}; 4] {
+        {% if is_scalar %}
+            [self.x, self.y, self.z, self.w]
+        {% else %}
+            unsafe { *(self as *const Self as *const [{{ scalar_t }}; 4]) }
+        {% endif %}
     }
 
     /// Returns the vector part of the quaternion.


### PR DESCRIPTION
# Objective

The `Vec` family provides symmetric `const from_array` and `const to_array` methods. `Quat` is inconsistent in this regard; only the `Quat::from_array` method is const. I want to fix this inconsistency so that I can convert to/from arrays at compile-time (which is helpful for writing const trait extensions on top of this library).

## Solution

Update the `Quat` template to make `to_array` const by borrowing `Vec`'s implementation:

https://github.com/bitshifter/glam-rs/blob/bd172a701971499191b8af85ed4d299e04057b08/templates/vec.rs.tera#L559-L569

## Code generation

- Most code in glam is generated by an offline tool. -- Ack'd
- Are you modify generated code? -- Yes
- Have you modified the templates and run the code generator? -- Yes

See https://github.com/bitshifter/glam-codegen/blob/main/README.md for details. -- Ack'd

## Testing and linting

- Your PR should include tests for any bug fixes or new features. -- N/A
- `cargo test` and `cargo clippy` must pass. -- Confirmed

You can run most of glam's tests locally by running `cargo run -p ci`. -- Done