### PR TITLE
fix: fix remaining 32-bit layout tests and add i686 CI coveragees

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,30 @@ jobs:
       - run: rustup default ${{ matrix.toolchain }}
       - run: cargo run --release -p ci -- test-features
 
+  test-i686:
+    name: Test i686 (32-bit)
+    strategy:
+      matrix:
+        toolchain: [stable]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: true
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install 32-bit linker and runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-multilib
+
+      - run: rustup update --no-self-update ${{ matrix.toolchain }}
+      - run: rustup default ${{ matrix.toolchain }}
+      - run: rustup target add i686-unknown-linux-gnu
+      - run: cargo run --release -p ci -- test-i686
+
   check-msrv:
     name: Check MSRV
     strategy:

--- a/src/features/impl_arbitrary.rs
+++ b/src/features/impl_arbitrary.rs
@@ -250,9 +250,12 @@ mod test {
     #[test]
     fn test_arbitrary_usize() {
         // The integer arbitrary impl converts little endian bytes.
-        let mut bytes = [0u8; 4 * size_of::<usize>()];
-        for (i, chunk) in bytes.chunks_exact_mut(size_of::<usize>()).enumerate() {
-            chunk.copy_from_slice(&(i + 1).to_le_bytes());
+        // usize/isize are forwarded to u64/i64 (for corpus portability between
+        // 32-bit and 64-bit builds) so each value consumes 8 bytes on all
+        // targets, including 32-bit targets.
+        let mut bytes = [0u8; 4 * size_of::<u64>()];
+        for (i, chunk) in bytes.chunks_exact_mut(size_of::<u64>()).enumerate() {
+            chunk.copy_from_slice(&((i + 1) as u64).to_le_bytes());
         }
 
         assert_eq!(
@@ -273,9 +276,12 @@ mod test {
     #[test]
     fn test_arbitrary_isize() {
         // The integer arbitrary impl converts little endian bytes.
-        let mut bytes = [0u8; 4 * size_of::<isize>()];
-        for (i, chunk) in bytes.chunks_exact_mut(size_of::<isize>()).enumerate() {
-            chunk.copy_from_slice(&(i + 1).to_le_bytes());
+        // usize/isize are forwarded to u64/i64 (for corpus portability between
+        // 32-bit and 64-bit builds) so each value consumes 8 bytes on all
+        // targets, including 32-bit targets.
+        let mut bytes = [0u8; 4 * size_of::<i64>()];
+        for (i, chunk) in bytes.chunks_exact_mut(size_of::<i64>()).enumerate() {
+            chunk.copy_from_slice(&((i + 1) as i64).to_le_bytes());
         }
 
         assert_eq!(

--- a/src/features/impl_arbitrary.rs
+++ b/src/features/impl_arbitrary.rs
@@ -298,6 +298,54 @@ mod test {
         );
     }
 
+    // usize::MAX / isize::MIN only round-trip through the usize/isize
+    // arbitrary impls on 64-bit targets; on 32-bit the values fit in a fixed
+    // 32-bit read too, so this guards against the vec impl silently degrading
+    // to fixed-width u32/i32 components.
+    #[cfg(all(feature = "usize", target_pointer_width = "64"))]
+    #[test]
+    fn test_arbitrary_usize_max() {
+        let mut bytes = [0u8; 4 * size_of::<u64>()];
+        for chunk in bytes.chunks_exact_mut(size_of::<u64>()) {
+            chunk.copy_from_slice(&(usize::MAX as u64).to_le_bytes());
+        }
+
+        assert_eq!(
+            USizeVec2::splat(usize::MAX),
+            Unstructured::new(&bytes).arbitrary().unwrap()
+        );
+        assert_eq!(
+            USizeVec3::splat(usize::MAX),
+            Unstructured::new(&bytes).arbitrary().unwrap()
+        );
+        assert_eq!(
+            USizeVec4::splat(usize::MAX),
+            Unstructured::new(&bytes).arbitrary().unwrap()
+        );
+    }
+
+    #[cfg(all(feature = "isize", target_pointer_width = "64"))]
+    #[test]
+    fn test_arbitrary_isize_min() {
+        let mut bytes = [0u8; 4 * size_of::<i64>()];
+        for chunk in bytes.chunks_exact_mut(size_of::<i64>()) {
+            chunk.copy_from_slice(&(isize::MIN as i64).to_le_bytes());
+        }
+
+        assert_eq!(
+            ISizeVec2::splat(isize::MIN),
+            Unstructured::new(&bytes).arbitrary().unwrap()
+        );
+        assert_eq!(
+            ISizeVec3::splat(isize::MIN),
+            Unstructured::new(&bytes).arbitrary().unwrap()
+        );
+        assert_eq!(
+            ISizeVec4::splat(isize::MIN),
+            Unstructured::new(&bytes).arbitrary().unwrap()
+        );
+    }
+
     #[cfg(feature = "u8")]
     #[test]
     fn test_arbitrary_u8() {

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -2376,7 +2376,7 @@ mod i64vec2 {
         use core::mem;
         assert_eq!(16, mem::size_of::<I64Vec2>());
         #[cfg(not(feature = "cuda"))]
-        assert_eq!(8, mem::align_of::<I64Vec2>());
+        assert_eq!(mem::align_of::<i64>(), mem::align_of::<I64Vec2>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<I64Vec2>());
     });
@@ -2421,7 +2421,7 @@ mod u64vec2 {
         use core::mem;
         assert_eq!(16, mem::size_of::<U64Vec2>());
         #[cfg(not(feature = "cuda"))]
-        assert_eq!(8, mem::align_of::<U64Vec2>());
+        assert_eq!(mem::align_of::<u64>(), mem::align_of::<U64Vec2>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<U64Vec2>());
     });

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -2806,7 +2806,7 @@ mod i64vec4 {
         use std::mem;
         assert_eq!(32, mem::size_of::<I64Vec4>());
         #[cfg(not(feature = "cuda"))]
-        assert_eq!(8, mem::align_of::<I64Vec4>());
+        assert_eq!(mem::align_of::<i64>(), mem::align_of::<I64Vec4>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<I64Vec4>());
     });
@@ -2851,7 +2851,7 @@ mod u64vec4 {
         use std::mem;
         assert_eq!(32, mem::size_of::<U64Vec4>());
         #[cfg(not(feature = "cuda"))]
-        assert_eq!(8, mem::align_of::<U64Vec4>());
+        assert_eq!(mem::align_of::<u64>(), mem::align_of::<U64Vec4>());
         #[cfg(feature = "cuda")]
         assert_eq!(16, mem::align_of::<U64Vec4>());
     });

--- a/tools/ci/src/commands.rs
+++ b/tools/ci/src/commands.rs
@@ -11,6 +11,7 @@ pub mod lints;
 pub mod msrv;
 pub mod pre_push;
 pub mod test_features;
+pub mod test_i686;
 pub mod wasm32;
 pub mod wasm32_chrome;
 pub mod wasm32_firefox;

--- a/tools/ci/src/commands/test_i686.rs
+++ b/tools/ci/src/commands/test_i686.rs
@@ -1,0 +1,51 @@
+use argh::FromArgs;
+use xshell::{cmd, Shell};
+
+use crate::args::Args;
+use crate::prepare::{Prepare, PreparedCommand};
+
+/// Test feature combinations on the 32-bit i686 target to catch layout
+/// differences that only exist on 32-bit targets, e.g. usize/isize sizing
+/// and i64/u64 alignment. Without --index, tests all sets.
+#[derive(FromArgs, Default)]
+#[argh(subcommand, name = "test-i686")]
+/// Build and test feature combinations on the 32-bit i686 target.
+pub struct TestI686 {
+    #[argh(option, description = "test a single feature set by 1-based index")]
+    index: Option<usize>,
+
+    #[argh(switch, description = "list available feature sets and exit")]
+    list: bool,
+}
+
+impl Prepare for TestI686 {
+    fn prepare<'a>(&self, sh: &'a Shell, _args: &Args) -> Vec<PreparedCommand<'a>> {
+        if self.list {
+            crate::features::print_feature_sets();
+            return Vec::new();
+        }
+
+        let mut cmds = Vec::new();
+
+        let sets = crate::features::resolve_sets(self.index);
+        let total = crate::features::FEATURE_SETS.len();
+
+        // Benchmarks are skipped with `--tests` because criterion and
+        // gungraun are only relevant on the host architecture and add
+        // significant cross-compilation time on the 32-bit target.
+        for (i, features) in sets.iter().enumerate() {
+            let idx = self.index.unwrap_or(i + 1);
+            let cmd = cmd!(
+                sh,
+                "cargo test --tests --no-default-features --features {features} --target i686-unknown-linux-gnu"
+            );
+            cmds.push(PreparedCommand {
+                name: format!("test i686 [{idx}/{total}]: {features}"),
+                command: cmd,
+                failure_message: "i686 test feature set failed",
+            });
+        }
+
+        cmds
+    }
+}

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -21,6 +21,7 @@ use commands::lints::Lints;
 use commands::msrv::Msrv;
 use commands::pre_push::PrePush;
 use commands::test_features::TestFeatures;
+use commands::test_i686::TestI686;
 use commands::wasm32::Wasm32;
 use commands::wasm32_chrome::Wasm32Chrome;
 use commands::wasm32_firefox::Wasm32Firefox;
@@ -54,6 +55,7 @@ enum Subcommand {
     Msrv(Msrv),
     PrePush(PrePush),
     TestFeatures(TestFeatures),
+    TestI686(TestI686),
     Wasm32(Wasm32),
     Wasm32Chrome(Wasm32Chrome),
     Wasm32Firefox(Wasm32Firefox),
@@ -77,6 +79,7 @@ impl Prepare for Subcommand {
             Subcommand::Msrv(cmd) => cmd.prepare(sh, args),
             Subcommand::PrePush(cmd) => cmd.prepare(sh, args),
             Subcommand::TestFeatures(cmd) => cmd.prepare(sh, args),
+            Subcommand::TestI686(cmd) => cmd.prepare(sh, args),
             Subcommand::Wasm32(cmd) => cmd.prepare(sh, args),
             Subcommand::Wasm32Chrome(cmd) => cmd.prepare(sh, args),
             Subcommand::Wasm32Firefox(cmd) => cmd.prepare(sh, args),


### PR DESCRIPTION
Fixes the remaining 32-bit target test failures from #770 that the earlier Debian-driven fixes (#771, #775, #781) missed.

- `I64Vec2`/`U64Vec2`/`I64Vec4`/`U64Vec4` alignment tests hard-coded 8-byte alignment; on 32-bit targets i64/u64 align to 4 bytes. Compare against the scalar alignment instead (same pattern as #781).
- `test_arbitrary_usize`/`test_arbitrary_isize` sized input by `size_of::<usize>()`, but `arbitrary` ≥ 1.4 forwards `usize`/`isize` to `u64`/`i64` (8 bytes per value on all targets), so the tests ran out of input on 32-bit.

Adds a `test-i686` job to CI that runs all feature sets on `i686-unknown-linux-gnu` (gcc-multilib + rustup target) so these regressions are caught upstream instead of by downstream packagers.

Validated all 9 feature sets on i686 via `cross` (cuda, scalar-math, libm) plus the host x86_64 suite; lints (fmt/clippy/codegen/doc) are green.