### PR TITLE
Add serde serialize to BVec3A & BVec4A when scalar-math enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+* Added missing serde serialization to `BVec3A` and `BVec4A` when the
+  `scalar-math` feature is enabled.
+
 ## [0.33.3] - 2026-08-03
 
 ### Added

--- a/src/features/impl_serde.rs
+++ b/src/features/impl_serde.rs
@@ -897,7 +897,6 @@ mod bool {
     #[cfg(test)]
     use super::test_bool_mask::*;
     use crate::{BVec2, BVec3, BVec4};
-    #[cfg(not(feature = "scalar-math"))]
     use crate::{BVec3A, BVec4A};
     use core::fmt;
     use serde_core::{
@@ -909,7 +908,6 @@ mod bool {
     impl_serde_vec3!(bool, BVec3);
     impl_serde_vec4!(bool, BVec4);
 
-    #[cfg(not(feature = "scalar-math"))]
     impl Serialize for BVec3A {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -924,7 +922,6 @@ mod bool {
         }
     }
 
-    #[cfg(not(feature = "scalar-math"))]
     impl<'de> Deserialize<'de> for BVec3A {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
@@ -960,7 +957,6 @@ mod bool {
         }
     }
 
-    #[cfg(not(feature = "scalar-math"))]
     #[test]
     fn test_bvec3a_serde() {
         let a = BVec3A::new(V1, V2, V3);
@@ -978,7 +974,6 @@ mod bool {
         assert!(deserialized.is_err());
     }
 
-    #[cfg(not(feature = "scalar-math"))]
     impl Serialize for BVec4A {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
@@ -994,7 +989,6 @@ mod bool {
         }
     }
 
-    #[cfg(not(feature = "scalar-math"))]
     impl<'de> Deserialize<'de> for BVec4A {
         fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
         where
@@ -1033,7 +1027,6 @@ mod bool {
         }
     }
 
-    #[cfg(not(feature = "scalar-math"))]
     #[test]
     fn test_bvec4a_serde() {
         let a = BVec4A::new(V1, V2, V3, V4);


### PR DESCRIPTION
# Objective

- Fixes #767 

## Solution

- serde was disabled for these types in the past because they weren't defined when `scalar-math` was enabled, but that hasn't been the case for a while.

