### PR TITLE
docs: normalize changelog to the release-plz format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,40 +2,33 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog], and this project adheres to
-[Semantic Versioning].
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-* Added missing serde serialization to `BVec3A` and `BVec4A` when the
-  `scalar-math` feature is enabled.
-
-## [0.33.3] - 2026-08-03
+## [0.33.3](https://github.com/bitshifter/glam-rs/compare/0.33.2...0.33.3) - 2026-08-03
 
 ### Added
 
-* Added `Vec3::angle_to` which returns the signed angle (in radians) between
+- Added `Vec3::angle_to` which returns the signed angle (in radians) between
   two vectors around a given axis in the range `[-π, +π]`. The angle follows
   the right-hand rule around the axis and can be used with `rotate_axis`, e.g.
   `self.rotate_axis(axis, self.angle_to(rhs, axis))` will be equal to `rhs`.
 
-* Added `Vec2::rotate_angle` which rotates a vector by an angle (in radians),
+- Added `Vec2::rotate_angle` which rotates a vector by an angle (in radians),
   equivalent to `self.rotate(Vec2::from_angle(angle))`.
 
-* Added `glam_assert`s that `angle_to` and `angle_between` inputs are non-zero
+- Added `glam_assert`s that `angle_to` and `angle_between` inputs are non-zero
   vectors.
 
 ### Changed
 
-* `to_array` is now a `const fn` on all quaternion types.
+- `to_array` is now a `const fn` on all quaternion types.
 
-## [0.33.2] - 2026-06-28
+## [0.33.2](https://github.com/bitshifter/glam-rs/compare/0.33.1...0.33.2) - 2026-06-28
 
 ### Added
 
-* Added the `camera` and `dcamera` modules containing view and projection
+- Added the `camera` and `dcamera` modules containing view and projection
   constructor functions organized by handedness and graphics API convention.
 
   The `view` sub-module provides `look_at_*` and `look_to_*` functions
@@ -48,444 +41,444 @@ The format is based on [Keep a Changelog], and this project adheres to
   and `frustum` constructors for both left-handed and right-handed view
   spaces.
 
-* Added a `prelude` module which re-exports all common types and traits
+- Added a `prelude` module which re-exports all common types and traits
   but not camera modules.
 
-* Added `slerp_long` method to quaternion types, a spherical linear
+- Added `slerp_long` method to quaternion types, a spherical linear
   interpolation that preserves the rotation direction.
 
-* Added `is_negative_mask` method to all signed vector types which returns a
+- Added `is_negative_mask` method to all signed vector types which returns a
   boolean mask vector indicating which components have a negative sign.
 
 ### Changed
 
