### PR TITLE
ci: filter release-plz changelog to user-facing changes

### DIFF
--- a/.github/workflows/lint-pr.yml
+++ b/.github/workflows/lint-pr.yml
@@ -29,6 +29,8 @@ jobs:
           # Allowed commit types. Breaking changes are marked with `!`
           # after the type or scope, e.g. `feat(quat)!: remove deprecated
           # API`; a scope is optional, e.g. `fix(vec3): correct typo`.
+          # The Keep a Changelog types (changed/deprecated/removed/security)
+          # map to changelog sections via the `[changelog]` commit parsers.
           types: |
             feat
             fix
@@ -41,6 +43,10 @@ jobs:
             ci
             build
             revert
+            changed
+            deprecated
+            removed
+            security
           ignoreLabels: |
             dependencies # dependabot PRs
             release # release-plz PRs ("Prepare <version> release")

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -10,6 +10,11 @@
 # branch prefix, so don't set pr_branch_prefix.
 release_always = false
 
+# Only trigger when a commit matches this allowlist; everything else rides
+# along with the next release. Whether ride-along commits show up in the
+# changelog is decided by the `[changelog]` parsers below.
+release_commits = '^(feat|fix|perf|changed|deprecated|removed|security)(\(.*\))?!?:'
+
 # Match the existing tag style: 0.33.3 (no "v" prefix, no package prefix).
 git_tag_name = "{{ version }}"
 
@@ -29,7 +34,8 @@ pr_labels = ["release"]
 semver_check = true
 
 # The changelog is generated from conventional commit messages on the
-# release PR using git-cliff's defaults (no git-cliff.toml). Version bumps
+# release PR using git-cliff; see the `[changelog]` section for which
+# commits are kept. Version bumps
 # follow release-plz's pre-1.0 rules: breaking changes bump the minor
 # version (the 0.x breaking slot), whether detected by cargo-semver-checks
 # or by the `!` marker in a commit title. Everything else, including
@@ -43,3 +49,19 @@ changelog_update = true
 [[package]]
 name = "codegen"
 release = false
+
+# Keep a Changelog sections, with the noise filtered out: maintenance
+# commits are dropped, breaking changes are always kept, and anything else
+# (e.g. dependabot bumps) falls into "Other".
+[changelog]
+protect_breaking_commits = true
+commit_parsers = [
+    { message = '^feat', group = "added" },
+    { message = '^changed', group = "changed" },
+    { message = '^deprecated', group = "deprecated" },
+    { message = '^removed', group = "removed" },
+    { message = '^fix', group = "fixed" },
+    { message = '^security', group = "security" },
+    { message = '^(docs|chore|ci|test|refactor|style|build|revert)(\(.*\))?!?:', skip = true },
+    { message = '^.*', group = "other" },
+]


### PR DESCRIPTION
Now that releases are automated with release-plz, the changelog is generated from commit messages rather than hand-written. This PR makes the generated changelog mirror the old manual one: only user-facing changes, grouped into Keep a Changelog sections.

## What changed

**`release-plz.toml`**

- `release_commits`: prepare a release only when a commit matches `^(feat|fix|perf|changed|deprecated|removed|security)(\(.*\))?!?:` instead of on every commit.
- New `[changelog]` section with `commit_parsers`: `feat`/`changed`/`deprecated`/`removed`/`fix`/`security` map to their Keep a Changelog sections, the maintenance types (`docs`, `chore`, `ci`, `test`, `refactor`, `style`, `build`, `revert`) are dropped, and anything else (e.g. dependabot bumps) falls into `Other`. `protect_breaking_commits = true` keeps breaking changes in the changelog even when their type would otherwise be skipped.

**`.github/workflows/lint-pr.yml`**

- Allow the four Keep a Changelog types (`changed`, `deprecated`, `removed`, `security`) as PR titles, since the changelog sections they produce depend on commits being typed that way.

## Notes

- Non-matching commits still ride along with the next release; the `[changelog]` parsers decide whether they appear.
- Breaking changes are always kept and the `!` marker still drives the 0.x minor bump.
- Behavior-changing refactors should be titled `changed:` (gets a section); internal ones `refactor:` (dropped).