### PR TITLE
Fix USizeVec2 layout checks on 32-bit targets

### DIFF
--- a/src/usize.rs
+++ b/src/usize.rs
@@ -10,8 +10,14 @@ pub use usizevec4::{usizevec4, USizeVec4};
 mod test {
     use super::*;
     mod const_test_usizevec2 {
+        #[cfg(not(all(feature = "cuda", target_pointer_width = "32")))]
         const_assert_eq!(
             core::mem::size_of::<usize>() * 2,
+            core::mem::size_of::<super::USizeVec2>()
+        );
+        #[cfg(all(feature = "cuda", target_pointer_width = "32"))]
+        const_assert_eq!(
+            16,
             core::mem::size_of::<super::USizeVec2>()
         );
 

--- a/src/usize.rs
+++ b/src/usize.rs
@@ -16,10 +16,7 @@ mod test {
             core::mem::size_of::<super::USizeVec2>()
         );
         #[cfg(all(feature = "cuda", target_pointer_width = "32"))]
-        const_assert_eq!(
-            16,
-            core::mem::size_of::<super::USizeVec2>()
-        );
+        const_assert_eq!(16, core::mem::size_of::<super::USizeVec2>());
 
         #[cfg(not(feature = "cuda"))]
         const_assert_eq!(

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -2509,7 +2509,10 @@ mod usizevec2 {
 
     glam_test!(test_align, {
         use core::mem;
+        #[cfg(not(all(feature = "cuda", target_pointer_width = "32")))]
         assert_eq!(mem::size_of::<usize>() * 2, mem::size_of::<USizeVec2>());
+        #[cfg(all(feature = "cuda", target_pointer_width = "32"))]
+        assert_eq!(16, mem::size_of::<USizeVec2>());
         #[cfg(not(feature = "cuda"))]
         assert_eq!(mem::align_of::<usize>(), mem::align_of::<USizeVec2>());
         #[cfg(feature = "cuda")]


### PR DESCRIPTION
Fix the remaining 32-bit layout assertions for `USizeVec2` when the `cuda` feature is enabled.

On i386, the generated `tests/vec2.rs` integration test still compared `size_of::<usize>() * 2` (8 bytes) with the CUDA-aligned `USizeVec2` size (16 bytes), causing the all-features test to fail. The compile-time source assertion and integration test now account for the 32-bit CUDA layout while preserving the existing checks elsewhere.

This addresses issue #770. Debian observed the failure while building glam 0.30.1 on i386.