### PR TITLE
Fix 32-bit I64Vec3 and U64Vec3 alignment tests

### DIFF
--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -2768,7 +2768,7 @@ mod i64vec3 {
     glam_test!(test_align, {
         use std::mem;
         assert_eq!(24, mem::size_of::<I64Vec3>());
-        assert_eq!(8, mem::align_of::<I64Vec3>());
+        assert_eq!(mem::align_of::<i64>(), mem::align_of::<I64Vec3>());
     });
 
     impl_vec3_i64_try_from_tests!(I64Vec3, i64);
@@ -2810,7 +2810,7 @@ mod u64vec3 {
     glam_test!(test_align, {
         use std::mem;
         assert_eq!(24, mem::size_of::<U64Vec3>());
-        assert_eq!(8, mem::align_of::<U64Vec3>());
+        assert_eq!(mem::align_of::<u64>(), mem::align_of::<U64Vec3>());
     });
 
     impl_vec3_u64_try_from_tests!(U64Vec3, u64);


### PR DESCRIPTION
Fixes the remaining 32-bit layout assertions related to #770.

The I64Vec3 and U64Vec3 tests assumed an 8-byte alignment. On 32-bit targets, the scalar i64/u64 alignment is 4 bytes, so the tests should compare the vector alignment with the scalar alignment instead.

This follows the Debian packaging fix and complements the existing CUDA 32-bit handling for USizeVec2 and ISizeVec2. The Debian i386 build exposed the U64Vec3 failure after the earlier USizeVec2 fix.

Validation:
- git diff --check passed.
- The local all-features test could not run because this environment has no writable Cargo registry cache; dependency download stopped before compilation.
