### PR TITLE
ci: exempt release-plz PRs from the title lint and fix the bump policy docs

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -7,11 +7,11 @@ name: Lint PR
 #
 # This check is advisory: it is not a required status check, so it does not
 # block merging. PR titles can also be adjusted in the merge dialog when
-# squashing. Dependabot PRs (labelled `dependencies`) and draft PRs are
-# exempt.
+# squashing. Dependabot PRs (labelled `dependencies`) and release-plz PRs
+# (labelled `release`) are exempt, as are draft PRs.
 on:
   pull_request_target:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, ready_for_review]
 
 permissions:
   pull-requests: read
@@ -19,6 +19,9 @@ permissions:
 jobs:
   conventional-commits:
     name: Conventional Commits
+    # Skip draft (work-in-progress) PRs; they are validated once marked
+    # ready for review.
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
     steps:
       - uses: amannn/action-semantic-pull-request@v6
@@ -38,7 +41,8 @@ jobs:
             ci
             build
             revert
-          ignoreLabels: dependencies # dependabot PRs
-          ignoreDraft: true # WIP PRs
+          ignoreLabels: |
+            dependencies # dependabot PRs
+            release # release-plz PRs ("Prepare <version> release")
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,12 +56,14 @@ Common types are `feat`, `fix`, `refactor`, `perf`, `docs`, `test`,
 area is optional, e.g. `feat(quat): ...` or `fix(vec3): ...`.
 
 Breaking changes append `!` after the type or scope, e.g.
-`feat(quat)!: remove the deprecated camera methods`, and will bump the
-minor version at the next release while glam is pre-1.0.
+`feat(quat)!: remove the deprecated camera methods`. Breaking changes
+bump the minor version at the next release while glam is pre-1.0; they
+are also detected automatically by cargo-semver-checks when the release
+PR is prepared, so a minor bump can occur even without the `!` marker.
 
 A check on the PR will suggest this format for titles that don't follow it.
 The check is not required and titles can also be adjusted in the merge
-dialog when squashing; dependabot and draft PRs are exempt.
+dialog when squashing; dependabot, release-plz and draft PRs are exempt.
 
 ## Code contributions
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -17,19 +17,23 @@ git_tag_name = "{{ version }}"
 git_release_enable = false
 
 # Squash-merging this PR produces the usual "Prepare <version> release"
-# commit on main.
+# commit on main. The `release` label is used by the PR-title lint
+# workflow to exempt release PRs from the Conventional Commits check.
 pr_name = "Prepare {{ version }} release"
+pr_labels = ["release"]
 
 # Run cargo-semver-checks and report API compatibility in the release PR
-# body. Note: the version bump itself is determined by the conventional
-# commit types below, not by this check.
+# body. This check can also drive the version bump: if it detects an
+# incompatible API change, release-plz bumps the minor version (the 0.x
+# breaking slot) regardless of the commit titles.
 semver_check = true
 
 # The changelog is generated from conventional commit messages on the
 # release PR using git-cliff's defaults (no git-cliff.toml). Version bumps
 # follow release-plz's pre-1.0 rules: breaking changes bump the minor
-# version (the 0.x breaking slot), while everything else - including
-# `feat:` - bumps the patch version. This matches the bump policy used
+# version (the 0.x breaking slot), whether detected by cargo-semver-checks
+# or by the `!` marker in a commit title. Everything else, including
+# `feat:`, bumps the patch version. This matches the bump policy used
 # before switching to release-plz.
 changelog_update = true
 


### PR DESCRIPTION
Follow-up to the release-plz setup (#772), addressing review feedback and a few issues found when testing the release PR flow:

- `release-plz.toml`: add `pr_labels = ["release"]` so release-plz PRs can be exempted from the Conventional Commits title lint, and correct the `semver_check` / bump-policy comments (cargo-semver-checks can drive the version bump when it detects an incompatible API change, not just commit titles)
- `.github/workflows/lint-pr.yml`: drop the non-existent `ignoreDraft` input; exempt draft PRs via a job-level condition with a `ready_for_review` trigger; exempt `release`-labelled PRs (release-plz) alongside `dependencies` (dependabot)
- `CONTRIBUTING.md`: document that breaking changes are also detected by cargo-semver-checks, and that release-plz PRs are exempt from the title check