### PR TITLE
fix: ISizeVec layout checks on 32-bit targets

### DIFF
--- a/src/isize.rs
+++ b/src/isize.rs
@@ -10,10 +10,13 @@ pub use isizevec4::{isizevec4, ISizeVec4};
 mod test {
     use super::*;
     mod const_test_isizevec2 {
+        #[cfg(not(all(feature = "cuda", target_pointer_width = "32")))]
         const_assert_eq!(
             core::mem::size_of::<isize>() * 2,
             core::mem::size_of::<super::ISizeVec2>()
         );
+        #[cfg(all(feature = "cuda", target_pointer_width = "32"))]
+        const_assert_eq!(16, core::mem::size_of::<super::ISizeVec2>());
 
         #[cfg(not(feature = "cuda"))]
         const_assert_eq!(

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -2464,9 +2464,12 @@ mod isizevec2 {
 
     glam_test!(test_align, {
         use core::mem;
+        #[cfg(not(all(feature = "cuda", target_pointer_width = "32")))]
+        assert_eq!(mem::size_of::<isize>() * 2, mem::size_of::<ISizeVec2>());
+        #[cfg(all(feature = "cuda", target_pointer_width = "32"))]
         assert_eq!(16, mem::size_of::<ISizeVec2>());
         #[cfg(not(feature = "cuda"))]
-        assert_eq!(8, mem::align_of::<ISizeVec2>());
+        assert_eq!(mem::align_of::<isize>(), mem::align_of::<ISizeVec2>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<ISizeVec2>());
     });

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -2851,8 +2851,8 @@ mod isizevec3 {
 
     glam_test!(test_align, {
         use std::mem;
-        assert_eq!(24, mem::size_of::<ISizeVec3>());
-        assert_eq!(8, mem::align_of::<ISizeVec3>());
+        assert_eq!(mem::size_of::<isize>() * 3, mem::size_of::<ISizeVec3>());
+        assert_eq!(mem::align_of::<isize>(), mem::align_of::<ISizeVec3>());
     });
 
     impl_vec3_isize_try_from_tests!(ISizeVec3, isize);

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -2894,9 +2894,9 @@ mod isizevec4 {
 
     glam_test!(test_align, {
         use std::mem;
-        assert_eq!(32, mem::size_of::<ISizeVec4>());
+        assert_eq!(mem::size_of::<isize>() * 4, mem::size_of::<ISizeVec4>());
         #[cfg(not(feature = "cuda"))]
-        assert_eq!(8, mem::align_of::<ISizeVec4>());
+        assert_eq!(mem::align_of::<isize>(), mem::align_of::<ISizeVec4>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<ISizeVec4>());
     });


### PR DESCRIPTION
Mirrors the USizeVec fix from #771 for the `ISizeVec` types, which were added after the version (0.30.1) that prompted that fix and have the same CUDA layout issues.

- `ISizeVec2` is `repr(align(16))` with the `cuda` feature, so on 32-bit targets its size is 16 bytes, not `size_of::<isize>() * 2` (8 bytes). This caused a compile-time `E0080` in the `src/isize.rs` const assertion and a runtime test failure when building with all features on i386/armhf.
- The `ISizeVec2`/3/4 integration test layout assertions hardcoded the 64-bit sizes and alignment, which also fail on 32-bit targets.

This addresses the remaining part of #770 for the `isize` types.