-* View and projection constructors (`look_at_*`, `look_to_*`,
+- View and projection constructors (`look_at_*`, `look_to_*`,
   `perspective_*`, `orthographic_*`, `frustum_*`) have been moved off
   matrix, affine and quaternion types into the `camera`/`dcamera` modules
   as free functions. The existing methods on those types have been
   deprecated.
 
-## [0.33.1] - 2026-06-06
+## [0.33.1](https://github.com/bitshifter/glam-rs/compare/0.33.0...0.33.1) - 2026-06-06
 
 ### Changed
 
-* Changed vector `map` method constraint from `Fn` to `FnMut`, allowing closures
+- Changed vector `map` method constraint from `Fn` to `FnMut`, allowing closures
   that mutate their captured state.
 
-* Clarified documentation for `any_orthogonal_pair` method to specify it produces
+- Clarified documentation for `any_orthogonal_pair` method to specify it produces
   a right-handed basis.
 
-## [0.33.0] - 2026-05-21
+## [0.33.0](https://github.com/bitshifter/glam-rs/compare/0.32.1...0.33.0) - 2026-05-21
 
 ### Breaking changes
 
-* All types apart from `f32` and `bool` types are now optional but enabled by
+- All types apart from `f32` and `bool` types are now optional but enabled by
   default. Unused types can be disabled to improve compile times.
 
-* Added `#[must_use]` attribute to `as_dmat2`, `as_dmat3` and `as_dmat4` vector
+- Added `#[must_use]` attribute to `as_dmat2`, `as_dmat3` and `as_dmat4` vector
   methods.
 
-## [0.32.1] - 2026-03-06
+## [0.32.1](https://github.com/bitshifter/glam-rs/compare/0.32.0...0.32.1) - 2026-03-06
 
 ### Fixed
 
-* Fixed the implementation of dividing a scalar value by a matrix. This was
-  actually dividing the matrix by the scalar value, with this fix 
+- Fixed the implementation of dividing a scalar value by a matrix. This was
+  actually dividing the matrix by the scalar value, with this fix
   `1.0/m == m.recip()` is now true.
 
 ### Added
 
-* Added matrix `recip()` method which returns a new matrix containing the
+- Added matrix `recip()` method which returns a new matrix containing the
   reciprocal of each element of the source matrix.
 
-## [0.32.0] - 2026-02-11
+## [0.32.0](https://github.com/bitshifter/glam-rs/compare/0.31.1...0.32.0) - 2026-02-11
 
 ### Breaking changes
 
-* Updated the optional `rand` dependency to `0.10`.
+- Updated the optional `rand` dependency to `0.10`.
 
-## [0.31.1] - 2026-02-10
+## [0.31.1](https://github.com/bitshifter/glam-rs/compare/0.31.0...0.31.1) - 2026-02-10
 
 ### Added
 
-* Added `isize` vector types `ISizeVec2`, `ISizeVec3` and `ISizeVec4`.
+- Added `isize` vector types `ISizeVec2`, `ISizeVec3` and `ISizeVec4`.
 
-* Added `wasm64-unknown-unknown` support. The `wasm64-unknown-unknown` target
+- Added `wasm64-unknown-unknown` support. The `wasm64-unknown-unknown` target
  uses the same `simd128` instructions as `wasm32`. Note that
  `wasm64-unknown-unknown` requires a `nightly` toolchain.
 
 ### Changed
 
-* The `USES_WASM32_SIMD` constant on vector types has been renamed to
+- The `USES_WASM32_SIMD` constant on vector types has been renamed to
  `USES_WASM_SIMD`, `USES_WASM32_SIMD` has been deprecated.
 
-## [0.31.0] - 2026-01-21
+## [0.31.0](https://github.com/bitshifter/glam-rs/compare/0.30.10...0.31.0) - 2026-01-21
 
 ### Breaking changes
 
-* The signature of `Quat::from_affine3(&Affine3A)` was changed to 
+- The signature of `Quat::from_affine3(&Affine3A)` was changed to
   `Quat::from_affine3(&Affine3)` with the addition of the `Affine3` type.
 
-* Removed deprecated `Vec2` and `DVec2` `angle_between` methods.
+- Removed deprecated `Vec2` and `DVec2` `angle_between` methods.
 
-* Consistently use `&self` for matrix and affine type methods and `self`
+- Consistently use `&self` for matrix and affine type methods and `self`
   for vector, quat and mask types.
 
 ### Added
 
-* Added `Affine3` type.
+- Added `Affine3` type.
 
-* Added `diagonal` method to matrix types which returns a vector containing the
+- Added `diagonal` method to matrix types which returns a vector containing the
   diagonal of the matrix.
 
-* Added `mul_diagonal_scale` methods to matrix types which multiply the matrix
+- Added `mul_diagonal_scale` methods to matrix types which multiply the matrix
   by a scale vector without needing to multiply by a scale matrix.
 
-* Added `mul_transpose_vecn` methods to matrix types which multiply the vector
+- Added `mul_transpose_vecn` methods to matrix types which multiply the vector
   by the transpose of the matrix without needing to transpose it first. They can
   be slightly more efficient for SIMD backed types.
 
-* Added `try_inverse` method to matrix types which returns an option containing
+- Added `try_inverse` method to matrix types which returns an option containing
   the inverted matrix or `None` if the matrix was not invertible.
 
-* Added `inverse_or_zero` method to matrix types which returns the inverted
+- Added `inverse_or_zero` method to matrix types which returns the inverted
   matrix or a zero matrix if the matrix was not invertible.
 
-* Added `step` and `saturate` methods to the `FloatExt` trait.
+- Added `step` and `saturate` methods to the `FloatExt` trait.
 
-* Added `step`, `saturate`, `sqrt`, `sin`, `cos` and `sin_cos` methods to float
+- Added `step`, `saturate`, `sqrt`, `sin`, `cos` and `sin_cos` methods to float
   vector types.
 
-* Added `from_rotation_axes` method to quaternion types. This method was
+- Added `from_rotation_axes` method to quaternion types. This method was
   previously internal only.
 
-## [0.30.10] - 2026-01-07
+## [0.30.10](https://github.com/bitshifter/glam-rs/compare/0.30.9...0.30.10) - 2026-01-07
 
 ### Added
 
-* Added float vector `exp2`, `ln` and `log2` methods.
+- Added float vector `exp2`, `ln` and `log2` methods.
 
-* Added convenience methods for working with homogeneous coordinates, including
+- Added convenience methods for working with homogeneous coordinates, including
   3D vector `from_homogeneous` and `to_homogeneous` and 4D vector `project`.
 
 ### Fixed
 
-* Fixed `rand` `UniformSampler` `new_inclusive` methods so they're actually
+- Fixed `rand` `UniformSampler` `new_inclusive` methods so they're actually
   inclusive.
 
-## [0.30.9] - 2025-10-28
+## [0.30.9](https://github.com/bitshifter/glam-rs/compare/0.30.8...0.30.9) - 2025-10-28
 
 ### Added
 
-* Added 3D vector `rotate_x`, `rotate_y`, `rotate_z` and `rotate_axis` methods.
+- Added 3D vector `rotate_x`, `rotate_y`, `rotate_z` and `rotate_axis` methods.
 
-* Added `arbitrary` feature, providing `arbitrary` trait implementations for
+- Added `arbitrary` feature, providing `arbitrary` trait implementations for
   `glam` types.
 
-* Added `zerocopy` feature, providing `zerocopy` trait implementations for
+- Added `zerocopy` feature, providing `zerocopy` trait implementations for
   `glam` types.
 
 ### Changed
 
-* Made the threshold used in `DQuat::is_near_identity()` more precise,
+- Made the threshold used in `DQuat::is_near_identity()` more precise,
   previously it used the same threshold as `Quat::is_near_identity`.
 
-## [0.30.8] - 2025-09-25
+## [0.30.8](https://github.com/bitshifter/glam-rs/compare/0.30.7...0.30.8) - 2025-09-25
 
 ### Changed
 
-* Updates from the rust-gpu project, primarily removing the requirement to use
+- Updates from the rust-gpu project, primarily removing the requirement to use
   `repr(simd)` on `spirv`.
 
-## [0.30.7] - 2025-09-20
+## [0.30.7](https://github.com/bitshifter/glam-rs/compare/0.30.6...0.30.7) - 2025-09-20
 
 ### Changed
 
-* Reverted change to use `self` in vectors and `&self` in vectors and matrices
+- Reverted change to use `self` in vectors and `&self` in vectors and matrices
   as this was a breaking change for some code.
 
-## [0.30.6] - 2025-09-18
+## [0.30.6](https://github.com/bitshifter/glam-rs/compare/0.30.5...0.30.6) - 2025-09-18
 
 ### Added
 
-* Added `encase` feature, providing `encase` trait implementations for `glam`
+- Added `encase` feature, providing `encase` trait implementations for `glam`
   types.
 
 ### Changed
 
-* Consistently use `self` for vector and quat methods and `&self` for matrix and
+- Consistently use `self` for vector and quat methods and `&self` for matrix and
   affine methods.
 
-## [0.30.5] - 2025-07-26
+## [0.30.5](https://github.com/bitshifter/glam-rs/compare/0.30.4...0.30.5) - 2025-07-26
 
 ### Added
 
-* Added `Vec3::to_vec3a` and `Vec3A::to_vec3` methods.
+- Added `Vec3::to_vec3a` and `Vec3A::to_vec3` methods.
 
 ### Fixed
 
-* Fixed using `bytemuck` feature on `spirv` targets.
+- Fixed using `bytemuck` feature on `spirv` targets.
 
-## [0.30.4] - 2025-06-12
+## [0.30.4](https://github.com/bitshifter/glam-rs/compare/0.30.3...0.30.4) - 2025-06-12
 
 ### Added
 
-* Added 4x4 matrix `frustum_lh`, `frustum_rh` and `frustum_rh_gl` methods.
+- Added 4x4 matrix `frustum_lh`, `frustum_rh` and `frustum_rh_gl` methods.
 
-* Added assign methods for all corresponding op trait impls (e.g. `add_assign`,
+- Added assign methods for all corresponding op trait impls (e.g. `add_assign`,
   `div_assign`, `mul_assign`, `sub_assign` etc.)
 
-* Added by reference implementations for all op trait impls.
+- Added by reference implementations for all op trait impls.
 
 ### Changed
 
-* `bytemuck` trait implementations now use derive macros to catch potentially
+- `bytemuck` trait implementations now use derive macros to catch potentially
   misuse.
 
 ### Fixed
 
-* Fixed unsoundness in core-simd implementation of `Vec3A` to `[f32;3]` array
+- Fixed unsoundness in core-simd implementation of `Vec3A` to `[f32;3]` array
   and `Vec3A` to `Vec3` conversion.
 
-* Fixed potential unsoundness in conversion from `Vec4` to
+- Fixed potential unsoundness in conversion from `Vec4` to
   `(f32, f32, f32, f32)` tuple conversion.
 
-## [0.30.3] - 2025-05-01
+## [0.30.3](https://github.com/bitshifter/glam-rs/compare/0.30.2...0.30.3) - 2025-05-01
 
 ### Added
 
-* Added `speedy` feature, implementing serialization and deserialization via the
+- Added `speedy` feature, implementing serialization and deserialization via the
   `speedy` crate.
 
-* Added `fract_gl` to the 'FloatExt' trait which uses the GLSL specification of
+- Added `fract_gl` to the 'FloatExt' trait which uses the GLSL specification of
   `fract`, `self - self.floor()`.
 
-## [0.30.2] - 2025-04-13
+## [0.30.2](https://github.com/bitshifter/glam-rs/compare/0.30.1...0.30.2) - 2025-04-13
 
 ### Added
 
-* Added precision conversion functions for affine types:
+- Added precision conversion functions for affine types:
   `Affine3A::as_daffine3`, `DAffine3::as_affine3a`, `Affine2::as_daffine2` and
   `DAffine3::as_affine2`
 
-* Added `normalize_and_length` method to `f32` and `f64` vectors.
+- Added `normalize_and_length` method to `f32` and `f64` vectors.
 
 ### Changed
 
-* Vector min and max scalar implementations have been changed to use an `if`
+- Vector min and max scalar implementations have been changed to use an `if`
   check instead of the built in Rust floating point primitive `min` and `max`
   methods. The Rust methods have special handling for `NaN` propagation however
   because this is not consistent between the different SIMD implementations in
   glam the most efficient implementation is preferred.
 
-## [0.30.1] - 2025-03-20
+## [0.30.1](https://github.com/bitshifter/glam-rs/compare/0.30.0...0.30.1) - 2025-03-20
 
 ### Added
 
-* Added `usize` vector types, `USizeVec2`, `USizeVec3` and `USizeVec4`.
+- Added `usize` vector types, `USizeVec2`, `USizeVec3` and `USizeVec4`.
 
-* Added `min_position` and `max_position` methods for vector types, which return
+- Added `min_position` and `max_position` methods for vector types, which return
   the index of the min or max element in the vector.
 
-* Added `rotate_towards` method to 3D vector types.
+- Added `rotate_towards` method to 3D vector types.
 
 ### Changed
 
-* Removed the small angle check from 2D vector `rotate_towards` implementations
+- Removed the small angle check from 2D vector `rotate_towards` implementations
   as it was unnecessary and would not preserve the length of the input.
 
-## [0.30.0] - 2025-02-18
+## [0.30.0](https://github.com/bitshifter/glam-rs/compare/0.29.2...0.30.0) - 2025-02-18
 
 ### Breaking changes
 
-* The `up` and `dir` vectors passed to affine and matrix `look_to_lh` and
+- The `up` and `dir` vectors passed to affine and matrix `look_to_lh` and
   `look_to_rh` methods must now be normalized. This was changed to be consistent
   with other methods.
 
-* Updated the optional `rand` dependency to `0.9`
+- Updated the optional `rand` dependency to `0.9`
 
-* Updated the optional `rkyv` dependency to `0.8`
+- Updated the optional `rkyv` dependency to `0.8`
 
 ### Added
 
-* Implemented `rand` `Uniform` distribution trait for  all vector types.
+- Implemented `rand` `Uniform` distribution trait for  all vector types.
 
-* Added "swizzle assignment" support to vector swizzles, in the form of
+- Added "swizzle assignment" support to vector swizzles, in the form of
   `v.with_zx(ivec2(1, 2))` which will return a copy of `v` where the `z`
   and `x` components are set to 1 and 2 respectively.
 
-* Added `Mat3` and `Quat` `look_at_lh` and `look_at_rh` methods.
+- Added `Mat3` and `Quat` `look_at_lh` and `look_at_rh` methods.
 
-* Added `Quat` `look_to_lh` and `look_to_rh` methods.
+- Added `Quat` `look_to_lh` and `look_to_rh` methods.
 
-* Added 3D vector `slerp` method that performs a spherical linear interpolation
+- Added 3D vector `slerp` method that performs a spherical linear interpolation
   between a source and a target 3D vector.
 
-* Added `manhattan_distance`, `checked_manhattan_distance` and
+- Added `manhattan_distance`, `checked_manhattan_distance` and
   `chebyshev_distance` methods to integer vector types which calculates the
   Manhattan Distance and the Chebyshev Distance between two vectors.
 
-* Added 4x4 matrix `from_mat3_translation` method to have parity with the 3D
+- Added 4x4 matrix `from_mat3_translation` method to have parity with the 3D
   affine type.
 
 ### Fixed
 
-* `Quat::rotate_towards()` now returns the target `Quat` if the angle is small.
+- `Quat::rotate_towards()` now returns the target `Quat` if the angle is small.
   Previously `self` was returned which could skip the rotation entirely.
 
-## [0.29.2] - 2024-11-05
+## [0.29.2](https://github.com/bitshifter/glam-rs/compare/0.29.1...0.29.2) - 2024-11-05
 
 ### Fixed
 
-* Fix regression in vector `write_to_slice` methods where the destination had to
+- Fix regression in vector `write_to_slice` methods where the destination had to
   be the same size as the input, but it should support writing to a slice that
   is the same size or larger than the input.
 
-## [0.29.1] - 2024-10-30
+## [0.29.1](https://github.com/bitshifter/glam-rs/compare/0.29.0...0.29.1) - 2024-10-30
 
 ### Added
 
-* Added `i8` and `u8` vector types, `I8Vec2`, `I8Vec3`, `I8Vec4`,
+- Added `i8` and `u8` vector types, `I8Vec2`, `I8Vec3`, `I8Vec4`,
   `U8Vec2`, `U8Vec3` and `U8Vec4`.
 
-* Added `Mat4::project_point3a(Vec3A)` method transforming points by
+- Added `Mat4::project_point3a(Vec3A)` method transforming points by
   perspective projections.
 
 ### Changed
 
-* Removed normalized assertions from quaternion multiplies as sometimes this is
+- Removed normalized assertions from quaternion multiplies as sometimes this is
   valid.
 
-* Include `Debug` and `Display` implementations on `spirv` targets.
+- Include `Debug` and `Display` implementations on `spirv` targets.
 
-* Optimized vector `from_slice` and `write_to_slice` methods.
+- Optimized vector `from_slice` and `write_to_slice` methods.
 
-* Improved `serde` error messages.
+- Improved `serde` error messages.
 
-## [0.29.0] - 2024-08-20
+## [0.29.0](https://github.com/bitshifter/glam-rs/compare/0.28.0...0.29.0) - 2024-08-20
 
 ### Breaking changes
 
-* `EulerRot` has been reimplemented and now has support for 24 different
+- `EulerRot` has been reimplemented and now has support for 24 different
   rotation order enum values.
 
 ### Fixed
 
-* Reduced the dot threshold at which quaternion slerp uses lerp to improve
+- Reduced the dot threshold at which quaternion slerp uses lerp to improve
   accuracy.
 
 ### Added
 
-* Added 3x3 matrix `from_mat4_minor()` and 2x2 matrix `from_mat3_minor()`
+- Added 3x3 matrix `from_mat4_minor()` and 2x2 matrix `from_mat3_minor()`
   methods.
 
-* Added `bvec2`, `bvec3`, `bvec3a`, `bvec4` and `bvec4a` vector mask creation
+- Added `bvec2`, `bvec3`, `bvec3a`, `bvec4` and `bvec4a` vector mask creation
   functions.
 
-* Added all 24 possible intrinsic and extrinsic Euler angle rotation
+- Added all 24 possible intrinsic and extrinsic Euler angle rotation
   combinations to `EulerRot` enum.
 
-* Added `is_finite_mask` method to vector types which returns a vector mask.
+- Added `is_finite_mask` method to vector types which returns a vector mask.
 
-* Added `reflect` and `refract` methods to vector types.
+- Added `reflect` and `refract` methods to vector types.
 
-* Added `to_euler` methods to matrix types which extracts Euler angles from a
+- Added `to_euler` methods to matrix types which extracts Euler angles from a
   rotation matrix for a given `EulerRot`.
 
-* Added generic `map` method to vector types which applies a functor to all
+- Added generic `map` method to vector types which applies a functor to all
   vector elements.
 
-* Vector arithmetic ops are now implemented on references.
+- Vector arithmetic ops are now implemented on references.
 
 ### Changed
 
-* Vector and quaternion lerp now uses a precise lerp algorithm.
+- Vector and quaternion lerp now uses a precise lerp algorithm.
 
-## [0.28.0] - 2024-06-10
+## [0.28.0](https://github.com/bitshifter/glam-rs/compare/0.27.0...0.28.0) - 2024-06-10
 
 ### Breaking changes
 
-* Removed derives from `glam::deref` types used by `Deref` on SIMD vector
+- Removed derives from `glam::deref` types used by `Deref` on SIMD vector
   types.  These unintentionally added support for traits like `PartialOrd` to
   SIMD vector types. This may break existing code that was depending on this.
   Please use `cmple().all()` etc. instead of `PartialOrd` methods.
 
-* Removed `impl From<Vec4> for Vec3A` as this violated the `From` trait
+- Removed `impl From<Vec4> for Vec3A` as this violated the `From` trait
   contract that conversions should be lossless. Please use the explicit
   `Vec3A::from_vec4` method instead.
 
-* Renamed 2D vector `angle_between` to `angle_to` to differentiate from the 3D
+- Renamed 2D vector `angle_between` to `angle_to` to differentiate from the 3D
   `angle_between` which has different semantics to the 2D version.
 
 ### Added
 
-* Added aarch64 neon support.
+- Added aarch64 neon support.
 
-* Added `rotate_towards` methods for 2D vectors and quaternions.
+- Added `rotate_towards` methods for 2D vectors and quaternions.
 
-* Added `Vec3A::from_vec4` method which can perform a no-op conversion when
+- Added `Vec3A::from_vec4` method which can perform a no-op conversion when
   SIMD is used. This replaces the `impl From<Vec4> for Vec3A` implementation.
 
-## [0.27.0] - 2024-03-23
+## [0.27.0](https://github.com/bitshifter/glam-rs/compare/0.26.0...0.27.0) - 2024-03-23
 
 ### Breaking changes
 
-* Changed implementation of vector `fract` method to match the Rust
+- Changed implementation of vector `fract` method to match the Rust
   implementation instead of the GLSL implementation, that is `self -
   self.trunc()` instead of `self - self.floor()`.
 
 ### Added
 
-* Added vector `fract_gl` which uses the GLSL specification of `fract`,
+- Added vector `fract_gl` which uses the GLSL specification of `fract`,
  `self - self.floor()`.
 
-## [0.26.0] - 2024-03-18
+## [0.26.0](https://github.com/bitshifter/glam-rs/compare/0.25.0...0.26.0) - 2024-03-18
 
 ### Breaking changes
 
-* Minimum Supported Rust Version bumped to 1.68.2 for
+- Minimum Supported Rust Version bumped to 1.68.2 for
  `impl From<bool> for {f32,f64}` support.
 
 ### Fixed
 
-* Respect precision format specifier in Display implementations. Previously it
+- Respect precision format specifier in Display implementations. Previously it
   was ignored.
 
-* Corrected precision documentation for vector `is_normalized` methods and
+- Corrected precision documentation for vector `is_normalized` methods and
   changed the internal check to use `2e-4` to better match the documented
   precision value of `1e-4`.
 
 ### Added
 
- * Added `with_x`, `with_y`, etc. to vector types which returns a copy of
+- Added `with_x`, `with_y`, etc. to vector types which returns a copy of
    the vector with the new component value.
 
- * Added `midpoint` method to vector types that returns the point between two
+- Added `midpoint` method to vector types that returns the point between two
    points.
 
- * Added `move_towards` for float vector types.
+- Added `move_towards` for float vector types.
 
- * Added saturating add and sub methods for signed and unsigned integer vector
+- Added saturating add and sub methods for signed and unsigned integer vector
    types.
 
- * Added element wise sum and product methods for vector types.
+- Added element wise sum and product methods for vector types.
 
- * Added element wise absolute values method for matrix types.
+- Added element wise absolute values method for matrix types.
 
- * Added `from_array` method for boolean vector types.
+- Added `from_array` method for boolean vector types.
 
- * Added `normalize_or` method to vector types that returns the specified value
+- Added `normalize_or` method to vector types that returns the specified value
    if normalization failed.
 
- * Added `From<BVecN>` support for all vector types.
+- Added `From<BVecN>` support for all vector types.
 
- * Added `Div` and `DivAssign` by scalar implementations to matrix types.
+- Added `Div` and `DivAssign` by scalar implementations to matrix types.
 
-## [0.25.0] - 2023-12-19
+## [0.25.0](https://github.com/bitshifter/glam-rs/compare/0.24.2...0.25.0) - 2023-12-19
 
 ### Breaking changes
 
-* Changed `Vec4` to always used `BVec4A` as a mask type, regardless if the
+- Changed `Vec4` to always used `BVec4A` as a mask type, regardless if the
   target architecture has SIMD support in glam. Previously this was inconsistent
   on different hardware like ARM. This will have a slight performance cost when
   SIMD is not available. `Vec4` will continue to use `BVec4` as a mask type when
@@ -493,1068 +486,985 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Fixed
 
-* Made `Affine2` implement the `bytemuck::AnyBitPattern` trait instead of
+- Made `Affine2` implement the `bytemuck::AnyBitPattern` trait instead of
   `bytemuck::Pod` as it contains internal padding due to `Mat2` being 16 byte
   aligned.
 
-* Updated the `core-simd` implementation to build on latest nightly.
+- Updated the `core-simd` implementation to build on latest nightly.
 
 ### Added
 
-* Added `to_angle` method to 2D vectors.
+- Added `to_angle` method to 2D vectors.
 
-* Added `FloatExt` trait which adds `lerp`, `inverse_lerp` and `remap` methods
+- Added `FloatExt` trait which adds `lerp`, `inverse_lerp` and `remap` methods
   to `f32` and `f64` types.
 
-* Added `i16` and `u16` vector types, `I16Vec2`, `I16Vec3`, `I16Vec4`,
+- Added `i16` and `u16` vector types, `I16Vec2`, `I16Vec3`, `I16Vec4`,
   `U16Vec2`, `U16Vec3` and `U16Vec4`.
 
 ### Changed
 
-* Renamed `Quat::as_f64()` to `Quat::as_dquat()` and `DQuat::as_f32()` to
+- Renamed `Quat::as_f64()` to `Quat::as_dquat()` and `DQuat::as_f32()` to
   `DQuat::as_quat()` to be consistent with other types. The old methods have
   been deprecated.
 
-* Added the `#[must_use]` attribute to all pure functions following the
+- Added the `#[must_use]` attribute to all pure functions following the
   guidelines for the Rust standard library.
 
-## [0.24.2] - 2023-09-23
+## [0.24.2](https://github.com/bitshifter/glam-rs/compare/0.24.1...0.24.2) - 2023-09-23
 
 ### Fixed
 
-* Fixed singularities in `Quat::to_euler`.
+- Fixed singularities in `Quat::to_euler`.
 
 ### Added
 
-* Added `div_euclid` and `rem_euclid` to integer vector types.
+- Added `div_euclid` and `rem_euclid` to integer vector types.
 
-* Added wrapping and saturating arithmetic operations to integer vector types.
+- Added wrapping and saturating arithmetic operations to integer vector types.
 
-* Added `to_scale_angle_translation` to 2D affine types.
+- Added `to_scale_angle_translation` to 2D affine types.
 
-* Added `mul_assign` ops to affine types.
+- Added `mul_assign` ops to affine types.
 
 ### Changed
 
-* Disable default features on optional `rkyv` dependency.
+- Disable default features on optional `rkyv` dependency.
 
-## [0.24.1] - 2023-06-24
+## [0.24.1](https://github.com/bitshifter/glam-rs/compare/0.24.0...0.24.1) - 2023-06-24
 
 ### Added
 
-* Implemented missing `bytemuck`, `mint`, `rand`, `rkyv` and `serde` traits for
+- Implemented missing `bytemuck`, `mint`, `rand`, `rkyv` and `serde` traits for
   `i64` and `u64` types.
 
-* Added missing safe `From` conversions from `f32` vectors to `f64` vectors.
+- Added missing safe `From` conversions from `f32` vectors to `f64` vectors.
 
-* Added `TryFrom` implementations between different vector types.
+- Added `TryFrom` implementations between different vector types.
 
-* Added `test` and `set` methods to `bool` vector types for testing and setting
+- Added `test` and `set` methods to `bool` vector types for testing and setting
   individual mask elements.
 
-* Added `MIN`, `MAX`, `INFINITY` and `NEG_INFINITY` vector constants.
+- Added `MIN`, `MAX`, `INFINITY` and `NEG_INFINITY` vector constants.
 
-## [0.24.0] - 2023-04-24
+## [0.24.0](https://github.com/bitshifter/glam-rs/compare/0.23.0...0.24.0) - 2023-04-24
 
 ### Breaking changes
 
-* Enabling `libm` in a `std` build now overrides the `std` math functions. This
+- Enabling `libm` in a `std` build now overrides the `std` math functions. This
   is unlikely to break anything but it is a change in behavior.
 
 ### Added
 
-* Added `i64` and `u64` vector types; `I64Vec2`, `I64Vec3`, `I64Vec4`,
+- Added `i64` and `u64` vector types; `I64Vec2`, `I64Vec3`, `I64Vec4`,
   `U64Vec2`, `U64Vec3` and `U64Vec4`.
 
-* Added `length_squared` method on signed and unsigned integer vector types.
+- Added `length_squared` method on signed and unsigned integer vector types.
 
-* Added `distance_squared` method on signed integer vector types.
+- Added `distance_squared` method on signed integer vector types.
 
-* Implemented the `bytemuck` `AnyBitPattern` trait on `Vec3A`, `Mat3A` and
+- Implemented the `bytemuck` `AnyBitPattern` trait on `Vec3A`, `Mat3A` and
   `Affine3A`.
 
 ### Changed
 
-* Changed quaternion `to_axis_angle` for improved numerical stability.
+- Changed quaternion `to_axis_angle` for improved numerical stability.
 
 ### Removed
 
-* Removed dependency on `serde_derive` for improved compile times when using
+- Removed dependency on `serde_derive` for improved compile times when using
   `serde`.
 
-## [0.23.0] - 2023-02-22
+## [0.23.0](https://github.com/bitshifter/glam-rs/compare/0.22.0...0.23.0) - 2023-02-22
 
 ### Breaking changes
 
-* When the `scalar-math` feature is enabled the vector mask type for `Vec3A` was
+- When the `scalar-math` feature is enabled the vector mask type for `Vec3A` was
   changed from `BVec3` to `BVec3A`.
 
 ### Added
 
-* Added `copysign` method to signed vector types.
+- Added `copysign` method to signed vector types.
 
-## [0.22.0] - 2022-10-24
+## [0.22.0](https://github.com/bitshifter/glam-rs/compare/0.21.3...0.22.0) - 2022-10-24
 
 ### Breaking changes
 
-* Added `u32` implementation of `BVec3A` and `BVec4` when SIMD is not available.
+- Added `u32` implementation of `BVec3A` and `BVec4` when SIMD is not available.
   These are used instead of aliasing to the `bool` implementations.
 
-* Removed `Add`, `Sub`, and scalar `Mul` implementations from affine types as
+- Removed `Add`, `Sub`, and scalar `Mul` implementations from affine types as
   they didn't make sense on these types.
 
-* Removed deprecated `const_*` macros. These have been replaced by `const fn`
+- Removed deprecated `const_*` macros. These have been replaced by `const fn`
   methods.
 
 ### Fixed
 
-* Fixed `neg` and `signum` to consistently handle negative zero across multiple
+- Fixed `neg` and `signum` to consistently handle negative zero across multiple
   platforms.
 
-* Removed `register_attr` feature usage for SPIR-V targets.
+- Removed `register_attr` feature usage for SPIR-V targets.
 
 ### Added
 
-* Added missing `Serialize`, `Deserialize` and `PartialEq` implementations.
+- Added missing `Serialize`, `Deserialize` and `PartialEq` implementations.
 
-* Added `Sum<Self>` and `Product<Self>` implementations for all vector, matrix
+- Added `Sum<Self>` and `Product<Self>` implementations for all vector, matrix
   and quaternion types.
 
-* Added 4x4 matrix methods `look_to_lh` and `look_to_rh`. These were previously
+- Added 4x4 matrix methods `look_to_lh` and `look_to_rh`. These were previously
   private.
 
-* Added `dot_into_vec` methods to vector which returns the result of the dot
+- Added `dot_into_vec` methods to vector which returns the result of the dot
   product splatted to all vector lanes.
 
-* Added `is_negative_bitmask` to vector types which returns a `u32` of bits for
+- Added `is_negative_bitmask` to vector types which returns a `u32` of bits for
   each negative vector lane.
 
-* Added `splat` method and `TRUE` and `FALSE` constants to all `BVec` types.
+- Added `splat` method and `TRUE` and `FALSE` constants to all `BVec` types.
 
-* Added `from_mat3a` methods to `Affine2`, `Mat2`, `Mat4` and `Quat` types.
+- Added `from_mat3a` methods to `Affine2`, `Mat2`, `Mat4` and `Quat` types.
 
 ### Changed
 
-* Disable `serde` default features.
+- Disable `serde` default features.
 
-* Made `to_cols_array`, `to_cols_array_2d`, and `from_diagonal` methods
+- Made `to_cols_array`, `to_cols_array_2d`, and `from_diagonal` methods
  `const fn`.
 
-## [0.21.3] - 2022-08-02
+## [0.21.3](https://github.com/bitshifter/glam-rs/compare/0.21.2...0.21.3) - 2022-08-02
 
 ### Fixed
 
-* Fixed `glam_assert` being too restrictive in matrix transform point and
+- Fixed `glam_assert` being too restrictive in matrix transform point and
   transform vector methods.
 
 ### Added
 
-* Added experimental `core-simd` feature which enables SIMD support via the
+- Added experimental `core-simd` feature which enables SIMD support via the
   unstable `core::simd` module.
 
 ### Changed
 
-* Derive from `PartialEq` and `Eq` instead of providing a trait implementation
+- Derive from `PartialEq` and `Eq` instead of providing a trait implementation
   for all non SIMD types.
 
-## [0.21.2] - 2022-06-25
+## [0.21.2](https://github.com/bitshifter/glam-rs/compare/0.21.1...0.21.2) - 2022-06-25
 
 ### Fixed
 
-* Restore missing `$crate::` prefix in deprecated `const_*` macros.
+- Restore missing `$crate::` prefix in deprecated `const_*` macros.
 
-* Fixed some performance regressions in affine and matrix determinant and
+- Fixed some performance regressions in affine and matrix determinant and
   inverses due to lack of inlining.
 
-* Fixed some performance regressions in the SSE2 `Vec3A` to `Vec3` from
+- Fixed some performance regressions in the SSE2 `Vec3A` to `Vec3` from
   conversion.
 
 ### Added
 
-* Implemented `BitXor` and `BitXorAssign` traits for `bool` vectors.
+- Implemented `BitXor` and `BitXorAssign` traits for `bool` vectors.
 
-## [0.21.1] - 2022-06-22
+## [0.21.1](https://github.com/bitshifter/glam-rs/compare/0.21.0...0.21.1) - 2022-06-22
 
 ### Fixed
 
-* Fix compilation when FMA support is enabled.
+- Fix compilation when FMA support is enabled.
 
-## [0.21.0] - 2022-06-22
+## [0.21.0](https://github.com/bitshifter/glam-rs/compare/0.20.5...0.21.0) - 2022-06-22
 
 ### Breaking changes
 
-* Minimum Supported Version of Rust bumped to 1.58.1 to allow `const` pointer
+- Minimum Supported Version of Rust bumped to 1.58.1 to allow `const` pointer
   dereferences in constant evaluation.
 
-* The `abs_diff_eq` method on `Mat2` and `DMat2` now takes `other` by value
+- The `abs_diff_eq` method on `Mat2` and `DMat2` now takes `other` by value
   instead of reference. This is consistent with the other matrix types.
 
-* The `AsMut` and `Deref` trait implementations on `Quat` and `DQuat` was
+- The `AsMut` and `Deref` trait implementations on `Quat` and `DQuat` was
   removed. Quaternion fields are now public.
 
-* The `AsRef` trait implementations were removed from `BVec2`, `BVec3`,
+- The `AsRef` trait implementations were removed from `BVec2`, `BVec3`,
   `BVec3A`, `BVec4` and `BVec4A`.
 
 ### Added
 
-* `NEG_ONE` constant was added to all signed vector types.
+- `NEG_ONE` constant was added to all signed vector types.
 
-* `NEG_X`, `NEG_Y`, `NEG_Z` and `NEG_W` negative axis vectors were added to
+- `NEG_X`, `NEG_Y`, `NEG_Z` and `NEG_W` negative axis vectors were added to
   signed vector types.
 
-* The `rotate` and `from_angle` methods were added to `Vec2` and `DVec2`.
+- The `rotate` and `from_angle` methods were added to `Vec2` and `DVec2`.
   `from_angle` returns a 2D vector containing `[angle.cos(), angle.sin()]` that
   can be used to `rotate` another 2D vector.
 
-* The `from_array` `const` function was added to all vector types.
+- The `from_array` `const` function was added to all vector types.
 
 ### Changed
 
-* Source code is now largely generated. This removes most usage of macros
+- Source code is now largely generated. This removes most usage of macros
   internally to improve readability. There should be no change in API or
   behavior other than what is documented here.
 
-* Many methods have been made `const fn`:
-  * `new`, `splat`, `from_slice`, `to_array` and `extend` on vector types
-  * `from_cols`, `from_cols_array`, `from_cols_array_2d`, `from_cols_slice` on
+- Many methods have been made `const fn`:
+  - `new`, `splat`, `from_slice`, `to_array` and `extend` on vector types
+  - `from_cols`, `from_cols_array`, `from_cols_array_2d`, `from_cols_slice` on
     matrix types
-  * `from_xyzw` and `from_array` on quaternion types
-  * `from_cols` on affine types
+  - `from_xyzw` and `from_array` on quaternion types
+  - `from_cols` on affine types
 
-* The `const` new macros where deprecated.
+- The `const` new macros where deprecated.
 
 ### Removed
 
-* Deleted deprecated `TransformRT` and `TransformSRT` types.
+- Deleted deprecated `TransformRT` and `TransformSRT` types.
 
-## [0.20.5] - 2022-04-12
+## [0.20.5](https://github.com/bitshifter/glam-rs/compare/0.20.4...0.20.5) - 2022-04-12
 
 ### Fixed
 
-* Fixed a bug in the scalar implementation of 4D vector `max_element` method
+- Fixed a bug in the scalar implementation of 4D vector `max_element` method
   where the `w` element check was incorrect.
 
-## [0.20.4] - 2022-04-11
+## [0.20.4](https://github.com/bitshifter/glam-rs/compare/0.20.3...0.20.4) - 2022-04-11
 
 ### Fixed
 
-* Fixed a bug with quaternion `slerp` with a rotation of tau.
+- Fixed a bug with quaternion `slerp` with a rotation of tau.
 
-## [0.20.3] - 2022-03-28
+## [0.20.3](https://github.com/bitshifter/glam-rs/compare/0.20.2...0.20.3) - 2022-03-28
 
 ### Added
 
-* Added `to_array()` to `Quat` and `DQuat`.
-* Added `mul_add` method to all vector types - note that this will be slower
+- Added `to_array()` to `Quat` and `DQuat`.
+- Added `mul_add` method to all vector types - note that this will be slower
   without hardware support enabled.
-* Added the `fast-math` flag which will sacrifice some float determinism for
+- Added the `fast-math` flag which will sacrifice some float determinism for
   speed.
 
 ### Fixed
 
-* Fixed a bug in the `sse2` and `wasm32` implementations of
+- Fixed a bug in the `sse2` and `wasm32` implementations of
   `Mat4::determinant()`.
 
-## [0.20.2] - 2021-12-20
+## [0.20.2](https://github.com/bitshifter/glam-rs/compare/0.20.1...0.20.2) - 2021-12-20
 
 ### Fixed
 
-* Fixed SPIR-V build which was broken due to a typo.
+- Fixed SPIR-V build which was broken due to a typo.
 
-## [0.20.1] - 2021-11-23
+## [0.20.1](https://github.com/bitshifter/glam-rs/compare/0.20.0...0.20.1) - 2021-11-23
 
 ### Added
 
-* Added the `from_rotation_arc_2d()` method to `Quat` and `DQuat` which will
+- Added the `from_rotation_arc_2d()` method to `Quat` and `DQuat` which will
   return a rotation between two 2D vectors around the z axis.
-* Added impl of `Neg` operator for matrix types.
-* Added `cuda` feature which forces `glam` types to match cuda's alignment
+- Added impl of `Neg` operator for matrix types.
+- Added `cuda` feature which forces `glam` types to match cuda's alignment
   requirements.
 
 ### Changed
 
-* The `Quat` and `DQuat` methods `from_rotation_arc()` and
+- The `Quat` and `DQuat` methods `from_rotation_arc()` and
   `from_rotation_arc_colinear()` are now available in `no_std`.
-* The `Vec3` and `DVec3` methods `any_orthogonal_vector()`,
+- The `Vec3` and `DVec3` methods `any_orthogonal_vector()`,
   `any_orthonormal_vector()` and `any_orthonormal_pair()` are now available in
   `no_std`.
-* Added `repr(C)` attribute to affine types.
+- Added `repr(C)` attribute to affine types.
 
 ### Removed
 
-* Removed deprecated `as_f32()`, `as_f64()`, `as_i32()` and `as_u32()` methods.
+- Removed deprecated `as_f32()`, `as_f64()`, `as_i32()` and `as_u32()` methods.
 
-## [0.20.0] - 2021-11-01
+## [0.20.0](https://github.com/bitshifter/glam-rs/compare/0.19.0...0.20.0) - 2021-11-01
 
 ### Breaking changes
 
-* Minimum Supported Version of Rust bumped to 1.52.1 for an update to the `mint`
+- Minimum Supported Version of Rust bumped to 1.52.1 for an update to the `mint`
   crate.
 
 ### Added
 
-* Added implementations for new `IntoMint` trait from the `mint` crate.
-* Added `mint` conversions for `Mat3A`.
-* Added `as_vec3a` cast methods to vector types.
+- Added implementations for new `IntoMint` trait from the `mint` crate.
+- Added `mint` conversions for `Mat3A`.
+- Added `as_vec3a` cast methods to vector types.
 
-## [0.19.0] - 2021-10-05
+## [0.19.0](https://github.com/bitshifter/glam-rs/compare/0.18.0...0.19.0) - 2021-10-05
 
 ### Breaking changes
 
-* Removed truncating vector `From` implementations. Use `.truncate()` or swizzle
+- Removed truncating vector `From` implementations. Use `.truncate()` or swizzle
   methods instead.
 
 ### Added
 
-* Added `Not`, `Shl`, `Shr`, `BitAnd`, `BitOr` and `BitXor` implementations for
+- Added `Not`, `Shl`, `Shr`, `BitAnd`, `BitOr` and `BitXor` implementations for
   all `IVec` and `UVec` vector types.
-* Added `NAN` constant for all types.
-* Documented `glam`'s [architecture](ARCHITECTURE.md).
+- Added `NAN` constant for all types.
+- Documented `glam`'s [architecture](ARCHITECTURE.md).
 
 ### Changed
 
-* `Sum` and `Product` traits are now implemented in `no_std` builds.
+- `Sum` and `Product` traits are now implemented in `no_std` builds.
 
-## [0.18.0] - 2021-08-26
+## [0.18.0](https://github.com/bitshifter/glam-rs/compare/0.17.3...0.18.0) - 2021-08-26
 
 ### Breaking changes
 
-* Minimum Supported Version of Rust bumped to 1.51.0 for `wasm-bindgen-test`
+- Minimum Supported Version of Rust bumped to 1.51.0 for `wasm-bindgen-test`
   and `rustdoc` `alias` support.
 
 ### Added
 
-* Added `wasm32` SIMD intrinsics support.
-* Added optional support for the `rkyv` serialization crate.
-* Added `Rem` and `RemAssign` implementations for all vector types.
-* Added quaternion `xyz()` method for returning the vector part of the
+- Added `wasm32` SIMD intrinsics support.
+- Added optional support for the `rkyv` serialization crate.
+- Added `Rem` and `RemAssign` implementations for all vector types.
+- Added quaternion `xyz()` method for returning the vector part of the
   quaternion.
-* Added `From((Scalar, Vector3))` for 4D vector types.
+- Added `From((Scalar, Vector3))` for 4D vector types.
 
 ### Changed
 
-* Deprecated `as_f32()`, `as_f64()`, `as_i32()` and `as_u32()` methods in favor
+- Deprecated `as_f32()`, `as_f64()`, `as_i32()` and `as_u32()` methods in favor
   of more specific methods such as `as_vec2()`, `as_dvec2()`, `as_ivec2()` and
   `as_uvec2()` and so on.
 
-## [0.17.3] - 2021-07-18
+## [0.17.3](https://github.com/bitshifter/glam-rs/compare/0.17.2...0.17.3) - 2021-07-18
 
 ### Fixed
 
-* Fix alignment unit tests on non x86 platforms.
+- Fix alignment unit tests on non x86 platforms.
 
-## [0.17.2] - 2021-07-15
+## [0.17.2](https://github.com/bitshifter/glam-rs/compare/0.17.1...0.17.2) - 2021-07-15
 
 ### Fixed
 
-* Fix alignment unit tests on i686 and S390x.
+- Fix alignment unit tests on i686 and S390x.
 
-## [0.17.1] - 2021-06-29
+## [0.17.1](https://github.com/bitshifter/glam-rs/compare/0.17.0...0.17.1) - 2021-06-29
 
 ### Added
 
-* Added `serde` support for `Affine2`, `DAffine2`, `Affine3A` and `DAffine3`.
+- Added `serde` support for `Affine2`, `DAffine2`, `Affine3A` and `DAffine3`.
 
-## [0.17.0] - 2021-06-26
+## [0.17.0](https://github.com/bitshifter/glam-rs/compare/0.16.0...0.17.0) - 2021-06-26
 
 ### Breaking changes
 
-* The addition of `Add` and `Sub` implementations of scalar values for vector
+- The addition of `Add` and `Sub` implementations of scalar values for vector
   types may create ambiguities with existing calls to `add` and `sub`.
-* Removed `From<Mat3>` implementation for `Mat2` and `From<DMat3>` for `DMat2`.
+- Removed `From<Mat3>` implementation for `Mat2` and `From<DMat3>` for `DMat2`.
   These have been replaced by `Mat2::from_mat3()` and `DMat2::from_mat3()`.
-* Removed `From<Mat4>` implementation for `Mat3` and `From<DMat4>` for `DMat3`.
+- Removed `From<Mat4>` implementation for `Mat3` and `From<DMat4>` for `DMat3`.
   These have been replaced by `Mat3::from_mat4()` and `DMat3::from_mat4()`.
-* Removed deprecated `from_slice_unaligned()`, `write_to_slice_unaligned()`,
+- Removed deprecated `from_slice_unaligned()`, `write_to_slice_unaligned()`,
   `from_rotation_mat4` and `from_rotation_ypr()` methods.
 
 ### Added
 
-* Added `col_mut()` method which returns a mutable reference to a matrix column
+- Added `col_mut()` method which returns a mutable reference to a matrix column
   to all matrix types.
-* Added `AddAssign`, `MulAssign` and `SubAssign` implementations for all matrix
+- Added `AddAssign`, `MulAssign` and `SubAssign` implementations for all matrix
   types.
-* Added `Add` and `Sub` implementations of scalar values for vector types.
-* Added more `glam_assert!` checks and documented methods where they are used.
-* Added vector projection and rejection methods `project_onto()`,
+- Added `Add` and `Sub` implementations of scalar values for vector types.
+- Added more `glam_assert!` checks and documented methods where they are used.
+- Added vector projection and rejection methods `project_onto()`,
   `project_onto_normalized()`, `reject_from()` and `reject_from_normalized()`.
-* Added `Mat2::from_mat3()`, `DMat2::from_mat3()`, `Mat3::from_mat4()`,
+- Added `Mat2::from_mat3()`, `DMat2::from_mat3()`, `Mat3::from_mat4()`,
   `DMat3::from_mat4()` which create a smaller matrix from a larger one,
   discarding a final row and column of the input matrix.
-* Added `Mat3::from_mat2()`, `DMat3::from_mat2()`, `Mat4::from_mat3()` and
+- Added `Mat3::from_mat2()`, `DMat3::from_mat2()`, `Mat4::from_mat3()` and
   `DMat4::from_mat3()` which create an affine transform from a smaller linear
   transform matrix.
 
 ### Changed
 
-* Don't support `AsRef` and `AsMut` on SPIR-V targets. Also removed SPIR-V
+- Don't support `AsRef` and `AsMut` on SPIR-V targets. Also removed SPIR-V
   support for some methods that used `as_ref()`, including `hash()`. Not a
   breaking change as these methods would not have worked anyway.
 
 ### Fixed
 
-* Fixed compile time alignment checks failing on i686 targets.
+- Fixed compile time alignment checks failing on i686 targets.
 
-## [0.16.0] - 2021-06-06
+## [0.16.0](https://github.com/bitshifter/glam-rs/compare/0.15.2...0.16.0) - 2021-06-06
 
 ### Breaking changes
 
-* `sprirv-std` dependency was removed, rust-gpu depends on glam internally
+- `sprirv-std` dependency was removed, rust-gpu depends on glam internally
   again for now.
-* Added `must_use` attribute to all `inverse()`, `normalize()`,
+- Added `must_use` attribute to all `inverse()`, `normalize()`,
   `try_normalize()`, `transpose()` and `conjugate()` methods.
 
 ### Added
 
-* Added `fract()` method to float vector types which return a vector containing
+- Added `fract()` method to float vector types which return a vector containing
   `self - self.floor()`.
-* Added optional support for the `approx` crate. Note that all glam types
+- Added optional support for the `approx` crate. Note that all glam types
   implement their own `abs_diff_eq()` method without requiring the `approx`
   dependency.
 
-## [0.15.2] - 2021-05-20
+## [0.15.2](https://github.com/bitshifter/glam-rs/compare/0.15.1...0.15.2) - 2021-05-20
 
 ### Added
 
-* Added `from_cols()` methods to affine types.
-* Added methods for reading and writing affine types from and to arrays and
+- Added `from_cols()` methods to affine types.
+- Added methods for reading and writing affine types from and to arrays and
   slices, including `from_cols_array()`, `to_cols_array()`,
   `from_cols_array_2d()`, `to_cols_array_2d()`, `from_cols_slice()` and
   `write_cols_to_slice()`.
-* Added `core::fmt::Display` trait implementations for affine types.
-* Added `core::ops::Add`, `core::ops::Mul` scalar and `core::ops::Sub` trait
+- Added `core::fmt::Display` trait implementations for affine types.
+- Added `core::ops::Add`, `core::ops::Mul` scalar and `core::ops::Sub` trait
   implementations for affine types.
-* Added `from_array()` methods to quaternion types.
+- Added `from_array()` methods to quaternion types.
 
 ### Changed
 
-* Renamed vector and quaternion `from_slice_unaligned()` and
+- Renamed vector and quaternion `from_slice_unaligned()` and
   `write_to_slice_unaligned()` methods to `from_slice()` and
   `write_to_slice()`.
-* Removed usage of `_mm_rcp_ps` from SSE2 implementation of `Quat::slerp` as
+- Removed usage of `_mm_rcp_ps` from SSE2 implementation of `Quat::slerp` as
   this instruction is not deterministic between Intel and AMD chips.
 
-## [0.15.1] - 2021-05-14
+## [0.15.1](https://github.com/bitshifter/glam-rs/compare/0.15.0...0.15.1) - 2021-05-14
 
 ### Changed
 
-* Disable `const_assert_eq!` size and alignment checks for SPIR-V targets.
+- Disable `const_assert_eq!` size and alignment checks for SPIR-V targets.
 
-## [0.15.0] - 2021-05-14
+## [0.15.0](https://github.com/bitshifter/glam-rs/compare/0.14.0...0.15.0) - 2021-05-14
 
 ### Breaking changes
 
-* Removed `PartialOrd` and `Ord` trait implementations for all `glam` types.
-* Removed deprecated `zero()`, `one()`, `unit_x()`, `unit_y()`, `unit_z()`,
+- Removed `PartialOrd` and `Ord` trait implementations for all `glam` types.
+- Removed deprecated `zero()`, `one()`, `unit_x()`, `unit_y()`, `unit_z()`,
   `unit_w()`, `identity()` and `Mat2::scale()` methods.
-* Remove problematic `Quat` `From` trait conversions which would allow creating
+- Remove problematic `Quat` `From` trait conversions which would allow creating
   a non-uniform quaternion without necessarily realizing, including from
   `Vec4`, `(x, y, z, w)` and `[f32; 4]`.
 
 ### Added
 
-* Added `EulerRot` enum for specifying Euler rotation order and
+- Added `EulerRot` enum for specifying Euler rotation order and
   `Quat::from_euler()`, `Mat3::from_euler()` and `Mat4::from_euler()` which
   support specifying a rotation order and angles of rotation.
-* Added `Quat::to_euler()` method for extracting Euler angles.
-* Added `Quat::from_vec4()` which is an explicit method for creating a
+- Added `Quat::to_euler()` method for extracting Euler angles.
+- Added `Quat::from_vec4()` which is an explicit method for creating a
   quaternion from a 4D vector. The method does not normalize the resulting
   quaternion.
-* Added `Mat3A` type which uses `Vec3A` columns. It is 16 byte aligned and
+- Added `Mat3A` type which uses `Vec3A` columns. It is 16 byte aligned and
   contains internal padding but it generally faster than `Mat3` for most
   operations if SIMD is available.
-* Added 3D affine transform types `Affine3A` and `DAffine3`. These are more
+- Added 3D affine transform types `Affine3A` and `DAffine3`. These are more
   efficient than using `Mat4` and `DMat4` respectively when working with 3D
   affine transforms.
-* Added 2D affine transform types `Affine2` and `DAffine2`. These are more
+- Added 2D affine transform types `Affine2` and `DAffine2`. These are more
   efficient than using `Mat3` and `DMat3` respectively when working with 2D
   affine transforms.
-* Added `Quat::from_affine3()` to create a quaternion from an affine transform
+- Added `Quat::from_affine3()` to create a quaternion from an affine transform
   rotation.
-* Added explicit `to_array()` method to vector types to better match the matrix
+- Added explicit `to_array()` method to vector types to better match the matrix
   methods.
 
 ### Changed
 
-* Deprecated `Quat::from_rotation_ypr()`, `Mat3::from_rotation_ypr()` and
+- Deprecated `Quat::from_rotation_ypr()`, `Mat3::from_rotation_ypr()` and
   `Mat4::from_rotation_ypr()` in favor of new `from_euler()` methods.
-* Deprecated `Quat::from_rotation_mat3()` and `Quat::from_rotation_mat4()` in
+- Deprecated `Quat::from_rotation_mat3()` and `Quat::from_rotation_mat4()` in
   favor of new `from_mat3` and `from_mat4` methods.
-* Deprecated `TransformSRT` and `TransformRT` which are under the
+- Deprecated `TransformSRT` and `TransformRT` which are under the
   `transform-types` feature. These will be moved to a separate experimental
   crate.
-* Updated `spirv-std` dependency version to `0.4.0-alpha7`.
+- Updated `spirv-std` dependency version to `0.4.0-alpha7`.
 
-## [0.14.0] - 2021-04-09
+## [0.14.0](https://github.com/bitshifter/glam-rs/compare/0.13.1...0.14.0) - 2021-04-09
 
 ### Breaking changes
 
-* Minimum Supported Version of Rust bumped to 1.45.0 for the `spirv-std`
+- Minimum Supported Version of Rust bumped to 1.45.0 for the `spirv-std`
   dependency.
 
 ### Added
 
-* Added `AXES[]` constants to all vector types. These are arrays containing the
+- Added `AXES[]` constants to all vector types. These are arrays containing the
   unit vector for each axis.
-* Added quaternion `from_scaled_axis` and `to_scaled_axis` methods.
+- Added quaternion `from_scaled_axis` and `to_scaled_axis` methods.
 
 ### Changed
 
-* Updated dependency versions of `bytemuck` to `1.5`, `rand` to `0.8`,
+- Updated dependency versions of `bytemuck` to `1.5`, `rand` to `0.8`,
   `rand_xoshiro` to `0.6` and `spirv-std` to `0.4.0-alpha4`.
 
-## [0.13.1] - 2021-03-24
+## [0.13.1](https://github.com/bitshifter/glam-rs/compare/0.13.0...0.13.1) - 2021-03-24
 
 ### Added
 
-* Added vector `clamp()` functions.
-* Added matrix column and row accessor methods, `col()` and `row()`.
-* Added SPIR-V module and dependency on `spirv-std` for the SPIR-V target.
-* Added matrix truncation from 4x4 to 3x3 and 3x3 to 2x2 via `From` impls.
+- Added vector `clamp()` functions.
+- Added matrix column and row accessor methods, `col()` and `row()`.
+- Added SPIR-V module and dependency on `spirv-std` for the SPIR-V target.
+- Added matrix truncation from 4x4 to 3x3 and 3x3 to 2x2 via `From` impls.
 
 ### Changed
 
-* Documentation corrections and improvements.
+- Documentation corrections and improvements.
 
-## [0.13.0] - 2021-03-04
+## [0.13.0](https://github.com/bitshifter/glam-rs/compare/0.12.0...0.13.0) - 2021-03-04
 
-### Breaking Changes
+### Breaking changes
 
-* The behavior of the 4x4 matrix method `transform_point3()` was changed to not
+- The behavior of the 4x4 matrix method `transform_point3()` was changed to not
   perform the perspective divide. This is an optimization for use with affine
   transforms where perspective correction is not required. The
   `project_point3()` method was added for transforming points by perspective
   projections.
-* The 3x3 matrix `from_scale()` method was changed to
+- The 3x3 matrix `from_scale()` method was changed to
   create a affine transform containing a 2-dimensional non-uniform scale to be
   consistent with the 4x4 matrix version. The
   `from_diagonal()` method can be used to create a 3x3 scale matrix.
-* The 3x3 matrix methods `transform_point2_as_vec3a`,
+- The 3x3 matrix methods `transform_point2_as_vec3a`,
   `transform_vector2_as_vec3a` and `mul_vec3_as_vec3a` were unintentionally
   `pub` and are no longer publicly accessible.
 
 ### Added
 
-* Added `Vec2::X`, `Vec4::W` etc constants as a shorter versions of `unit_x()`
+- Added `Vec2::X`, `Vec4::W` etc constants as a shorter versions of `unit_x()`
   and friends.
-* Added `ONE` constants for vectors.
-* Added `IDENTITY` constants for `Mat2`, `Mat3`, `Mat4` and `Quat`.
-* Added `ZERO` constant for vectors and matrices.
-* Added `clamp_length()`, `clamp_length_max()`, and `clamp_length_min` methods
+- Added `ONE` constants for vectors.
+- Added `IDENTITY` constants for `Mat2`, `Mat3`, `Mat4` and `Quat`.
+- Added `ZERO` constant for vectors and matrices.
+- Added `clamp_length()`, `clamp_length_max()`, and `clamp_length_min` methods
   for `f32` and `f64` vector types.
-* Added `try_normalize()` and `normalize_or_zero()` for all real vector types.
-* Added `from_diagonal()` methods to all matrix types for creating diagonal
+- Added `try_normalize()` and `normalize_or_zero()` for all real vector types.
+- Added `from_diagonal()` methods to all matrix types for creating diagonal
   matrices from a vector.
-* Added `angle_between()`, `from_rotation_arc()` and
+- Added `angle_between()`, `from_rotation_arc()` and
   `from_rotation_arc_colinear()` to quaternion types.
-* Added quaternion `inverse()` which assumes the quaternion is already
+- Added quaternion `inverse()` which assumes the quaternion is already
   normalized and returns the conjugate.
-* Added `from_translation()` and `from_angle()` methods to 3x3 matrix types.
-* Added `project_point3()` method to 4x4 matrix types. This method is for
+- Added `from_translation()` and `from_angle()` methods to 3x3 matrix types.
+- Added `project_point3()` method to 4x4 matrix types. This method is for
   transforming 3D vectors by perspective projection transforms.
-* Added `Eq` and `Hash` impls for integer vector types.
+- Added `Eq` and `Hash` impls for integer vector types.
 
 ### Changed
 
-* Deprecated `::unit_x/y/z()`, `::zero()`, `::one()`, `::identity()` functions
+- Deprecated `::unit_x/y/z()`, `::zero()`, `::one()`, `::identity()` functions
   in favor of constants.
 
-## [0.12.0] - 2021-01-15
+## [0.12.0](https://github.com/bitshifter/glam-rs/compare/0.11.3...0.12.0) - 2021-01-15
 
-### Breaking Changes
+### Breaking changes
 
-* `Vec2Mask`, `Vec3Mask` and `Vec4Mask` have been replaced by `BVec2`, `BVec3`,
+- `Vec2Mask`, `Vec3Mask` and `Vec4Mask` have been replaced by `BVec2`, `BVec3`,
   `BVec3A`, `BVec4` and `BVec4A`. These types are used by some vector methods
   and are not typically referenced directly.
 
 ### Added
 
-* Added `f64` primitive type support
-  * vectors: `DVec2`, `DVec3` and `DVec4`
-  * square matrices: `DMat2`, `DMat3` and `DMat4`
-  * a quaternion type: `DQuat`
-* Added `i32` primitive type support
-  * vectors: `IVec2`, `IVec3` and `IVec4`
-* Added `u32` primitive type support
-  * vectors: `UVec2`, `UVec3` and `UVec4`
-* Added `bool` primitive type support
-  * vectors: `BVec2`, `BVec3` and `BVec4`
+- Added `f64` primitive type support
+  - vectors: `DVec2`, `DVec3` and `DVec4`
+  - square matrices: `DMat2`, `DMat3` and `DMat4`
+  - a quaternion type: `DQuat`
+- Added `i32` primitive type support
+  - vectors: `IVec2`, `IVec3` and `IVec4`
+- Added `u32` primitive type support
+  - vectors: `UVec2`, `UVec3` and `UVec4`
+- Added `bool` primitive type support
+  - vectors: `BVec2`, `BVec3` and `BVec4`
 
 ### Removed
 
-* `build.rs` has been removed.
+- `build.rs` has been removed.
 
-## [0.11.3] - 2020-12-29
-
-### Changed
-
-* Made `Vec3` `repr(simd)` for `spirv` targets.
-
-### Added
-
-* Added `From<(Vec2, f32)>` for `Vec3` and `From<(Vec3, f32)` for `Vec4`.
-
-## [0.11.2] - 2020-12-04
+## [0.11.3](https://github.com/bitshifter/glam-rs/compare/0.11.2...0.11.3) - 2020-12-29
 
 ### Changed
 
-* Compilation fixes for Rust 1.36.0.
-
-## [0.11.1] - 2020-12-03
+- Made `Vec3` `repr(simd)` for `spirv` targets.
 
 ### Added
 
-* Added support for the [Rust GPU](https://github.com/EmbarkStudios/rust-gpu)
+- Added `From<(Vec2, f32)>` for `Vec3` and `From<(Vec3, f32)` for `Vec4`.
+
+## [0.11.2](https://github.com/bitshifter/glam-rs/compare/0.11.1...0.11.2) - 2020-12-04
+
+### Changed
+
+- Compilation fixes for Rust 1.36.0.
+
+## [0.11.1](https://github.com/bitshifter/glam-rs/compare/0.11.0...0.11.1) - 2020-12-03
+
+### Added
+
+- Added support for the [Rust GPU](https://github.com/EmbarkStudios/rust-gpu)
   SPIR-V target architecture.
 
-## [0.11.0] - 2020-11-26
+## [0.11.0](https://github.com/bitshifter/glam-rs/compare/0.10.2...0.11.0) - 2020-11-26
 
 ### Added
 
-* Added `is_finite` method to all types which returns `true` if, and only if,
+- Added `is_finite` method to all types which returns `true` if, and only if,
   all contained elements are finite.
-* Added `exp` and `powf` methods for all vector types.
+- Added `exp` and `powf` methods for all vector types.
 
 ### Changed
 
-* The `is_nan` method now returns a `bool` to match the new `is_finite` method
+- The `is_nan` method now returns a `bool` to match the new `is_finite` method
   and to be consistent with the same methods on the `f32` and `f64` primitive
   types.
-* Renamed `is_nan` which returns a vector mask to `is_nan_mask`.
-* Don't use the `cfg` definitions added by `build.rs` for defining structs as
+- Renamed `is_nan` which returns a vector mask to `is_nan_mask`.
+- Don't use the `cfg` definitions added by `build.rs` for defining structs as
   `rust-analyzer` is not aware of them.
 
 ### Removed
 
-* Removed deprecated accessor methods.
+- Removed deprecated accessor methods.
 
-## [0.10.2] - 2020-11-17
+## [0.10.2](https://github.com/bitshifter/glam-rs/compare/0.10.1...0.10.2) - 2020-11-17
 
 ### Changed
 
-* Deprecated element accessor members `.x()`, `.x_mut()`, `.set_x()`, etc. on
+- Deprecated element accessor members `.x()`, `.x_mut()`, `.set_x()`, etc. on
   vector and quaternion types.
-* Deprecated column accessor members `.x_axis()`, `.x_axis_mut()`,
+- Deprecated column accessor members `.x_axis()`, `.x_axis_mut()`,
   `.set_x_axis()`, etc. on matrix types.
 
-## [0.10.1] - 2020-11-15
+## [0.10.1](https://github.com/bitshifter/glam-rs/compare/0.10.0...0.10.1) - 2020-11-15
 
 ### Added
 
-* Added the `Vec2::perp` method which returns a `Vec2` perpendicular to `self`.
+- Added the `Vec2::perp` method which returns a `Vec2` perpendicular to `self`.
 
 ### Changed
 
-* `Vec2` and `Vec3` types were changed to use public named fields for `.x`,
+- `Vec2` and `Vec3` types were changed to use public named fields for `.x`,
   `.y`, and `.z` instead of accessors.
-* `Quat`, `Vec3A` and `Vec4` implement `Deref` and `DerefMut` for the new `XYZ`
+- `Quat`, `Vec3A` and `Vec4` implement `Deref` and `DerefMut` for the new `XYZ`
   and `XYZW` structs to emulate public named field access.
-* `Mat3` and `Mat4` had their axis members made public instead of needing
+- `Mat3` and `Mat4` had their axis members made public instead of needing
   accessors.
-* `Mat2` implements `Deref` and `DerefMut` for the new `XYAxes` struct to
+- `Mat2` implements `Deref` and `DerefMut` for the new `XYAxes` struct to
   emulate public named field access.
 
 ### Removed
 
-* Removed deprecated `length_reciprocal` and `sign` methods.
+- Removed deprecated `length_reciprocal` and `sign` methods.
 
 ### Fixed
 
-* Adding `glam` as a `no_std` dependency should now work as expected.
+- Adding `glam` as a `no_std` dependency should now work as expected.
 
-## [0.10.0] - 2020-10-31
+## [0.10.0](https://github.com/bitshifter/glam-rs/compare/0.9.5...0.10.0) - 2020-10-31
 
-### Breaking Changes
+### Breaking changes
 
-* Changed the return type of `Vec4::truncate` from `Vec3A` to `Vec3`.
+- Changed the return type of `Vec4::truncate` from `Vec3A` to `Vec3`.
 
 ### Added
 
-* Added `From` implementations to truncate to narrower vector types, e.g.
+- Added `From` implementations to truncate to narrower vector types, e.g.
   `Vec4` to `Vec3A`, `Vec3` and `Vec2` and from `Vec3A` and `Vec3` to `Vec2`.
-* Added swizzles for `Vec4`, `Vec3A`, `Vec3` and `Vec2`. These can be used to
+- Added swizzles for `Vec4`, `Vec3A`, `Vec3` and `Vec2`. These can be used to
   reorder elements in the same type and also to create larger or smaller
   vectors from the given vectors elements.
-* Added `Quat` operators `Add<Quat>`, `Sub<Quat>`, `Mul<f32>` and `Div<f32`.
+- Added `Quat` operators `Add<Quat>`, `Sub<Quat>`, `Mul<f32>` and `Div<f32`.
   These are used by other crates for interpolation quaternions along splines.
   Note that these operations will not return unit length quaternions, thus the
   results must be normalized before performing other `Quat` operations.
-* Added `Mat4::transform_point3a` and `Mat4::transform_vector3a`.
-* Added `AsRef<[f32; 9]>` and `AsMut<[f32; 9]>` trait implementations to `Mat3`.
-* Added optional `bytemuck` support primarily for casting types to `&[u8]`.
-* Added support for compiling with `no_std` by disabling the default `std`
+- Added `Mat4::transform_point3a` and `Mat4::transform_vector3a`.
+- Added `AsRef<[f32; 9]>` and `AsMut<[f32; 9]>` trait implementations to `Mat3`.
+- Added optional `bytemuck` support primarily for casting types to `&[u8]`.
+- Added support for compiling with `no_std` by disabling the default `std`
   feature and adding the `libm` feature.
-* Added `distance` and `distance_squared` methods to `Vec2`, `Vec3`, `Vec3A`
+- Added `distance` and `distance_squared` methods to `Vec2`, `Vec3`, `Vec3A`
   and `Vec4`.
 
-## [0.9.5] - 2020-10-10
+## [0.9.5](https://github.com/bitshifter/glam-rs/compare/0.9.4...0.9.5) - 2020-10-10
 
 ### Added
 
-* `glam` uses SSE2 for some types which prevents constructor functions can not
+- `glam` uses SSE2 for some types which prevents constructor functions can not
   be made `const fn`. To work around this limitation the following macro
   functions have been added to support creating `const` values of `glam` types:
   `const_mat2`, `const_mat3`, `const_mat4`, `const_quat`, `const_vec2`,
   `const_vec3`, `const_vec3a` and `const_vec4`.
-* Added `is_nan` methods to `Vec2`, `Vec3`, `Vec3A` and `Vec4` which return a
+- Added `is_nan` methods to `Vec2`, `Vec3`, `Vec3A` and `Vec4` which return a
   mask.
 
 ## Changed
 
-* Renamed the vector `reciprocal` and `length_reciprocal` methods to `recip`
+- Renamed the vector `reciprocal` and `length_reciprocal` methods to `recip`
   and `length_recip` to match the Rust standard library naming. The old methods
   have been deprecated.
-* Renamed the vector `sign` methods to `signum` match the Rust standard library
+- Renamed the vector `sign` methods to `signum` match the Rust standard library
   naming. The new methods now check for `NAN`. The old methods have been
   deprecated.
-* Added SSE2 optimized implementations of `Mat4::determinant` and
+- Added SSE2 optimized implementations of `Mat4::determinant` and
   `Mat4::inverse`.
 
 ### Removed
 
-* Removed deprecated function `Mat4::perspective_glu_rh`.
+- Removed deprecated function `Mat4::perspective_glu_rh`.
 
-## [0.9.4] - 2020-08-31
+## [0.9.4](https://github.com/bitshifter/glam-rs/compare/0.9.3...0.9.4) - 2020-08-31
 
 ### Fixed
 
-* Fixed `Mat4::transform_point3` to account for homogeneous w coordinate.
+- Fixed `Mat4::transform_point3` to account for homogeneous w coordinate.
   Previously this would have been incorrect when the resulting homogeneous
   coordinate was not 1.0, e.g. when transforming by a perspective projection.
-* Fixed `Mat3::transform_point2` to account for homogeneous z coordinate.
+- Fixed `Mat3::transform_point2` to account for homogeneous z coordinate.
 
-## [0.9.3] - 2020-08-11
-
-### Added
-
-* Added `Mat4::perspective_rh`.
-
-## [0.9.2] - 2020-07-09
+## [0.9.3](https://github.com/bitshifter/glam-rs/compare/0.9.2...0.9.3) - 2020-08-11
 
 ### Added
 
-* Added `Mat3::mul_vec3a` and `Quat::mul_vec3a`.
+- Added `Mat4::perspective_rh`.
+
+## [0.9.2](https://github.com/bitshifter/glam-rs/compare/0.9.1...0.9.2) - 2020-07-09
+
+### Added
+
+- Added `Mat3::mul_vec3a` and `Quat::mul_vec3a`.
 
 ### Changed
 
-* Changed `Quat::mul_vec3` to accept and return `Vec3` instead of `Vec3A`.
+- Changed `Quat::mul_vec3` to accept and return `Vec3` instead of `Vec3A`.
 
-## [0.9.1] - 2020-07-01
+## [0.9.1](https://github.com/bitshifter/glam-rs/compare/0.9.0...0.9.1) - 2020-07-01
 
 ### Added
 
-* Added `Mat3 * Vec3A` implementation.
-* Added `Vec3A` benches.
+- Added `Mat3 * Vec3A` implementation.
+- Added `Vec3A` benches.
 
 ### Changed
 
-* Some documentation improvements around the new `Vec3A` type.
+- Some documentation improvements around the new `Vec3A` type.
 
-## [0.9.0] - 2020-06-28
+## [0.9.0](https://github.com/bitshifter/glam-rs/compare/0.8.7...0.9.0) - 2020-06-28
 
 ### Added
 
-* `Vec3` has been split into scalar `Vec3` and 16 byte aligned `Vec3A` types.
+- `Vec3` has been split into scalar `Vec3` and 16 byte aligned `Vec3A` types.
   Only the `Vec3A` type currently uses SIMD optimizations.
-* `Vec3Mask` has been split into scalar `Vec3Mask` and 16 byte aligned
+- `Vec3Mask` has been split into scalar `Vec3Mask` and 16 byte aligned
   `Vec3AMask` types.
-* Added `mut` column accessors to all matrix types, e.g. `Mat2::x_axis_mut()`.
-* Added `From` trait implementations for `Vec3AMask` and `Vec4Mask` to `__m128`.
+- Added `mut` column accessors to all matrix types, e.g. `Mat2::x_axis_mut()`.
+- Added `From` trait implementations for `Vec3AMask` and `Vec4Mask` to `__m128`.
 
 ### Changed
 
-* The `Mat3` type is using the scalar `Vec3` type for storage.
-* Simplified `Debug` trait output for `Quat`, `Vec4` and `Vec3A`.
+- The `Mat3` type is using the scalar `Vec3` type for storage.
+- Simplified `Debug` trait output for `Quat`, `Vec4` and `Vec3A`.
 
 ## Removed
 
-* Removed the `packed-vec3` feature flag as it is now redundant.
+- Removed the `packed-vec3` feature flag as it is now redundant.
 
-## [0.8.7] - 2020-04-28
+## [0.8.7](https://github.com/bitshifter/glam-rs/compare/0.8.6...0.8.7) - 2020-04-28
 
 ### Added
 
-* Added `Quat::slerp` - note that this uses a `sin` approximation.
-* Added `angle_between` method for `Vec2` and `Vec3`.
-* Implemented `Debug`, `Display`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`,
+- Added `Quat::slerp` - note that this uses a `sin` approximation.
+- Added `angle_between` method for `Vec2` and `Vec3`.
+- Implemented `Debug`, `Display`, `PartialEq`, `Eq`, `PartialOrd`, `Ord`,
   `Hash`, and `AsRef` traits for `Vec2Mask`, `Vec3Mask` and `Vec4Mask`.
-* Added conversion functions from `Vec2Mask`, `Vec3Mask` and `Vec4Mask` to an
+- Added conversion functions from `Vec2Mask`, `Vec3Mask` and `Vec4Mask` to an
   array of `[u32]`.
-* Added `build.rs` to simplify conditional feature compilation.
+- Added `build.rs` to simplify conditional feature compilation.
 
 ### Changed
 
-* Increased test coverage.
+- Increased test coverage.
 
 ### Removed
 
-* Removed `cfg-if` dependency.
+- Removed `cfg-if` dependency.
 
-## [0.8.6] - 2020-02-18
+## [0.8.6](https://github.com/bitshifter/glam-rs/compare/0.8.5...0.8.6) - 2020-02-18
 
 ### Added
 
-* Added the `packed-vec3` feature flag to disable using SIMD types for `Vec3`
+- Added the `packed-vec3` feature flag to disable using SIMD types for `Vec3`
   and `Mat3` types. This avoids wasting some space due to 16 byte alignment at
   the cost of some performance.
-* Added `x_mut`, `y_mut`, `z_mut`, `w_mut` where appropriate to `Vec2`, `Vec3`
+- Added `x_mut`, `y_mut`, `z_mut`, `w_mut` where appropriate to `Vec2`, `Vec3`
   and `Vec4`.
-* Added implementation of `core::ops::Index` and `core::ops::IndexMut` for
+- Added implementation of `core::ops::Index` and `core::ops::IndexMut` for
   `Vec2`, `Vec3` and `Vec4`.
 
 ### Changed
 
-* Merged SSE2 and scalar `Vec3` and `Vec4` implementations into single files
+- Merged SSE2 and scalar `Vec3` and `Vec4` implementations into single files
   using the `cfg-if` crate.
 
-## [0.8.5] - 2020-01-02
+## [0.8.5](https://github.com/bitshifter/glam-rs/compare/0.8.4...0.8.5) - 2020-01-02
 
 ### Added
 
-* Added projection functions `Mat4::perspective_lh`,
+- Added projection functions `Mat4::perspective_lh`,
   `Mat4::perspective_infinite_lh`, `Mat4::perspective_infinite_reverse_lh`,
   `Mat4::orthgraphic_lh` and `Mat4::orthographic_rh`.
-* Added `round`, `ceil` and `floor` methods to `Vec2`, `Vec3` and `Vec4`.
+- Added `round`, `ceil` and `floor` methods to `Vec2`, `Vec3` and `Vec4`.
 
-## [0.8.4] - 2019-12-17
+## [0.8.4](https://github.com/bitshifter/glam-rs/compare/0.8.3...0.8.4) - 2019-12-17
 
 ### Added
 
-* Added `Mat4::to_scale_rotation_translation` for extracting scale, rotation and
+- Added `Mat4::to_scale_rotation_translation` for extracting scale, rotation and
   translation from a 4x4 homogeneous transformation matrix.
-* Added `cargo-deny` GitHub Action.
+- Added `cargo-deny` GitHub Action.
 
 ### Changed
 
-* Renamed `Quat::new` to `Quat::from_xyzw`.
+- Renamed `Quat::new` to `Quat::from_xyzw`.
 
-## [0.8.3] - 2019-11-27
+## [0.8.3](https://github.com/bitshifter/glam-rs/compare/0.8.2...0.8.3) - 2019-11-27
 
 ### Added
 
-* Added `Mat4::orthographic_rh_gl`.
+- Added `Mat4::orthographic_rh_gl`.
 
 ### Changed
 
-* Renamed `Mat4::perspective_glu_rh` to `Mat4::perspective_rh_gl`.
-* SSE2 optimizations for `Mat2::determinant`, `Mat2::inverse`,
+- Renamed `Mat4::perspective_glu_rh` to `Mat4::perspective_rh_gl`.
+- SSE2 optimizations for `Mat2::determinant`, `Mat2::inverse`,
   `Mat2::transpose`, `Mat3::transpose`, `Quat::conjugate`, `Quat::lerp`,
   `Quat::mul_vec3`, `Quat::mul_quat` and `Quat::from_rotation_ypr`.
-* Disabled optimizations to `Mat4::transform_point3` and
+- Disabled optimizations to `Mat4::transform_point3` and
   `Mat4::transform_vector3` as they are probably incorrect and need
   investigating.
-* Added missing `#[repr(C)]` to `Mat2`, `Mat3` and `Mat4`.
-* Benchmarks now store output of functions to better estimate the cost of a
+- Added missing `#[repr(C)]` to `Mat2`, `Mat3` and `Mat4`.
+- Benchmarks now store output of functions to better estimate the cost of a
   function call.
 
 ### Removed
 
-* Removed deprecated functions `Mat2::new`, `Mat3::new` and `Mat4::new`.
+- Removed deprecated functions `Mat2::new`, `Mat3::new` and `Mat4::new`.
 
-## [0.8.2] - 2019-11-06
+## [0.8.2](https://github.com/bitshifter/glam-rs/compare/0.8.1...0.8.2) - 2019-11-06
 
 ### Changed
 
-* `glam_assert!` is no longer enabled by default in debug builds, it can be
+- `glam_assert!` is no longer enabled by default in debug builds, it can be
   enabled in any configuration using the `glam-assert` feature or in debug
   builds only using the `debug-glam-assert` feature.
 
 ### Removed
 
-* `glam_assert!`'s checking `lerp` is bounded between 0.0 and 1.0 and that
+- `glam_assert!`'s checking `lerp` is bounded between 0.0 and 1.0 and that
   matrix scales are non-zero have been removed.
 
-## [0.8.1] - 2019-11-03
+## [0.8.1](https://github.com/bitshifter/glam-rs/compare/0.8.0...0.8.1) - 2019-11-03
 
 ### Added
 
-* Added `Display` trait implementations for `Mat2`, `Mat3` and `Mat4`.
+- Added `Display` trait implementations for `Mat2`, `Mat3` and `Mat4`.
 
 ### Changed
 
-* Disabled `glam`'s SSE2 `sin_cos` implementation - it became less precise for
+- Disabled `glam`'s SSE2 `sin_cos` implementation - it became less precise for
   large angle values.
-* Reduced the default epsilon used by the `is_normalized!` macro from
+- Reduced the default epsilon used by the `is_normalized!` macro from
   `std::f32::EPSILON` to `1e-6`.
 
-## [0.8.0] - 2019-10-14
+## [0.8.0](https://github.com/bitshifter/glam-rs/compare/0.7.2...0.8.0) - 2019-10-14
 
 ### Removed
 
-* Removed the `approx` crate dependency. Each `glam` type has an `abs_diff_eq`
+- Removed the `approx` crate dependency. Each `glam` type has an `abs_diff_eq`
   method added which is used by unit tests for approximate floating point
   comparisons.
-* Removed the `Angle` type. All angles are now `f32` and are expected to
+- Removed the `Angle` type. All angles are now `f32` and are expected to
   be in radians.
-* Removed the deprecated `Vec2b`, `Vec3b` and `Vec4b` types and the `mask`
+- Removed the deprecated `Vec2b`, `Vec3b` and `Vec4b` types and the `mask`
   methods on `Vec2Mask`, `Vec3Mask` and `Vec4Mask`.
 
 ### Changed
 
-* The `rand` crate dependency has been removed from default features. This was
+- The `rand` crate dependency has been removed from default features. This was
   required for benchmarking but a simple random number generator has been added
   to the benches `support` module instead.
-* The `From` trait implementation converting between 1D and 2D `f32` arrays and
+- The `From` trait implementation converting between 1D and 2D `f32` arrays and
   matrix types have been removed. It was ambiguous how array data would map to
   matrix columns so these have been replaced with explicit methods
   `from_cols_array` and `from_cols_array_2d`.
-* Matrix `new` methods have been renamed to `from_cols` to be consistent with
+- Matrix `new` methods have been renamed to `from_cols` to be consistent with
   the other methods that create matrices from data.
-* Renamed `Mat4::perspective_glu` to `Mat4::perspective_glu_rh`.
+- Renamed `Mat4::perspective_glu` to `Mat4::perspective_glu_rh`.
 
-## [0.7.2] - 2019-09-22
+## [0.7.2](https://github.com/bitshifter/glam-rs/compare/0.7.1...0.7.2) - 2019-09-22
 
 ### Fixed
 
-* Fixed incorrect projection matrix methods `Mat4::look_at_lh`
+- Fixed incorrect projection matrix methods `Mat4::look_at_lh`
   and `Mat4::look_at_rh`.
 
 ### Added
 
-* Added support for building infinite projection matrices, including both
+- Added support for building infinite projection matrices, including both
   standard and reverse depth `Mat4::perspective_infinite_rh` and
   `Mat4::perspective_infinite_rh`.
-* Added `Vec2Mask::new`, `Vec3Mask::new` and `Vec4Mask::new` methods.
-* Implemented `std::ops` `BitAnd`, `BitAndAssign`, `BitOr`, `BitOrAssign`
+- Added `Vec2Mask::new`, `Vec3Mask::new` and `Vec4Mask::new` methods.
+- Implemented `std::ops` `BitAnd`, `BitAndAssign`, `BitOr`, `BitOrAssign`
   and `Not` traits for `Vec2Mask`, `Vec3Mask` and `Vec4Mask`.
-* Added method documentation for `Vec4` and `Vec4Mask` types.
-* Added missing `serde` implementations for `Mat2`, `Mat3` and `Mat4`.
-* Updated `rand` and `criterion` versions.
+- Added method documentation for `Vec4` and `Vec4Mask` types.
+- Added missing `serde` implementations for `Mat2`, `Mat3` and `Mat4`.
+- Updated `rand` and `criterion` versions.
 
-## [0.7.1] - 2019-07-08
+## [0.7.1](https://github.com/bitshifter/glam-rs/compare/0.7.0...0.7.1) - 2019-07-08
 
 ### Fixed
 
-* The SSE2 implementation of `Vec4` `dot` was missing a shuffle, meaning the
+- The SSE2 implementation of `Vec4` `dot` was missing a shuffle, meaning the
   `dot`, `length`, `length_squared`, `length_reciprocal` and `normalize`
   methods were sometimes incorrect.
 
 ### Added
 
-* Added the `glam_assert` macro which behaves like Rust's `debug_assert` but
+- Added the `glam_assert` macro which behaves like Rust's `debug_assert` but
   can be enabled separately to `debug_assert`. This is used to perform
   asserts on correctness.
-* Added `is_normalized` method to `Vec2`, `Vec3` and `Vec4`.
+- Added `is_normalized` method to `Vec2`, `Vec3` and `Vec4`.
 
 ### Changed
 
-* Replaced usage of `std::mem::uninitialized` with `std::mem::MaybeUninit`. This
+- Replaced usage of `std::mem::uninitialized` with `std::mem::MaybeUninit`. This
   change requires stable Rust 1.36.
-* Renamed `Vec2b` to `Vec2Mask`, `Vec3b` to `Vec3Mask` and `Vec4b` to
+- Renamed `Vec2b` to `Vec2Mask`, `Vec3b` to `Vec3Mask` and `Vec4b` to
   `Vec4Mask`. Old names are aliased to the new name and deprecated.
-* Deprecate `VecNMask` `mask` method, use new `bitmask` method instead
-* Made fallback version of `VecNMask` types the same size and alignment as the
+- Deprecate `VecNMask` `mask` method, use new `bitmask` method instead
+- Made fallback version of `VecNMask` types the same size and alignment as the
   SIMD versions.
-* Added `Default` support to `VecNMask` types, will add more common traits in
+- Added `Default` support to `VecNMask` types, will add more common traits in
   the future.
-* Added `#[inline]` to `mat2`, `mat3` and `mat4` functions.
+- Added `#[inline]` to `mat2`, `mat3` and `mat4` functions.
 
-## [0.7.0] - 2019-06-28
+## [0.7.0](https://github.com/bitshifter/glam-rs/compare/0.6.1...0.7.0) - 2019-06-28
 
 ### Added
 
-* Added `Mat2` into `[f32; 4]`, `Mat3` into `[f32; 9]` and `Mat4` into
+- Added `Mat2` into `[f32; 4]`, `Mat3` into `[f32; 9]` and `Mat4` into
   `[f32; 16]`.
 
 ### Removed
 
-* Removed `impl Mul<&Vec2> for Mat2` and `impl Mul<&Vec3> for Vec3` as these
+- Removed `impl Mul<&Vec2> for Mat2` and `impl Mul<&Vec3> for Vec3` as these
   don't exist for any other types.
 
-## [0.6.1] - 2019-06-22
+## [0.6.1](https://github.com/bitshifter/glam-rs/compare/0.6.0...0.6.1) - 2019-06-22
 
 ### Changed
 
-* `Mat2` now uses a `Vec4` internally which gives it some performance
+- `Mat2` now uses a `Vec4` internally which gives it some performance
    improvements when SSE2 is available.
 
 ## 0.6.0 - 2019-06-13
 
 ### Changed
 
-* Switched from row vectors to column vectors
-* Vectors are now on the right of multiplications with matrices and quaternions.
+- Switched from row vectors to column vectors
+- Vectors are now on the right of multiplications with matrices and quaternions.
 
-[Keep a Changelog]: https://keepachangelog.com/
-[Semantic Versioning]: https://semver.org/spec/v2.0.0.html
-[Unreleased]: https://github.com/bitshifter/glam-rs/compare/0.33.3...HEAD
-[0.33.3]: https://github.com/bitshifter/glam-rs/compare/0.33.2...0.33.3
-[0.33.2]: https://github.com/bitshifter/glam-rs/compare/0.33.1...0.33.2
-[0.33.1]: https://github.com/bitshifter/glam-rs/compare/0.33.0...0.33.1
-[0.33.0]: https://github.com/bitshifter/glam-rs/compare/0.32.1...0.33.0
-[0.32.1]: https://github.com/bitshifter/glam-rs/compare/0.32.0...0.32.1
-[0.32.0]: https://github.com/bitshifter/glam-rs/compare/0.31.1...0.32.0
-[0.31.1]: https://github.com/bitshifter/glam-rs/compare/0.31.0...0.31.1
-[0.31.0]: https://github.com/bitshifter/glam-rs/compare/0.30.10...0.31.0
-[0.30.10]: https://github.com/bitshifter/glam-rs/compare/0.30.9...0.30.10
-[0.30.9]: https://github.com/bitshifter/glam-rs/compare/0.30.8...0.30.9
-[0.30.8]: https://github.com/bitshifter/glam-rs/compare/0.30.7...0.30.8
-[0.30.7]: https://github.com/bitshifter/glam-rs/compare/0.30.6...0.30.7
-[0.30.6]: https://github.com/bitshifter/glam-rs/compare/0.30.5...0.30.6
-[0.30.5]: https://github.com/bitshifter/glam-rs/compare/0.30.4...0.30.5
-[0.30.4]: https://github.com/bitshifter/glam-rs/compare/0.30.3...0.30.4
-[0.30.3]: https://github.com/bitshifter/glam-rs/compare/0.30.2...0.30.3
-[0.30.2]: https://github.com/bitshifter/glam-rs/compare/0.30.1...0.30.2
-[0.30.1]: https://github.com/bitshifter/glam-rs/compare/0.30.0...0.30.1
-[0.30.0]: https://github.com/bitshifter/glam-rs/compare/0.29.2...0.30.0
-[0.29.2]: https://github.com/bitshifter/glam-rs/compare/0.29.1...0.29.2
-[0.29.1]: https://github.com/bitshifter/glam-rs/compare/0.29.0...0.29.1
-[0.29.0]: https://github.com/bitshifter/glam-rs/compare/0.28.0...0.29.0
-[0.28.0]: https://github.com/bitshifter/glam-rs/compare/0.27.0...0.28.0
-[0.27.0]: https://github.com/bitshifter/glam-rs/compare/0.26.0...0.27.0
-[0.26.0]: https://github.com/bitshifter/glam-rs/compare/0.25.0...0.26.0
-[0.25.0]: https://github.com/bitshifter/glam-rs/compare/0.24.2...0.25.0
-[0.24.2]: https://github.com/bitshifter/glam-rs/compare/0.24.1...0.24.2
-[0.24.1]: https://github.com/bitshifter/glam-rs/compare/0.24.0...0.24.1
-[0.24.0]: https://github.com/bitshifter/glam-rs/compare/0.23.0...0.24.0
-[0.23.0]: https://github.com/bitshifter/glam-rs/compare/0.22.0...0.23.0
-[0.22.0]: https://github.com/bitshifter/glam-rs/compare/0.21.3...0.22.0
-[0.21.3]: https://github.com/bitshifter/glam-rs/compare/0.21.2...0.21.3
-[0.21.2]: https://github.com/bitshifter/glam-rs/compare/0.21.1...0.21.2
-[0.21.1]: https://github.com/bitshifter/glam-rs/compare/0.21.0...0.21.1
-[0.21.0]: https://github.com/bitshifter/glam-rs/compare/0.20.5...0.21.0
-[0.20.5]: https://github.com/bitshifter/glam-rs/compare/0.20.4...0.20.5
-[0.20.4]: https://github.com/bitshifter/glam-rs/compare/0.20.3...0.20.4
-[0.20.3]: https://github.com/bitshifter/glam-rs/compare/0.20.2...0.20.3
-[0.20.2]: https://github.com/bitshifter/glam-rs/compare/0.20.1...0.20.2
-[0.20.1]: https://github.com/bitshifter/glam-rs/compare/0.20.0...0.20.1
-[0.20.0]: https://github.com/bitshifter/glam-rs/compare/0.19.0...0.20.0
-[0.19.0]: https://github.com/bitshifter/glam-rs/compare/0.18.0...0.19.0
-[0.18.0]: https://github.com/bitshifter/glam-rs/compare/0.17.3...0.18.0
-[0.17.3]: https://github.com/bitshifter/glam-rs/compare/0.17.2...0.17.3
-[0.17.2]: https://github.com/bitshifter/glam-rs/compare/0.17.1...0.17.2
-[0.17.1]: https://github.com/bitshifter/glam-rs/compare/0.17.0...0.17.1
-[0.17.0]: https://github.com/bitshifter/glam-rs/compare/0.16.0...0.17.0
-[0.16.0]: https://github.com/bitshifter/glam-rs/compare/0.15.2...0.16.0
-[0.15.2]: https://github.com/bitshifter/glam-rs/compare/0.15.1...0.15.2
-[0.15.1]: https://github.com/bitshifter/glam-rs/compare/0.15.0...0.15.1
-[0.15.0]: https://github.com/bitshifter/glam-rs/compare/0.14.0...0.15.0
-[0.14.0]: https://github.com/bitshifter/glam-rs/compare/0.13.1...0.14.0
-[0.13.1]: https://github.com/bitshifter/glam-rs/compare/0.13.0...0.13.1
-[0.13.0]: https://github.com/bitshifter/glam-rs/compare/0.12.0...0.13.0
-[0.12.0]: https://github.com/bitshifter/glam-rs/compare/0.11.3...0.12.0
-[0.11.3]: https://github.com/bitshifter/glam-rs/compare/0.11.2...0.11.3
-[0.11.2]: https://github.com/bitshifter/glam-rs/compare/0.11.1...0.11.2
-[0.11.1]: https://github.com/bitshifter/glam-rs/compare/0.11.0...0.11.1
-[0.11.0]: https://github.com/bitshifter/glam-rs/compare/0.10.2...0.11.0
-[0.10.2]: https://github.com/bitshifter/glam-rs/compare/0.10.1...0.10.2
-[0.10.1]: https://github.com/bitshifter/glam-rs/compare/0.10.0...0.10.1
-[0.10.0]: https://github.com/bitshifter/glam-rs/compare/0.9.5...0.10.0
-[0.9.5]: https://github.com/bitshifter/glam-rs/compare/0.9.4...0.9.5
-[0.9.4]: https://github.com/bitshifter/glam-rs/compare/0.9.3...0.9.4
-[0.9.3]: https://github.com/bitshifter/glam-rs/compare/0.9.2...0.9.3
-[0.9.2]: https://github.com/bitshifter/glam-rs/compare/0.9.1...0.9.2
-[0.9.1]: https://github.com/bitshifter/glam-rs/compare/0.9.0...0.9.1
-[0.9.0]: https://github.com/bitshifter/glam-rs/compare/0.8.7...0.9.0
-[0.8.7]: https://github.com/bitshifter/glam-rs/compare/0.8.6...0.8.7
-[0.8.6]: https://github.com/bitshifter/glam-rs/compare/0.8.5...0.8.6
-[0.8.5]: https://github.com/bitshifter/glam-rs/compare/0.8.4...0.8.5
-[0.8.4]: https://github.com/bitshifter/glam-rs/compare/0.8.3...0.8.4
-[0.8.3]: https://github.com/bitshifter/glam-rs/compare/0.8.2...0.8.3
-[0.8.2]: https://github.com/bitshifter/glam-rs/compare/0.8.1...0.8.2
-[0.8.1]: https://github.com/bitshifter/glam-rs/compare/0.8.0...0.8.1
-[0.8.0]: https://github.com/bitshifter/glam-rs/compare/0.7.2...0.8.0
-[0.7.2]: https://github.com/bitshifter/glam-rs/compare/0.7.1...0.7.2
-[0.7.1]: https://github.com/bitshifter/glam-rs/compare/0.7.0...0.7.1
-[0.7.0]: https://github.com/bitshifter/glam-rs/compare/0.6.1...0.7.0
-[0.6.1]: https://github.com/bitshifter/glam-rs/compare/0.6.0...0.6.1


### PR DESCRIPTION
Normalize the hand-curated CHANGELOG.md to the format release-plz generates, as part of the release-plz migration (see #772).

- drop the `## [Unreleased]` section (release-plz regenerates entries from commit history; removes the need to maintain the `[Unreleased]:` compare link each release)
- `*` bullets -> `-` bullets
- reference-style links -> inline links (version compare links, intro links)
- delete the bottom reference block
- unify `### Breaking Changes` capitalization