### PR TITLE
changed(rkyv)!: Archive glam types to dedicated portable archived types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `bytemuck::Pod` and `bytemuck::Zeroable` impls for the archived types, so archived
+  buffers can still be cast to bytes for a GPU upload or a file write without going through
+  a serializer.
+
+* Added `From` conversions between each type and its archived form, which is all the leaf
+  types need to read a single value back and avoids requiring a deserializer for a
+  conversion that cannot fail.
+
 * Added `Archive::COPY_OPTIMIZATION` to the `rkyv` impls of every type whose archived form
   is a byte for byte copy of the native one, which lets `rkyv` serialize slices of them
   with a single `memcpy`. This covers `Vec2`, `Vec3`, `Vec4`, `Quat`, `Mat2`, `Mat3`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   changes the archived binary format, and reading an archived value now converts rather
   than casting a reference.
 
+### Added
+
+* Added `Archive::COPY_OPTIMIZATION` to the `rkyv` impls of every type whose archived form
+  is a byte for byte copy of the native one, which lets `rkyv` serialize slices of them
+  with a single `memcpy`. This covers `Vec2`, `Vec3`, `Vec4`, `Quat`, `Mat2`, `Mat3`,
+  `Mat4` and `Affine3` and their non `f32` equivalents, plus `Affine2` on backends where it
+  carries no padding. It is derived rather than hardcoded, so it turns itself off for the
+  16 byte aligned types and whenever the archive endianness does not match the target.
+
 ### Fixed
 
 * Fixed `unsafe impl NoUndef` being applied to types that carry padding, which copied

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,39 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Breaking change: `rkyv` support now archives each type to a dedicated `Archived*` type
-  built from `rkyv`'s own archived primitives, instead of aliasing the native `glam` type.
-  Archived data is endianness-explicit, independent of the SIMD backend `glam` was built
-  with, and one byte aligned when `rkyv` is built with its `unaligned` feature. This
-  changes the archived binary format, and reading an archived value now converts rather
-  than casting a reference.
+- [**breaking**] `rkyv` support now archives each type to a dedicated `Archived*` type
+  instead of the native `glam` type, so archives no longer inherit the native type's
+  endianness or SIMD-backend-dependent layout, and no longer copy uninitialised padding.
+  This changes the archived format, and reading an archived value now converts it instead
+  of casting a reference.
 
 ### Added
 
-* Added `bytemuck::Pod` and `bytemuck::Zeroable` impls for the archived types, so archived
-  buffers can still be cast to bytes for a GPU upload or a file write without going through
-  a serializer.
+- `bytemuck::Pod` and `bytemuck::Zeroable` impls for the `rkyv` archived types, so they
+  can still be cast to bytes for a GPU upload or file write without a serializer.
 
-* Added `From` conversions between each type and its archived form, which is all the leaf
-  types need to read a single value back and avoids requiring a deserializer for a
-  conversion that cannot fail.
+- `From` conversions between each type and its `rkyv` archived form.
 
-* Added `Archive::COPY_OPTIMIZATION` to the `rkyv` impls of every type whose archived form
-  is a byte for byte copy of the native one, which lets `rkyv` serialize slices of them
-  with a single `memcpy`. This covers `Vec2`, `Vec3`, `Vec4`, `Quat`, `Mat2`, `Mat3`,
-  `Mat4` and `Affine3` and their non `f32` equivalents, plus `Affine2` on backends where it
-  carries no padding. It is derived rather than hardcoded, so it turns itself off for the
-  16 byte aligned types and whenever the archive endianness does not match the target.
+- `Archive::COPY_OPTIMIZATION` for the `rkyv` impls whose archived form is a byte-for-byte
+  copy of the native form, so slices serialize with a single `memcpy`.
 
 ### Fixed
 
-* Fixed `unsafe impl NoUndef` being applied to types that carry padding, which copied
-  uninitialised bytes into archives. Every backend was affected: `Vec3A`, `Mat3A` and
-  `Affine3A` have four bytes of padding per `Vec3A` under `scalar-math`, and `Affine2` has
-  eight bytes of tail padding under SSE2 and NEON, where `Mat2` is 16 byte aligned.
+- `NoUndef` is now only implemented for the padding-free `rkyv` archived types, so
+  uninitialised padding is no longer copied into archives.
 
-* Fixed `unsafe impl Portable` claiming a layout identical on all targets for types whose
-  archived form was native-endian and dependent on the selected SIMD backend.
+- `Portable` is now implemented on the `rkyv` archived types, which have a layout identical
+  on all targets, instead of the native types that depended on the SIMD backend.
 
 ## [0.33.6](https://github.com/bitshifter/glam-rs/compare/0.33.5...0.33.6) - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+* Breaking change: `rkyv` support now archives each type to a dedicated `Archived*` type
+  built from `rkyv`'s own archived primitives, instead of aliasing the native `glam` type.
+  Archived data is endianness-explicit, independent of the SIMD backend `glam` was built
+  with, and one byte aligned when `rkyv` is built with its `unaligned` feature. This
+  changes the archived binary format, and reading an archived value now converts rather
+  than casting a reference.
+
+### Fixed
+
+* Fixed `unsafe impl NoUndef` being applied to types that carry padding, which copied
+  uninitialised bytes into archives. Every backend was affected: `Vec3A`, `Mat3A` and
+  `Affine3A` have four bytes of padding per `Vec3A` under `scalar-math`, and `Affine2` has
+  eight bytes of tail padding under SSE2 and NEON, where `Mat2` is 16 byte aligned.
+
+* Fixed `unsafe impl Portable` claiming a layout identical on all targets for types whose
+  archived form was native-endian and dependent on the selected SIMD backend.
+
 ## [0.33.6](https://github.com/bitshifter/glam-rs/compare/0.33.5...0.33.6) - 2026-08-28
 
 ### Added

