### PR TITLE
docs: update CONTRIBUTING.md and ARCHITECTURE.md

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,11 +2,11 @@
 
 This document describes the high-level architecture of `glam`. While `glam` is
 not a large library there are some complexities to its implementation. The
-rational and explanation of these follows.
+rationale and explanation of these follows.
 
 ## Design goals
 
-There overarching design goals of glam are:
+The overarching design goals of glam are:
 
 - Good out of the box performance using SIMD when available
 - Has a simple public interface
@@ -59,28 +59,37 @@ making them a trait means they won't pollute documentation.
 ### Support common primitives
 
 Initially `glam` only supported `f32` which kept the internal implementation
-relatively simple. However users also wanted support for other primitives types
-like `f64`, `i32` and `u32`. Because `glam` avoids using `generics` adding
-support for other primitive types without a lot of code duplication required
-some additional complexity in implementation.
+relatively simple. However users also wanted support for other primitive types.
+`glam` now supports `f32` and `f64` floats and the signed and unsigned integers
+`i8`/`u8`, `i16`/`u16`, `i32`/`u32`, `i64`/`u64` and `isize`/`usize`. Because
+`glam` avoids using generics, adding support for all of these types without a
+lot of code duplication requires some additional implementation complexity.
 
 ## High level structure
 
-`glam` supports a number of permutations of vector, quaternion and matrix types
-for `f32`, `f64`, `i32` and `u32` primitives, with SSE2, NEON, or WASM SIMD for
-some `f32` types and scalar fallbacks if SIMD is not available.
+`glam` supports a number of permutations of vector, quaternion, matrix, affine
+transform and boolean vector mask types for the `f32`, `f64` and integer
+primitives listed above. Some of these types have SSE2, NEON, WASM and
+`core-simd` backends, with scalar fallbacks when SIMD is not available.
 
 ### Component access via Deref
 
-The `Deref` trait is used to provide direct access to SIMD vector components
-like `.x`, `.y` and so on. The `Deref` implementation will return `XYZ<T>`
-structure on which the vector components are accessible. Unfortunately if users
-dereference the public types they will see confusing error messages about `XYZ`
-types but this on balance seemed preferable to needing to setter and getting
-methods to read and write component values.
+Vector, quaternion, matrix and affine transform types with SIMD backends store
+their data in SIMD values, e.g. an `__m128` on x86. The `Deref` and
+`DerefMut` traits are used to provide direct access to the components (`.x`,
+`.y`, `.z`, `.w`) or columns (`x_axis`, `y_axis` and so on) of these types.
+The `Deref` implementations return `Vec3<T>`, `Vec4<T>` or `Cols2<V>`,
+`Cols3<V>`, `Cols4<V>` structures defined in `src/deref.rs` on which those
+fields are directly accessible, e.g. `Vec3A` and `Quat` deref to `Vec3<T>` and
+`Vec4<T>` while SIMD-backed matrix and affine transform types deref to the
+`Cols*` structures. Unfortunately if users dereference the public types they
+will see confusing error messages about these wrapper types, but on balance
+this seemed preferable to needing setter and getter methods to read and write
+component values. When SIMD is not available or the `scalar-math` feature is
+enabled, these types instead expose their components as public fields directly.
 
 ## Code generation
 
 See the [codegen README] for information on `glam`'s code generation process.
 
-[codegen README]: tools/codegen/README.md
+[codegen README]: https://github.com/bitshifter/glam-codegen/blob/main/README.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,19 +67,43 @@ dialog when squashing; dependabot, release-plz and draft PRs are exempt.
 
 ## Code contributions
 
-Most of `glam`'s source code is generated. See the [codegen README] on how
-to modify the code templates and generate new source code.
+Most of `glam`'s source code is generated. See the [codegen README] for how to
+modify the code templates and generate new source code.
 
 Edit templates in the `templates/` directory (they use the [Tera v2] templating
 language) and the `codegen.json` file which maps templates to output files.
+Generated files are identified by the header comment at the top of the file,
+e.g. `// Generated from vec.rs.tera template. Edit the template, not the
+generated file.`
+
 After modifying templates, run `cargo run --release -p codegen` from the repo
 root to regenerate source files (requires initializing the codegen submodule
-with `git submodule update --init tools/codegen`).
+with `git submodule update --init tools/codegen`). By default codegen skips
+output files that have uncommitted modifications. Pass `-f` (or `--force`) to
+overwrite them, which is usually what you want when iterating on a template. A
+glob argument limits regeneration to matching files for faster iteration, e.g.
+`cargo run --release -p codegen -- -f 'src/f32/vec3.rs'`. Generated files are
+already rustfmt-formatted, so `cargo fmt` is only needed for hand-written files
+such as tests.
 
-You can run `glam`'s test suite locally by running `cargo run -p ci`.
-It's worth running that before creating a PR.
+The minimum supported Rust version is 1.68.2 and is checked by
+`cargo run -p ci -- msrv`, so avoid using newer language features in code or
+tests.
 
-Also run `cargo fmt` and `cargo clippy` on any new code.
+You can run `glam`'s test suite locally:
+
+- `cargo test` runs everything, or `cargo test --test vec3` for a single test
+  file.
+- Some tests assert that `glam_assert!` panics on invalid input; these only
+  take effect with the `glam-assert` or `debug-glam-assert` feature enabled, so
+  run `cargo test --features=debug-glam-assert` to check them.
+- `cargo run -p ci` runs the same checks as the pre-push hook (fmt, clippy and
+  tests across feature combinations). It's worth running that before creating a
+  PR. The fuller `cargo run -p ci -- ci` suite additionally checks the MSRV and
+  wasm targets and needs nightly and wasm toolchains installed, so it's usually
+  best left to GitHub Actions.
+
+Also run `cargo fmt` on any new hand-written files and `cargo clippy` on any new code.
 
 [start a discussion]: https://github.com/bitshifter/glam-rs/discussions/new
 [open an issue]: https://GitHub.com/bitshifter/glam-rs/issues/new


### PR DESCRIPTION
Updates the developer-facing docs:

- **CONTRIBUTING.md**: expand the code contributions section - how to identify generated files, codegen `-f` and glob options, the `debug-glam-assert` test feature, local test commands, and the MSRV.
- **ARCHITECTURE.md**: fix the outdated `XYZ<T>` Deref description, add the newer primitive types and `core-simd` backend, and point the codegen README link at GitHub so it works without the submodule checked out.