--- a/src/features/impl_rkyv.rs
+++ b/src/features/impl_rkyv.rs
@@ -1,186 +1,315 @@
-#[cfg(feature = "bytecheck")]
+//! `rkyv` support for glam types.
+//!
+//! Every glam type archives to a dedicated `Archived*` struct built out of rkyv's own
+//! archived primitives ([`rkyv::Archived<f32>`] and friends) rather than aliasing the
+//! native glam type. That keeps the archived representation independent of the SIMD
+//! backend glam was built with, gives it the endianness rkyv asks for, and lets it
+//! inherit rkyv's `unaligned` feature so archives can be read from buffers that are not
+//! aligned to the native type.
+//!
+//! The archived types are storage only: they carry no `#[repr(align(..))]` and implement
+//! no arithmetic. Use [`rkyv::Deserialize`] to recover the native glam type.
+
+use rkyv::{
+    rancor::Fallible, traits::NoUndef, Archive, Archived, Deserialize, Place, Portable, Serialize,
+};
+
+use crate::{Affine2, Affine3, Affine3A, Mat2, Mat3, Mat3A, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
+#[cfg(feature = "f64")]
+use crate::{DAffine2, DAffine3, DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4};
+#[cfg(feature = "i16")]
+use crate::{I16Vec2, I16Vec3, I16Vec4};
+#[cfg(feature = "i64")]
+use crate::{I64Vec2, I64Vec3, I64Vec4};
+#[cfg(feature = "i8")]
+use crate::{I8Vec2, I8Vec3, I8Vec4};
+#[cfg(feature = "i32")]
+use crate::{IVec2, IVec3, IVec4};
+#[cfg(feature = "u16")]
+use crate::{U16Vec2, U16Vec3, U16Vec4};
+#[cfg(feature = "u64")]
+use crate::{U64Vec2, U64Vec3, U64Vec4};
+#[cfg(feature = "u8")]
+use crate::{U8Vec2, U8Vec3, U8Vec4};
+#[cfg(feature = "u32")]
+use crate::{UVec2, UVec3, UVec4};
+
+/// Conversion between a primitive and the archived form rkyv picked for it.
+///
+/// [`rkyv::Archived`] is one of `rend`'s endianness-explicit types for multi-byte
+/// primitives, and the primitive itself for single-byte ones, which have no endianness.
+trait ArchivablePrimitive: Archive + Copy {
+    fn to_archived(self) -> Archived<Self>;
+    fn from_archived(archived: Archived<Self>) -> Self;
+}
+
+macro_rules! impl_archivable_primitive {
+    ($($prim:ty),* $(,)?) => {
+        $(
+            impl ArchivablePrimitive for $prim {
+                #[inline]
+                fn to_archived(self) -> Archived<Self> {
+                    Archived::<Self>::from_native(self)
+                }
+
+                #[inline]
+                fn from_archived(archived: Archived<Self>) -> Self {
+                    archived.to_native()
+                }
+            }
+        )*
+    };
+}
+
+macro_rules! impl_archivable_byte {
+    ($($prim:ty),* $(,)?) => {
+        $(
+            impl ArchivablePrimitive for $prim {
+                #[inline]
+                fn to_archived(self) -> Archived<Self> {
+                    self
+                }
+
+                #[inline]
+                fn from_archived(archived: Archived<Self>) -> Self {
+                    archived
+                }
+            }
+        )*
+    };
+}
+
+impl_archivable_primitive!(f32, f64, i16, i32, i64, u16, u32, u64);
+impl_archivable_byte!(i8, u8);
+
 macro_rules! impl_rkyv {
-    (@bytecheck $type:ty) => {
-        // SAFETY: All bit patterns are valid for these primitive types.
-        // https://docs.rs/bytecheck/0.8.1/src/bytecheck/lib.rs.html#352
-        unsafe impl<C: Fallible +?Sized> rkyv::bytecheck::CheckBytes<C> for $type {
+    (array $type:ident, $archived:ident, $prim:ty, $n:expr) => {
+        impl_rkyv!(
+            @impl $type, $archived, $prim, $n,
+            |value| value.to_array(),
+            |array| <$type>::from_array(array)
+        );
+    };
+
+    (cols $type:ident, $archived:ident, $prim:ty, $n:expr) => {
+        impl_rkyv!(
+            @impl $type, $archived, $prim, $n,
+            |value| value.to_cols_array(),
+            |array| <$type>::from_cols_array(&array)
+        );
+    };
+
+    (
+        @impl $type:ident, $archived:ident, $prim:ty, $n:expr,
+        |$value:ident| $to_native:expr,
+        |$array:ident| $from_native:expr
+    ) => {
+        #[doc = concat!("The archived version of [`", stringify!($type), "`].")]
+        ///
+        /// The element type follows rkyv's `unaligned` and `big_endian` features, so this
+        /// type is one byte aligned whenever rkyv itself is built that way.
+        #[derive(Clone, Copy, Debug, PartialEq)]
+        #[repr(transparent)]
+        pub struct $archived(pub [Archived<$prim>; $n]);
+
+        // SAFETY: `#[repr(transparent)]` over an array of archived primitives, each of
+        // which has a stable layout and explicit endianness on every target. Contains no
+        // interior mutability.
+        unsafe impl Portable for $archived {}
+
+        // SAFETY: `#[repr(transparent)]` over an array of equally sized archived
+        // primitives, so there is no padding and no uninitialised byte.
+        unsafe impl NoUndef for $archived {}
+
+        impl Archive for $type {
+            type Archived = $archived;
+            type Resolver = ();
+
             #[inline]
-            unsafe fn check_bytes(
-                _value: *const Self,
-                _: &mut C,
-            ) -> Result<(), C::Error> {
-                Ok(())
+            fn resolve(&self, _: Self::Resolver, out: Place<Self::Archived>) {
+                let $value = self;
+                let native: [$prim; $n] = $to_native;
+                out.write($archived(native.map(ArchivablePrimitive::to_archived)));
             }
         }
-    };
 
-    ($type:ty) => {
-        impl_rkyv_derive!(@serialize $type);
-        impl_rkyv_derive!(@archive_deserialize $type);
-        impl_rkyv!(@bytecheck $type);
-    };
-}
-
-#[cfg(not(feature = "bytecheck"))]
-macro_rules! impl_rkyv {
-    ($type:ty) => {
-        impl_rkyv_derive!(@serialize $type);
-        impl_rkyv_derive!(@archive_deserialize $type);
-    };
-}
-
-macro_rules! impl_rkyv_derive {
-    (@serialize $type:ty) => {
         impl<S: Fallible + ?Sized> Serialize<S> for $type {
             #[inline]
             fn serialize(&self, _: &mut S) -> Result<Self::Resolver, S::Error> {
                 Ok(())
             }
         }
-    };
 
-    (@archive_deserialize $type:ty) => {
-        // SAFETY: All glam types have a fully defined data layout.
-        unsafe impl rkyv::traits::NoUndef for $type {}
-        // SAFETY: All glam types have a stable, well-defined layout that is identical on all
-        // targets.
-        unsafe impl rkyv::Portable for $type {}
-        impl Archive for $type {
-            type Archived = $type;
-            type Resolver = ();
-
+        impl<D: Fallible + ?Sized> Deserialize<$type, D> for $archived {
             #[inline]
-            fn resolve(&self, _: Self::Resolver, out: Place<Self::Archived>) {
-                out.write(*self)
+            fn deserialize(&self, _: &mut D) -> Result<$type, D::Error> {
+                let $array: [$prim; $n] = self.0.map(ArchivablePrimitive::from_archived);
+                Ok($from_native)
             }
         }
 
-        impl<D: Fallible + ?Sized> Deserialize<$type, D> for $type {
+        impl PartialEq<$type> for $archived {
             #[inline]
-            fn deserialize(&self, _: &mut D) -> Result<$type, D::Error> {
-                Ok(*self)
+            fn eq(&self, other: &$type) -> bool {
+                let $value = other;
+                let native: [$prim; $n] = $to_native;
+                let archived: [$prim; $n] = self.0.map(ArchivablePrimitive::from_archived);
+                archived == native
+            }
+        }
+
+        #[cfg(feature = "bytecheck")]
+        // SAFETY: `#[repr(transparent)]` over the array, so a pointer to `Self` is a
+        // valid pointer to the array, and validating the array validates `Self`.
+        unsafe impl<C> rkyv::bytecheck::CheckBytes<C> for $archived
+        where
+            C: Fallible + ?Sized,
+            [Archived<$prim>; $n]: rkyv::bytecheck::CheckBytes<C>,
+        {
+            #[inline]
+            unsafe fn check_bytes(value: *const Self, context: &mut C) -> Result<(), C::Error> {
+                unsafe {
+                    <[Archived<$prim>; $n] as rkyv::bytecheck::CheckBytes<C>>::check_bytes(
+                        value.cast(),
+                        context,
+                    )
+                }
             }
         }
     };
 }
 
-mod f32 {
-    use crate::{
-        Affine2, Affine3, Affine3A, Mat2, Mat3, Mat3A, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4,
-    };
-    use rkyv::{rancor::Fallible, Archive, Deserialize, Place, Serialize};
-    impl_rkyv!(Affine2);
-    impl_rkyv!(Affine3);
-    impl_rkyv!(Affine3A);
-    impl_rkyv!(Mat2);
-    impl_rkyv!(Mat3);
-    impl_rkyv!(Mat3A);
-    impl_rkyv!(Mat4);
-    impl_rkyv!(Quat);
-    impl_rkyv!(Vec2);
-    impl_rkyv!(Vec3);
-    impl_rkyv!(Vec3A);
-    impl_rkyv!(Vec4);
+impl_rkyv!(cols Affine2, ArchivedAffine2, f32, 6);
+impl_rkyv!(cols Affine3, ArchivedAffine3, f32, 12);
+impl_rkyv!(cols Affine3A, ArchivedAffine3A, f32, 12);
+impl_rkyv!(cols Mat2, ArchivedMat2, f32, 4);
+impl_rkyv!(cols Mat3, ArchivedMat3, f32, 9);
+impl_rkyv!(cols Mat3A, ArchivedMat3A, f32, 9);
+impl_rkyv!(cols Mat4, ArchivedMat4, f32, 16);
+impl_rkyv!(array Quat, ArchivedQuat, f32, 4);
+impl_rkyv!(array Vec2, ArchivedVec2, f32, 2);
+impl_rkyv!(array Vec3, ArchivedVec3, f32, 3);
+impl_rkyv!(array Vec3A, ArchivedVec3A, f32, 3);
+impl_rkyv!(array Vec4, ArchivedVec4, f32, 4);
+
+#[cfg(feature = "f64")]
+mod f64_impls {
+    use super::*;
+
+    impl_rkyv!(cols DAffine2, ArchivedDAffine2, f64, 6);
+    impl_rkyv!(cols DAffine3, ArchivedDAffine3, f64, 12);
+    impl_rkyv!(cols DMat2, ArchivedDMat2, f64, 4);
+    impl_rkyv!(cols DMat3, ArchivedDMat3, f64, 9);
+    impl_rkyv!(cols DMat4, ArchivedDMat4, f64, 16);
+    impl_rkyv!(array DQuat, ArchivedDQuat, f64, 4);
+    impl_rkyv!(array DVec2, ArchivedDVec2, f64, 2);
+    impl_rkyv!(array DVec3, ArchivedDVec3, f64, 3);
+    impl_rkyv!(array DVec4, ArchivedDVec4, f64, 4);
 }
 
 #[cfg(feature = "f64")]
-mod f64 {
-    use crate::{DAffine2, DAffine3, DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4};
-    use rkyv::{rancor::Fallible, Archive, Deserialize, Place, Serialize};
+pub use f64_impls::*;
 
-    impl_rkyv!(DAffine2);
-    impl_rkyv!(DAffine3);
-    impl_rkyv!(DMat2);
-    impl_rkyv!(DMat3);
-    impl_rkyv!(DMat4);
-    impl_rkyv!(DQuat);
-    impl_rkyv!(DVec2);
-    impl_rkyv!(DVec3);
-    impl_rkyv!(DVec4);
+#[cfg(feature = "i8")]
+mod i8_impls {
+    use super::*;
+
+    impl_rkyv!(array I8Vec2, ArchivedI8Vec2, i8, 2);
+    impl_rkyv!(array I8Vec3, ArchivedI8Vec3, i8, 3);
+    impl_rkyv!(array I8Vec4, ArchivedI8Vec4, i8, 4);
 }
 
 #[cfg(feature = "i8")]
-mod i8 {
-    use crate::{I8Vec2, I8Vec3, I8Vec4};
-    use rkyv::{rancor::Fallible, Archive, Deserialize, Place, Serialize};
+pub use i8_impls::*;
 
-    impl_rkyv!(I8Vec2);
-    impl_rkyv!(I8Vec3);
-    impl_rkyv!(I8Vec4);
+#[cfg(feature = "i16")]
+mod i16_impls {
+    use super::*;
+
+    impl_rkyv!(array I16Vec2, ArchivedI16Vec2, i16, 2);
+    impl_rkyv!(array I16Vec3, ArchivedI16Vec3, i16, 3);
+    impl_rkyv!(array I16Vec4, ArchivedI16Vec4, i16, 4);
 }
 
 #[cfg(feature = "i16")]
-mod i16 {
-    use crate::{I16Vec2, I16Vec3, I16Vec4};
-    use rkyv::{rancor::Fallible, Archive, Deserialize, Place, Serialize};
+pub use i16_impls::*;
 
-    impl_rkyv!(I16Vec2);
-    impl_rkyv!(I16Vec3);
-    impl_rkyv!(I16Vec4);
+#[cfg(feature = "i32")]
+mod i32_impls {
+    use super::*;
+
+    impl_rkyv!(array IVec2, ArchivedIVec2, i32, 2);
+    impl_rkyv!(array IVec3, ArchivedIVec3, i32, 3);
+    impl_rkyv!(array IVec4, ArchivedIVec4, i32, 4);
 }
 
 #[cfg(feature = "i32")]
-mod i32 {
-    use crate::{IVec2, IVec3, IVec4};
-    use rkyv::{rancor::Fallible, Archive, Deserialize, Place, Serialize};
+pub use i32_impls::*;
 
-    impl_rkyv!(IVec2);
-    impl_rkyv!(IVec3);
-    impl_rkyv!(IVec4);
+#[cfg(feature = "i64")]
+mod i64_impls {
+    use super::*;
+
+    impl_rkyv!(array I64Vec2, ArchivedI64Vec2, i64, 2);
+    impl_rkyv!(array I64Vec3, ArchivedI64Vec3, i64, 3);
+    impl_rkyv!(array I64Vec4, ArchivedI64Vec4, i64, 4);
 }
 
 #[cfg(feature = "i64")]
-mod i64 {
-    use crate::{I64Vec2, I64Vec3, I64Vec4};
-    use rkyv::{rancor::Fallible, Archive, Deserialize, Place, Serialize};
+pub use i64_impls::*;
 
-    impl_rkyv!(I64Vec2);
-    impl_rkyv!(I64Vec3);
-    impl_rkyv!(I64Vec4);
+#[cfg(feature = "u8")]
+mod u8_impls {
+    use super::*;
+
+    impl_rkyv!(array U8Vec2, ArchivedU8Vec2, u8, 2);
+    impl_rkyv!(array U8Vec3, ArchivedU8Vec3, u8, 3);
+    impl_rkyv!(array U8Vec4, ArchivedU8Vec4, u8, 4);
 }
 
 #[cfg(feature = "u8")]
-mod u8 {
-    use crate::{U8Vec2, U8Vec3, U8Vec4};
-    use rkyv::{rancor::Fallible, Archive, Deserialize, Place, Serialize};
+pub use u8_impls::*;
 
-    impl_rkyv!(U8Vec2);
-    impl_rkyv!(U8Vec3);
-    impl_rkyv!(U8Vec4);
+#[cfg(feature = "u16")]
+mod u16_impls {
+    use super::*;
+
+    impl_rkyv!(array U16Vec2, ArchivedU16Vec2, u16, 2);
+    impl_rkyv!(array U16Vec3, ArchivedU16Vec3, u16, 3);
+    impl_rkyv!(array U16Vec4, ArchivedU16Vec4, u16, 4);
 }
 
 #[cfg(feature = "u16")]
-mod u16 {
-    use crate::{U16Vec2, U16Vec3, U16Vec4};
-    use rkyv::{rancor::Fallible, Archive, Deserialize, Place, Serialize};
+pub use u16_impls::*;
 
-    impl_rkyv!(U16Vec2);
-    impl_rkyv!(U16Vec3);
-    impl_rkyv!(U16Vec4);
+#[cfg(feature = "u32")]
+mod u32_impls {
+    use super::*;
+
+    impl_rkyv!(array UVec2, ArchivedUVec2, u32, 2);
+    impl_rkyv!(array UVec3, ArchivedUVec3, u32, 3);
+    impl_rkyv!(array UVec4, ArchivedUVec4, u32, 4);
 }
 
 #[cfg(feature = "u32")]
-mod u32 {
-    use crate::{UVec2, UVec3, UVec4};
-    use rkyv::{rancor::Fallible, Archive, Deserialize, Place, Serialize};
+pub use u32_impls::*;
 
-    impl_rkyv!(UVec2);
-    impl_rkyv!(UVec3);
-    impl_rkyv!(UVec4);
+#[cfg(feature = "u64")]
+mod u64_impls {
+    use super::*;
+
+    impl_rkyv!(array U64Vec2, ArchivedU64Vec2, u64, 2);
+    impl_rkyv!(array U64Vec3, ArchivedU64Vec3, u64, 3);
+    impl_rkyv!(array U64Vec4, ArchivedU64Vec4, u64, 4);
 }
 
 #[cfg(feature = "u64")]
-mod u64 {
-    use crate::{U64Vec2, U64Vec3, U64Vec4};
-    use rkyv::{rancor::Fallible, Archive, Deserialize, Place, Serialize};
-
-    impl_rkyv!(U64Vec2);
-    impl_rkyv!(U64Vec3);
-    impl_rkyv!(U64Vec4);
-}
+pub use u64_impls::*;
 
 #[cfg(test)]
 mod test {
+    use rkyv::Archive;
+
     /// The serializer type expected by [`rkyv::to_bytes()`].
     pub type TestSerializer<'a> = rkyv::api::high::HighSerializer<
         rkyv::util::AlignedVec,
@@ -189,25 +318,79 @@ mod test {
     >;
     /// The deserializer type expected by [`rkyv::deserialize()`].
     pub type TestDeserializer = rkyv::api::high::HighDeserializer<rkyv::rancor::Panic>;
+
+    #[cfg(feature = "bytecheck")]
     pub fn test_archive<T>(value: &T)
     where
-        T: core::fmt::Debug
-            + PartialEq
+        T: core::fmt::Debug + PartialEq + for<'a> rkyv::Serialize<TestSerializer<'a>>,
+        T::Archived: core::fmt::Debug
+            + PartialEq<T>
+            + rkyv::Deserialize<T, TestDeserializer>
             + rkyv::Portable
-            + for<'a> rkyv::Serialize<TestSerializer<'a>>,
-        T::Archived: core::fmt::Debug + PartialEq<T> + rkyv::Deserialize<T, TestDeserializer>,
+            + for<'a> rkyv::bytecheck::CheckBytes<
+                rkyv::api::high::HighValidator<'a, rkyv::rancor::Panic>,
+            >,
     {
         let buffer = rkyv::to_bytes(value).unwrap();
 
-        // SAFETY: all bit patterns are valid for the primitive types used by glam.  There is
-        // no need to write special-cased conditional tests that rely on bytecheck for the safe
-        // rkyv::access() wrapper.
+        // The archive is validated rather than accessed unchecked, which also covers the
+        // alignment of the buffer it is read out of.
+        let archived_value = rkyv::access::<T::Archived, rkyv::rancor::Panic>(&buffer).unwrap();
+        assert_archived_eq::<T>(archived_value, value);
+    }
+
+    #[cfg(not(feature = "bytecheck"))]
+    pub fn test_archive<T>(value: &T)
+    where
+        T: core::fmt::Debug + PartialEq + for<'a> rkyv::Serialize<TestSerializer<'a>>,
+        T::Archived: core::fmt::Debug
+            + PartialEq<T>
+            + rkyv::Deserialize<T, TestDeserializer>
+            + rkyv::Portable,
+    {
+        let buffer = rkyv::to_bytes(value).unwrap();
+
+        // SAFETY: `to_bytes` returns an `AlignedVec`, which satisfies the alignment of any
+        // archived type, and every archived glam type is an array of archived primitives
+        // for which all bit patterns are valid.
         let archived_value = unsafe { rkyv::access_unchecked::<T::Archived>(&buffer) };
+        assert_archived_eq::<T>(archived_value, value);
+    }
+
+    fn assert_archived_eq<T>(archived_value: &T::Archived, value: &T)
+    where
+        T: core::fmt::Debug + PartialEq + Archive,
+        T::Archived: core::fmt::Debug + PartialEq<T> + rkyv::Deserialize<T, TestDeserializer>,
+    {
         assert_eq!(archived_value, value);
         assert_eq!(
             &rkyv::deserialize::<T, rkyv::rancor::Panic>(archived_value).unwrap(),
             value
         );
+    }
+
+    /// The archived form must not impose an alignment on the buffer it is read from when
+    /// `rkyv` is built with its `unaligned` feature.
+    #[test]
+    fn archived_alignment_follows_rkyv() {
+        use crate::{ArchivedVec3, ArchivedVec3A, ArchivedVec4};
+
+        let expected = core::mem::align_of::<rkyv::Archived<f32>>();
+        assert_eq!(core::mem::align_of::<ArchivedVec3>(), expected);
+        assert_eq!(core::mem::align_of::<ArchivedVec3A>(), expected);
+        assert_eq!(core::mem::align_of::<ArchivedVec4>(), expected);
+    }
+
+    /// The archived form is a packed array of elements, with no padding or trailing
+    /// alignment, regardless of the SIMD backend glam was built with.
+    #[test]
+    fn archived_size_is_exact() {
+        use crate::{ArchivedVec3, ArchivedVec3A, ArchivedVec4};
+
+        let element = core::mem::size_of::<rkyv::Archived<f32>>();
+        assert_eq!(core::mem::size_of::<ArchivedVec3>(), element * 3);
+        assert_eq!(core::mem::size_of::<ArchivedVec3A>(), element * 3);
+        assert_eq!(core::mem::size_of::<ArchivedVec4>(), element * 4);
     }
 
     #[test]

--- a/src/features/impl_rkyv.rs
+++ b/src/features/impl_rkyv.rs
@@ -123,6 +123,39 @@ macro_rules! impl_rkyv {
         // primitives, so there is no padding and no uninitialised byte.
         unsafe impl NoUndef for $archived {}
 
+        // SAFETY: An array of archived primitives, for which zero is a valid value.
+        //
+        // The derive is unusable here: it would require the element type to implement
+        // `Zeroable`, which it only does when `rend` is built with its `bytemuck-1`
+        // feature, and that is not something `glam` can enable through `rkyv`.
+        #[cfg(feature = "bytemuck")]
+        unsafe impl bytemuck::Zeroable for $archived {}
+
+        // SAFETY: `#[repr(transparent)]` over an array of equally sized archived
+        // primitives, so there is no padding, and every bit pattern is a valid value of
+        // the primitive it archives. Note that this says nothing about endianness: reading
+        // these bytes as native primitives is only meaningful when the archive endianness
+        // matches the target, exactly as for the native `glam` types.
+        #[cfg(feature = "bytemuck")]
+        unsafe impl bytemuck::Pod for $archived {}
+
+        impl From<$type> for $archived {
+            #[inline]
+            fn from(value: $type) -> Self {
+                let $value = &value;
+                let native: [$prim; $n] = $to_native;
+                Self(native.map(ArchivablePrimitive::to_archived))
+            }
+        }
+
+        impl From<$archived> for $type {
+            #[inline]
+            fn from(archived: $archived) -> Self {
+                let $array: [$prim; $n] = archived.0.map(ArchivablePrimitive::from_archived);
+                $from_native
+            }
+        }
+
         impl Archive for $type {
             // SAFETY: The optimization copies the bytes of the native value straight into
             // the archive, so the two layouts have to agree byte for byte.
@@ -149,9 +182,7 @@ macro_rules! impl_rkyv {
 
             #[inline]
             fn resolve(&self, _: Self::Resolver, out: Place<Self::Archived>) {
-                let $value = self;
-                let native: [$prim; $n] = $to_native;
-                out.write($archived(native.map(ArchivablePrimitive::to_archived)));
+                out.write((*self).into());
             }
         }
 
@@ -165,8 +196,7 @@ macro_rules! impl_rkyv {
         impl<D: Fallible + ?Sized> Deserialize<$type, D> for $archived {
             #[inline]
             fn deserialize(&self, _: &mut D) -> Result<$type, D::Error> {
-                let $array: [$prim; $n] = self.0.map(ArchivablePrimitive::from_archived);
-                Ok($from_native)
+                Ok((*self).into())
             }
         }
 
@@ -481,6 +511,36 @@ mod test {
         assert!(!is_enabled::<Vec3A>());
         assert!(!is_enabled::<Mat3A>());
         assert!(!is_enabled::<Affine3A>());
+    }
+
+    /// The archived types are the form data is uploaded to a GPU or written to a file in,
+    /// so they have to be castable to bytes without going through a serializer.
+    #[cfg(feature = "bytemuck")]
+    #[test]
+    fn archived_types_are_pod() {
+        use crate::{ArchivedVec3, Vec3};
+
+        let values = [
+            ArchivedVec3::from(Vec3::new(1.0, 2.0, 3.0)),
+            ArchivedVec3::from(Vec3::new(4.0, 5.0, 6.0)),
+        ];
+
+        let bytes = bytemuck::cast_slice::<ArchivedVec3, u8>(&values);
+        assert_eq!(bytes.len(), 2 * core::mem::size_of::<ArchivedVec3>());
+        assert_eq!(bytemuck::cast_slice::<u8, ArchivedVec3>(bytes), &values);
+    }
+
+    /// Converting an archived value back without a deserializer, which is all the leaf
+    /// types need and is what makes the reference cast that used to work unnecessary.
+    #[test]
+    fn archived_conversions_round_trip() {
+        use crate::{ArchivedMat2, ArchivedVec3, Mat2, Vec3};
+
+        let vec = Vec3::new(1.0, 2.0, 3.0);
+        assert_eq!(Vec3::from(ArchivedVec3::from(vec)), vec);
+
+        let mat = Mat2::from_cols_array(&[1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(Mat2::from(ArchivedMat2::from(mat)), mat);
     }
 
     #[test]

--- a/src/features/impl_rkyv.rs
+++ b/src/features/impl_rkyv.rs
@@ -11,7 +11,9 @@
 //! no arithmetic. Use [`rkyv::Deserialize`] to recover the native glam type.
 
 use rkyv::{
-    rancor::Fallible, traits::NoUndef, Archive, Archived, Deserialize, Place, Portable, Serialize,
+    rancor::Fallible,
+    traits::{CopyOptimization, NoUndef},
+    Archive, Archived, Deserialize, Place, Portable, Serialize,
 };
 
 use crate::{Affine2, Affine3, Affine3A, Mat2, Mat3, Mat3A, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
@@ -122,6 +124,26 @@ macro_rules! impl_rkyv {
         unsafe impl NoUndef for $archived {}
 
         impl Archive for $type {
+            // SAFETY: The optimization copies the bytes of the native value straight into
+            // the archive, so the two layouts have to agree byte for byte.
+            //
+            // The element type reports whether an archived primitive is a copy of its
+            // native form, which is false when the archive endianness and the target
+            // endianness disagree. Given that, the size check is enough: the native type
+            // holds exactly `$n` primitives, so if it is no larger than `$n` of them it has
+            // no padding, and both forms store those primitives in the order used by
+            // `to_array`/`to_cols_array` -- which glam itself implements as a transmute for
+            // the types that are laid out that way.
+            //
+            // Types that do have padding, such as `Vec3A` and (on SIMD backends) `Affine2`,
+            // are larger than their archived form and so disable the optimization here.
+            const COPY_OPTIMIZATION: CopyOptimization<Self> = unsafe {
+                CopyOptimization::enable_if(
+                    <$prim as Archive>::COPY_OPTIMIZATION.is_enabled()
+                        && core::mem::size_of::<Self>() == core::mem::size_of::<$archived>(),
+                )
+            };
+
             type Archived = $archived;
             type Resolver = ();
 
@@ -367,6 +389,43 @@ mod test {
             &rkyv::deserialize::<T, rkyv::rancor::Panic>(archived_value).unwrap(),
             value
         );
+        assert_copy_optimization_is_sound(value, archived_value);
+    }
+
+    /// [`rkyv::Archive::COPY_OPTIMIZATION`] promises that the archived form is a copy of
+    /// the native one, and rkyv acts on it by memcpying whole slices of native values into
+    /// the archive. The size half of that promise is checked when the constant is declared;
+    /// this pins the field order, which is not otherwise verifiable at compile time.
+    fn assert_copy_optimization_is_sound<T: Archive>(value: &T, archived_value: &T::Archived) {
+        if !T::COPY_OPTIMIZATION.is_enabled() {
+            return;
+        }
+
+        assert_eq!(
+            core::mem::size_of::<T>(),
+            core::mem::size_of::<T::Archived>(),
+            "the copy optimization may only be enabled for equally sized types"
+        );
+
+        // SAFETY: The optimization is only enabled for types without padding, so every byte
+        // of both values is initialised. This is the same read rkyv performs when it acts on
+        // the hint.
+        let (native, archived) = unsafe {
+            (
+                core::slice::from_raw_parts(
+                    core::ptr::from_ref(value).cast::<u8>(),
+                    core::mem::size_of::<T>(),
+                ),
+                core::slice::from_raw_parts(
+                    core::ptr::from_ref(archived_value).cast::<u8>(),
+                    core::mem::size_of::<T::Archived>(),
+                ),
+            )
+        };
+        assert_eq!(
+            native, archived,
+            "the copy optimization is enabled for a type whose archived form is not a copy"
+        );
     }
 
     /// The archived form must not impose an alignment on the buffer it is read from when
@@ -391,6 +450,37 @@ mod test {
         assert_eq!(core::mem::size_of::<ArchivedVec3>(), element * 3);
         assert_eq!(core::mem::size_of::<ArchivedVec3A>(), element * 3);
         assert_eq!(core::mem::size_of::<ArchivedVec4>(), element * 4);
+    }
+
+    /// Whether a type can be copied into the archive wholesale is a property of its native
+    /// layout, so it must not depend on the SIMD backend glam was built with.
+    #[test]
+    fn copy_optimization_is_backend_independent() {
+        use crate::{Affine3, Affine3A, Mat2, Mat3, Mat3A, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
+
+        fn is_enabled<T: Archive>() -> bool {
+            T::COPY_OPTIMIZATION.is_enabled()
+        }
+
+        // False when rkyv archives to the endianness the target does not use, which rules
+        // the optimization out for every type built on `f32`.
+        if is_enabled::<f32>() {
+            assert!(is_enabled::<Vec2>());
+            assert!(is_enabled::<Vec3>());
+            assert!(is_enabled::<Vec4>());
+            assert!(is_enabled::<Quat>());
+            assert!(is_enabled::<Mat2>());
+            assert!(is_enabled::<Mat3>());
+            assert!(is_enabled::<Mat4>());
+            assert!(is_enabled::<Affine3>());
+        }
+
+        // The archived form of the 16 byte aligned types drops the padding the native form
+        // carries, so it is smaller and cannot be a copy. `Affine2` is deliberately absent:
+        // it has tail padding on the SIMD backends but not under `scalar-math`.
+        assert!(!is_enabled::<Vec3A>());
+        assert!(!is_enabled::<Mat3A>());
+        assert!(!is_enabled::<Affine3A>());
     }
 
     #[test]

--- a/src/features/impl_rkyv.rs
+++ b/src/features/impl_rkyv.rs
@@ -462,7 +462,7 @@ mod test {
     /// `rkyv` is built with its `unaligned` feature.
     #[test]
     fn archived_alignment_follows_rkyv() {
-        use crate::{ArchivedVec3, ArchivedVec3A, ArchivedVec4};
+        use crate::rkyv::{ArchivedVec3, ArchivedVec3A, ArchivedVec4};
 
         let expected = core::mem::align_of::<rkyv::Archived<f32>>();
         assert_eq!(core::mem::align_of::<ArchivedVec3>(), expected);
@@ -474,7 +474,7 @@ mod test {
     /// alignment, regardless of the SIMD backend glam was built with.
     #[test]
     fn archived_size_is_exact() {
-        use crate::{ArchivedVec3, ArchivedVec3A, ArchivedVec4};
+        use crate::rkyv::{ArchivedVec3, ArchivedVec3A, ArchivedVec4};
 
         let element = core::mem::size_of::<rkyv::Archived<f32>>();
         assert_eq!(core::mem::size_of::<ArchivedVec3>(), element * 3);
@@ -518,7 +518,8 @@ mod test {
     #[cfg(feature = "bytemuck")]
     #[test]
     fn archived_types_are_pod() {
-        use crate::{ArchivedVec3, Vec3};
+        use crate::rkyv::ArchivedVec3;
+        use crate::Vec3;
 
         let values = [
             ArchivedVec3::from(Vec3::new(1.0, 2.0, 3.0)),
@@ -534,7 +535,8 @@ mod test {
     /// types need and is what makes the reference cast that used to work unnecessary.
     #[test]
     fn archived_conversions_round_trip() {
-        use crate::{ArchivedMat2, ArchivedVec3, Mat2, Vec3};
+        use crate::rkyv::{ArchivedMat2, ArchivedVec3};
+        use crate::{Mat2, Vec3};
 
         let vec = Vec3::new(1.0, 2.0, 3.0);
         assert_eq!(Vec3::from(ArchivedVec3::from(vec)), vec);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -329,7 +329,7 @@ mod euler;
 mod features;
 
 #[cfg(feature = "rkyv")]
-pub use features::impl_rkyv::*;
+pub use features::impl_rkyv as rkyv;
 
 #[cfg(all(
     target_arch = "aarch64",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,6 +328,9 @@ mod deref;
 mod euler;
 mod features;
 
+#[cfg(feature = "rkyv")]
+pub use features::impl_rkyv::*;
+
 #[cfg(all(
     target_arch = "aarch64",
     not(any(feature = "core-simd", feature = "scalar-math"))


### PR DESCRIPTION
# Archive glam types to dedicated portable archived types

Every glam type currently archives to itself (`type Archived = Vec3`), so the archived representation inherits three properties an archive format should not have:

- **Native endianness**, so an archive written on a little-endian machine cannot be read on a big-endian one.
- **SIMD-backend-dependent layout.** `Vec4` is `align_of == 16` on SSE2/NEON and 4 under `scalar-math`, which shifts field offsets in any struct embedding one — a `scalar-math` build cannot read an archive written by a SIMD build of the same version.
- **Padding copied in uninitialised.** `resolve` does `out.write(*self)`, so any padding in the native type lands in the archive uninitialised — and every backend has some type with padding, just not the same one. Under `scalar-math` it is `Vec3A`/`Mat3A`/`Affine3A`, which are `#[repr(C, align(16))]` over three `f32`, so four of their sixteen bytes are padding. Under SSE2/NEON those are fine — their fourth lane is real and initialised — but `Affine2` is 32 bytes there against 24 bytes of fields, because `Mat2` becomes 16 byte aligned, leaving 8 bytes of tail padding. Besides being UB, this makes archives non-reproducible, which matters to anyone byte-comparing them.

## The fix

Give each type an `Archived*` struct built from rkyv's own archived primitives, as rkyv's derive already does for user structs:

```rust
#[derive(Clone, Copy, Debug, PartialEq)]
#[repr(transparent)]
pub struct ArchivedVec3(pub [Archived<f32>; 3]);
```

`rkyv::Archived<f32>` resolves to `f32_le`/`f32_ule`/`f32_be`/`f32_ube` per rkyv's own `unaligned` and `big_endian` features, so one definition covers every configuration and **no new glam feature is needed** — a crate cannot `cfg` on another crate's features, so deferring to these aliases is the only mechanism that works.

Conversions use `to_array`/`to_cols_array`, which behave identically on every backend, so the archived layout no longer depends on how glam was compiled. Single-byte vectors keep byte elements (`Archived<u8>` is `u8`). The archived types are storage only: no `#[repr(align(..))]`, no arithmetic — `Deserialize` recovers the native type and its alignment.

## Effects

| type | native (SIMD) | native (`scalar-math`) | archived, both |
| --- | --- | --- | --- |
| `Vec3A` | align 16, size 16 | align 16, size 16 | align 4, size 12 |
| `Vec4` | align 16, size 16 | align 4, size 16 | align 4, size 16 |
| `Mat3A` | align 16, size 48 | align 16, size 48 | align 4, size 36 |
| `Affine3A` | align 16, size 64 | align 16, size 64 | align 4, size 48 |

With rkyv's `unaligned` feature all of these are align 1, which is the payoff: archives can be read in place from buffers with no alignment guarantee, such as mmap'd database records.

This breaks the archived format, and `&ArchivedVec3` is no longer a free reference cast to `&Vec3` — reads convert now. That cast was only valid when the caller controlled both alignment and endianness of the buffer, which a library cannot assume on a consumer's behalf; for `Vec3A`, a 16-aligned SIMD load straight out of an archive was never guaranteed. Happy to put the old behaviour behind an opt-in feature if that is wanted.

To keep that from being painful, the archived types carry `From` conversions in both directions, and `bytemuck::Pod`/`Zeroable` under the existing `bytemuck` feature. The latter matters more than it looks: archived data is what gets uploaded to a GPU or written to a file, and while `Archived = Self` that worked through the native type's own `Pod` derive. The derive is unusable on the archived types — it would require the element type to be `Pod`, which `rend` only is with its `bytemuck-1` feature, not reachable through `rkyv` — so these are hand-written impls with the padding and bit-pattern reasoning spelled out. I found both of these by patching this branch into a consumer that streams archived glam buffers straight to the GPU; without them the breakage is much wider than the format change itself.

## Note on the rkyv 0.8 port

`type Archived = $type` predates the 0.8 upgrade, so all three problems are inherited. rkyv 0.7 had no way to state them: `resolve` wrote through a raw `*mut`, making the padding copy a latent hazard rather than a claim. The 0.8 port added two `unsafe impl`s that assert the opposite — `Portable` ("layout that is the same on all targets", which the first two points deny) and `NoUndef` (absence of padding). `Place::write` is gated on `NoUndef` precisely to keep uninit bytes out of the buffer, so the guard rail was there and the impl asserted past it. glam's bytemuck support already draws this distinction correctly, deriving `AnyBitPattern` for scalar `Vec3A` and `Pod` only for the SIMD ones. Both impls hold unconditionally for the new types.

`CheckBytes` returning `Ok(())` was sound throughout — the `BVec` bool vectors are deliberately not covered — but is now delegated to the underlying array so nothing is asserted by hand.

That does partly walk back #606, which dropped the validated-access branch from `test_archive` on the grounds that every bit pattern is valid for the primitives glam uses. That reasoning still holds for bit patterns, but `rkyv::access` also checks that the buffer satisfies the archived type's alignment, which is the property this PR is about — so the tests use it again when `bytecheck` is enabled, and fall back to unchecked access only when it is not.

## `COPY_OPTIMIZATION`

glam never set `Archive::COPY_OPTIMIZATION`, so it defaulted to `disable()` and rkyv serialized a `Vec<Vec3>` element by element. This PR enables it wherever the archived form really is a copy of the native one, which is most types, so the common bulk cases (vertex positions, UVs, transform arrays) become a single memcpy — that also keeps this change from costing consumers throughput on the way past.

The condition is derived rather than hardcoded, since eligibility varies by backend:

```rust
CopyOptimization::enable_if(
    <$prim as Archive>::COPY_OPTIMIZATION.is_enabled()
        && size_of::<Self>() == size_of::<$archived>(),
)
```

The first half is rkyv's own `MULTIBYTE_PRIMITIVES_ARE_TRIVIALLY_COPYABLE`, false whenever the archive endianness and the target endianness disagree. The second is what rules out padding: the native type holds exactly `$n` primitives, so if it is no larger than `$n` of them there is nowhere for padding to hide. That covers `Vec2`, `Vec3`, `Vec4`, `Quat`, `Mat2`, `Mat3`, `Mat4` and `Affine3` in both backends, and lets `Affine2` opt in under `scalar-math` while turning itself off under SSE2/NEON, with no per-backend `cfg`.

Byte-order identity is the one part not provable from sizes. glam implements `to_array`/`to_cols_array` as a transmute for the flat SIMD types and in declaration order for the composites, so it holds — and a test now asserts the archived bytes equal the native bytes for every type where the hint is on, so a future layout change fails the build rather than silently corrupting archives.

## Open question: the `A` types

`Vec3A`/`Mat3A`/`Affine3A` cannot have it, and that is the one real trade-off here: a tight archived form (12 bytes, no uninit) rules the memcpy out forever, while archived-equals-native (16 bytes) keeps it available but copies the padding, which `CopyOptimization::enable()` forbids outright. Smaller archives seemed the better default, but happy to go the other way.

Giving scalar `Vec3A` an explicit fourth field — as the SIMD backends already have a real `w` lane — would get both, and let it derive `Pod` instead of `AnyBitPattern`, at the cost of changing the type itself rather than just its rkyv support.

## Testing

`cargo run -p ci` passes, as do `rkyv`, `rkyv,bytecheck`, `rkyv,scalar-math`, `rkyv,bytecheck,scalar-math` and all numeric-type features. Four new tests: the archived alignment is pinned to `Archived<f32>` and the archived size to the exact element count, so a future `repr(align)` or padding regression fails the build instead of silently changing the format; the copy optimization is asserted to be on for the types that qualify in both backends and off for the three that never can; and `test_archive` now compares the archived bytes against the native bytes whenever the hint is enabled. I checked those last two are not vacuous by forcing the hint on, which fails on `Affine2` at 32 against 24 bytes under SSE2. The test helper now uses the checked `rkyv::access` when `bytecheck` is on; the unchecked path remains only for builds without it, where the safety comment now names alignment as well as bit-pattern validity.
