### PR TITLE
feat(vec3a): add explicit padding to scalar Vec3A for bytemuck Pod/Zeroable and zerocopy IntoBytes

### DIFF
--- a/src/f32/affine3a.rs
+++ b/src/f32/affine3a.rs
@@ -10,7 +10,7 @@ use zerocopy_derive::*;
 ///
 /// This type is 16 byte aligned.
 #[derive(Copy, Clone)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(
     all(feature = "zerocopy", not(feature = "core-simd")),
     derive(FromBytes, Immutable, KnownLayout)

--- a/src/f32/affine3a.rs
+++ b/src/f32/affine3a.rs
@@ -13,19 +13,7 @@ use zerocopy_derive::*;
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(
     all(feature = "zerocopy", not(feature = "core-simd")),
-    derive(FromBytes, Immutable, KnownLayout)
-)]
-#[cfg_attr(
-    all(
-        feature = "zerocopy",
-        any(
-            target_arch = "aarch64",
-            target_feature = "sse2",
-            target_feature = "simd128"
-        ),
-        not(any(feature = "core-simd", feature = "scalar-math"))
-    ),
-    derive(IntoBytes)
+    derive(FromBytes, Immutable, IntoBytes, KnownLayout)
 )]
 #[repr(C)]
 pub struct Affine3A {

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -48,7 +48,7 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
 #[derive(Clone, Copy)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(feature = "zerocopy", derive(FromBytes, Immutable, KnownLayout))]
 #[repr(C)]
 pub struct Mat3A {

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -49,7 +49,10 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// transform.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
-#[cfg_attr(feature = "zerocopy", derive(FromBytes, Immutable, KnownLayout))]
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(FromBytes, Immutable, IntoBytes, KnownLayout)
+)]
 #[repr(C)]
 pub struct Mat3A {
     pub x_axis: Vec3A,

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -27,7 +27,10 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 /// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
-#[cfg_attr(feature = "zerocopy", derive(FromBytes, Immutable, KnownLayout))]
+#[cfg_attr(
+    feature = "zerocopy",
+    derive(FromBytes, Immutable, IntoBytes, KnownLayout)
+)]
 #[repr(align(16))]
 #[repr(C)]
 #[cfg_attr(target_arch = "spirv", rust_gpu::vector::v1)]

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -35,6 +35,7 @@ pub struct Vec3A {
     pub x: f32,
     pub y: f32,
     pub z: f32,
+    _w: f32,
 }
 
 impl Vec3A {
@@ -100,14 +101,14 @@ impl Vec3A {
     #[inline(always)]
     #[must_use]
     pub const fn new(x: f32, y: f32, z: f32) -> Self {
-        Self { x, y, z }
+        Self { x, y, z, _w: 0.0 }
     }
 
     /// Creates a vector with all elements set to `v`.
     #[inline]
     #[must_use]
     pub const fn splat(v: f32) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -128,11 +129,11 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3A, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -177,11 +178,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn from_vec4(v: Vec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -269,11 +266,11 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -285,11 +282,11 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -301,11 +298,11 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`f32::clamp`].
@@ -473,11 +470,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: math::abs(self.x),
-            y: math::abs(self.y),
-            z: math::abs(self.z),
-        }
+        Self::new(math::abs(self.x), math::abs(self.y), math::abs(self.z))
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -488,22 +481,22 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: math::signum(self.x),
-            y: math::signum(self.y),
-            z: math::signum(self.z),
-        }
+        Self::new(
+            math::signum(self.x),
+            math::signum(self.y),
+            math::signum(self.z),
+        )
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
     #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
-        Self {
-            x: math::copysign(self.x, rhs.x),
-            y: math::copysign(self.y, rhs.y),
-            z: math::copysign(self.z, rhs.z),
-        }
+        Self::new(
+            math::copysign(self.x, rhs.x),
+            math::copysign(self.y, rhs.y),
+            math::copysign(self.z, rhs.z),
+        )
     }
 
     /// Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
@@ -796,11 +789,11 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn round(self) -> Self {
-        Self {
-            x: math::round(self.x),
-            y: math::round(self.y),
-            z: math::round(self.z),
-        }
+        Self::new(
+            math::round(self.x),
+            math::round(self.y),
+            math::round(self.z),
+        )
     }
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
@@ -808,11 +801,11 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn floor(self) -> Self {
-        Self {
-            x: math::floor(self.x),
-            y: math::floor(self.y),
-            z: math::floor(self.z),
-        }
+        Self::new(
+            math::floor(self.x),
+            math::floor(self.y),
+            math::floor(self.z),
+        )
     }
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
@@ -820,11 +813,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn ceil(self) -> Self {
-        Self {
-            x: math::ceil(self.x),
-            y: math::ceil(self.y),
-            z: math::ceil(self.z),
-        }
+        Self::new(math::ceil(self.x), math::ceil(self.y), math::ceil(self.z))
     }
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
@@ -832,11 +821,11 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn trunc(self) -> Self {
-        Self {
-            x: math::trunc(self.x),
-            y: math::trunc(self.y),
-            z: math::trunc(self.z),
-        }
+        Self::new(
+            math::trunc(self.x),
+            math::trunc(self.y),
+            math::trunc(self.z),
+        )
     }
 
     /// Returns a vector containing `0.0` if `rhs < self` and 1.0 otherwise.
@@ -961,11 +950,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn recip(self) -> Self {
-        Self {
-            x: 1.0 / self.x,
-            y: 1.0 / self.y,
-            z: 1.0 / self.z,
-        }
+        Self::new(1.0 / self.x, 1.0 / self.y, 1.0 / self.z)
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
@@ -1440,11 +1425,7 @@ impl Div for Vec3A {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -1492,11 +1473,7 @@ impl Div<f32> for Vec3A {
     type Output = Self;
     #[inline]
     fn div(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -1544,11 +1521,7 @@ impl Div<Vec3A> for f32 {
     type Output = Vec3A;
     #[inline]
     fn div(self, rhs: Vec3A) -> Vec3A {
-        Vec3A {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        Vec3A::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -1580,11 +1553,7 @@ impl Mul for Vec3A {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1632,11 +1601,7 @@ impl Mul<f32> for Vec3A {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1684,11 +1649,7 @@ impl Mul<Vec3A> for f32 {
     type Output = Vec3A;
     #[inline]
     fn mul(self, rhs: Vec3A) -> Vec3A {
-        Vec3A {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        Vec3A::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1720,11 +1681,7 @@ impl Add for Vec3A {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1772,11 +1729,7 @@ impl Add<f32> for Vec3A {
     type Output = Self;
     #[inline]
     fn add(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1824,11 +1777,7 @@ impl Add<Vec3A> for f32 {
     type Output = Vec3A;
     #[inline]
     fn add(self, rhs: Vec3A) -> Vec3A {
-        Vec3A {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        Vec3A::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1860,11 +1809,7 @@ impl Sub for Vec3A {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1912,11 +1857,7 @@ impl Sub<f32> for Vec3A {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1964,11 +1905,7 @@ impl Sub<Vec3A> for f32 {
     type Output = Vec3A;
     #[inline]
     fn sub(self, rhs: Vec3A) -> Vec3A {
-        Vec3A {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        Vec3A::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -2000,11 +1937,7 @@ impl Rem for Vec3A {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -2052,11 +1985,7 @@ impl Rem<f32> for Vec3A {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -2104,11 +2033,7 @@ impl Rem<Vec3A> for f32 {
     type Output = Vec3A;
     #[inline]
     fn rem(self, rhs: Vec3A) -> Vec3A {
-        Vec3A {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        Vec3A::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -2194,11 +2119,7 @@ impl Neg for Vec3A {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg())
     }
 }
 
@@ -2293,11 +2214,7 @@ impl From<Vec3> for Vec3A {
 impl From<Vec3A> for Vec3 {
     #[inline]
     fn from(v: Vec3A) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 }
 

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -25,8 +25,8 @@ pub const fn vec3a(x: f32, y: f32, z: f32) -> Vec3A {
 /// or [`Into`] trait implementations.
 ///
 /// This type is 16 byte aligned.
-#[derive(Clone, Copy, PartialEq)]
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[derive(Clone, Copy)]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(feature = "zerocopy", derive(FromBytes, Immutable, KnownLayout))]
 #[repr(align(16))]
 #[repr(C)]
@@ -101,7 +101,7 @@ impl Vec3A {
     #[inline(always)]
     #[must_use]
     pub const fn new(x: f32, y: f32, z: f32) -> Self {
-        Self { x, y, z, _w: 0.0 }
+        Self { x, y, z, _w: z }
     }
 
     /// Creates a vector with all elements set to `v`.
@@ -1418,6 +1418,13 @@ impl Default for Vec3A {
     #[inline(always)]
     fn default() -> Self {
         Self::ZERO
+    }
+}
+
+impl PartialEq for Vec3A {
+    #[inline]
+    fn eq(&self, rhs: &Self) -> bool {
+        self.x == rhs.x && self.y == rhs.y && self.z == rhs.z
     }
 }
 

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -114,15 +114,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: f32) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -143,12 +135,12 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4A, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -267,12 +259,12 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -284,12 +276,12 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`f32::clamp`].
@@ -495,12 +487,12 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: math::abs(self.x),
-            y: math::abs(self.y),
-            z: math::abs(self.z),
-            w: math::abs(self.w),
-        }
+        Self::new(
+            math::abs(self.x),
+            math::abs(self.y),
+            math::abs(self.z),
+            math::abs(self.w),
+        )
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -511,24 +503,24 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: math::signum(self.x),
-            y: math::signum(self.y),
-            z: math::signum(self.z),
-            w: math::signum(self.w),
-        }
+        Self::new(
+            math::signum(self.x),
+            math::signum(self.y),
+            math::signum(self.z),
+            math::signum(self.w),
+        )
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
     #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
-        Self {
-            x: math::copysign(self.x, rhs.x),
-            y: math::copysign(self.y, rhs.y),
-            z: math::copysign(self.z, rhs.z),
-            w: math::copysign(self.w, rhs.w),
-        }
+        Self::new(
+            math::copysign(self.x, rhs.x),
+            math::copysign(self.y, rhs.y),
+            math::copysign(self.z, rhs.z),
+            math::copysign(self.w, rhs.w),
+        )
     }
 
     /// Returns a bitmask with the lowest 4 bits set to the sign bits from the elements of `self`.
@@ -835,12 +827,12 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn round(self) -> Self {
-        Self {
-            x: math::round(self.x),
-            y: math::round(self.y),
-            z: math::round(self.z),
-            w: math::round(self.w),
-        }
+        Self::new(
+            math::round(self.x),
+            math::round(self.y),
+            math::round(self.z),
+            math::round(self.w),
+        )
     }
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
@@ -848,12 +840,12 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn floor(self) -> Self {
-        Self {
-            x: math::floor(self.x),
-            y: math::floor(self.y),
-            z: math::floor(self.z),
-            w: math::floor(self.w),
-        }
+        Self::new(
+            math::floor(self.x),
+            math::floor(self.y),
+            math::floor(self.z),
+            math::floor(self.w),
+        )
     }
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
@@ -861,12 +853,12 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn ceil(self) -> Self {
-        Self {
-            x: math::ceil(self.x),
-            y: math::ceil(self.y),
-            z: math::ceil(self.z),
-            w: math::ceil(self.w),
-        }
+        Self::new(
+            math::ceil(self.x),
+            math::ceil(self.y),
+            math::ceil(self.z),
+            math::ceil(self.w),
+        )
     }
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
@@ -874,12 +866,12 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn trunc(self) -> Self {
-        Self {
-            x: math::trunc(self.x),
-            y: math::trunc(self.y),
-            z: math::trunc(self.z),
-            w: math::trunc(self.w),
-        }
+        Self::new(
+            math::trunc(self.x),
+            math::trunc(self.y),
+            math::trunc(self.z),
+            math::trunc(self.w),
+        )
     }
 
     /// Returns a vector containing `0.0` if `rhs < self` and 1.0 otherwise.
@@ -1041,12 +1033,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn recip(self) -> Self {
-        Self {
-            x: 1.0 / self.x,
-            y: 1.0 / self.y,
-            z: 1.0 / self.z,
-            w: 1.0 / self.w,
-        }
+        Self::new(1.0 / self.x, 1.0 / self.y, 1.0 / self.z, 1.0 / self.w)
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
@@ -1321,12 +1308,12 @@ impl Div for Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -1375,12 +1362,12 @@ impl Div<f32> for Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -1429,12 +1416,12 @@ impl Div<Vec4> for f32 {
     type Output = Vec4;
     #[inline]
     fn div(self, rhs: Vec4) -> Vec4 {
-        Vec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        Vec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1466,12 +1453,12 @@ impl Mul for Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1520,12 +1507,12 @@ impl Mul<f32> for Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1574,12 +1561,12 @@ impl Mul<Vec4> for f32 {
     type Output = Vec4;
     #[inline]
     fn mul(self, rhs: Vec4) -> Vec4 {
-        Vec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        Vec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1611,12 +1598,12 @@ impl Add for Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1665,12 +1652,12 @@ impl Add<f32> for Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1719,12 +1706,12 @@ impl Add<Vec4> for f32 {
     type Output = Vec4;
     #[inline]
     fn add(self, rhs: Vec4) -> Vec4 {
-        Vec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        Vec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1756,12 +1743,12 @@ impl Sub for Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1810,12 +1797,12 @@ impl Sub<f32> for Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1864,12 +1851,12 @@ impl Sub<Vec4> for f32 {
     type Output = Vec4;
     #[inline]
     fn sub(self, rhs: Vec4) -> Vec4 {
-        Vec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        Vec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1901,12 +1888,12 @@ impl Rem for Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1955,12 +1942,12 @@ impl Rem<f32> for Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -2009,12 +1996,12 @@ impl Rem<Vec4> for f32 {
     type Output = Vec4;
     #[inline]
     fn rem(self, rhs: Vec4) -> Vec4 {
-        Vec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        Vec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -2100,12 +2087,7 @@ impl Neg for Vec4 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-            w: self.w.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg(), self.w.neg())
     }
 }
 

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -95,7 +95,7 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: f32) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -116,10 +116,10 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -204,10 +204,10 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -219,10 +219,10 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`f32::clamp`].
@@ -380,10 +380,7 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: math::abs(self.x),
-            y: math::abs(self.y),
-        }
+        Self::new(math::abs(self.x), math::abs(self.y))
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -394,20 +391,14 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: math::signum(self.x),
-            y: math::signum(self.y),
-        }
+        Self::new(math::signum(self.x), math::signum(self.y))
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
     #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
-        Self {
-            x: math::copysign(self.x, rhs.x),
-            y: math::copysign(self.y, rhs.y),
-        }
+        Self::new(math::copysign(self.x, rhs.x), math::copysign(self.y, rhs.y))
     }
 
     /// Returns a bitmask with the lowest 2 bits set to the sign bits from the elements of `self`.
@@ -692,10 +683,7 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn round(self) -> Self {
-        Self {
-            x: math::round(self.x),
-            y: math::round(self.y),
-        }
+        Self::new(math::round(self.x), math::round(self.y))
     }
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
@@ -703,10 +691,7 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn floor(self) -> Self {
-        Self {
-            x: math::floor(self.x),
-            y: math::floor(self.y),
-        }
+        Self::new(math::floor(self.x), math::floor(self.y))
     }
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
@@ -714,10 +699,7 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn ceil(self) -> Self {
-        Self {
-            x: math::ceil(self.x),
-            y: math::ceil(self.y),
-        }
+        Self::new(math::ceil(self.x), math::ceil(self.y))
     }
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
@@ -725,10 +707,7 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn trunc(self) -> Self {
-        Self {
-            x: math::trunc(self.x),
-            y: math::trunc(self.y),
-        }
+        Self::new(math::trunc(self.x), math::trunc(self.y))
     }
 
     /// Returns a vector containing `0.0` if `rhs < self` and 1.0 otherwise.
@@ -845,10 +824,7 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn recip(self) -> Self {
-        Self {
-            x: 1.0 / self.x,
-            y: 1.0 / self.y,
-        }
+        Self::new(1.0 / self.x, 1.0 / self.y)
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
@@ -1019,7 +995,7 @@ impl Vec2 {
     #[must_use]
     pub fn from_angle(angle: f32) -> Self {
         let (sin, cos) = math::sin_cos(angle);
-        Self { x: cos, y: sin }
+        Self::new(cos, sin)
     }
 
     /// Returns the angle (in radians) of this vector in the range `[-π, +π]`.
@@ -1057,10 +1033,7 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn perp(self) -> Self {
-        Self {
-            x: -self.y,
-            y: self.x,
-        }
+        Self::new(-self.y, self.x)
     }
 
     /// The perpendicular dot product of `self` and `rhs`.
@@ -1084,10 +1057,10 @@ impl Vec2 {
     #[inline]
     #[must_use]
     pub fn rotate(self, rhs: Self) -> Self {
-        Self {
-            x: self.x * rhs.x - self.y * rhs.y,
-            y: self.y * rhs.x + self.x * rhs.y,
-        }
+        Self::new(
+            self.x * rhs.x - self.y * rhs.y,
+            self.y * rhs.x + self.x * rhs.y,
+        )
     }
 
     /// Rotates `self` by `angle` (in radians), equivalent to
@@ -1213,10 +1186,7 @@ impl Div for Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -1263,10 +1233,7 @@ impl Div<f32> for Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -1313,10 +1280,7 @@ impl Div<Vec2> for f32 {
     type Output = Vec2;
     #[inline]
     fn div(self, rhs: Vec2) -> Vec2 {
-        Vec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        Vec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -1348,10 +1312,7 @@ impl Mul for Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -1398,10 +1359,7 @@ impl Mul<f32> for Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -1448,10 +1406,7 @@ impl Mul<Vec2> for f32 {
     type Output = Vec2;
     #[inline]
     fn mul(self, rhs: Vec2) -> Vec2 {
-        Vec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        Vec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -1483,10 +1438,7 @@ impl Add for Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1533,10 +1485,7 @@ impl Add<f32> for Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1583,10 +1532,7 @@ impl Add<Vec2> for f32 {
     type Output = Vec2;
     #[inline]
     fn add(self, rhs: Vec2) -> Vec2 {
-        Vec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        Vec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1618,10 +1564,7 @@ impl Sub for Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1668,10 +1611,7 @@ impl Sub<f32> for Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1718,10 +1658,7 @@ impl Sub<Vec2> for f32 {
     type Output = Vec2;
     #[inline]
     fn sub(self, rhs: Vec2) -> Vec2 {
-        Vec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        Vec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1753,10 +1690,7 @@ impl Rem for Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1803,10 +1737,7 @@ impl Rem<f32> for Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1853,10 +1784,7 @@ impl Rem<Vec2> for f32 {
     type Output = Vec2;
     #[inline]
     fn rem(self, rhs: Vec2) -> Vec2 {
-        Vec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        Vec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1942,10 +1870,7 @@ impl Neg for Vec2 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg())
     }
 }
 

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -101,7 +101,7 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: f32) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -122,11 +122,11 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -170,11 +170,7 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: Vec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -262,11 +258,11 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -278,11 +274,11 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -294,11 +290,11 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`f32::clamp`].
@@ -466,11 +462,7 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: math::abs(self.x),
-            y: math::abs(self.y),
-            z: math::abs(self.z),
-        }
+        Self::new(math::abs(self.x), math::abs(self.y), math::abs(self.z))
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -481,22 +473,22 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: math::signum(self.x),
-            y: math::signum(self.y),
-            z: math::signum(self.z),
-        }
+        Self::new(
+            math::signum(self.x),
+            math::signum(self.y),
+            math::signum(self.z),
+        )
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
     #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
-        Self {
-            x: math::copysign(self.x, rhs.x),
-            y: math::copysign(self.y, rhs.y),
-            z: math::copysign(self.z, rhs.z),
-        }
+        Self::new(
+            math::copysign(self.x, rhs.x),
+            math::copysign(self.y, rhs.y),
+            math::copysign(self.z, rhs.z),
+        )
     }
 
     /// Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
@@ -789,11 +781,11 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn round(self) -> Self {
-        Self {
-            x: math::round(self.x),
-            y: math::round(self.y),
-            z: math::round(self.z),
-        }
+        Self::new(
+            math::round(self.x),
+            math::round(self.y),
+            math::round(self.z),
+        )
     }
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
@@ -801,11 +793,11 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn floor(self) -> Self {
-        Self {
-            x: math::floor(self.x),
-            y: math::floor(self.y),
-            z: math::floor(self.z),
-        }
+        Self::new(
+            math::floor(self.x),
+            math::floor(self.y),
+            math::floor(self.z),
+        )
     }
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
@@ -813,11 +805,7 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn ceil(self) -> Self {
-        Self {
-            x: math::ceil(self.x),
-            y: math::ceil(self.y),
-            z: math::ceil(self.z),
-        }
+        Self::new(math::ceil(self.x), math::ceil(self.y), math::ceil(self.z))
     }
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
@@ -825,11 +813,11 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn trunc(self) -> Self {
-        Self {
-            x: math::trunc(self.x),
-            y: math::trunc(self.y),
-            z: math::trunc(self.z),
-        }
+        Self::new(
+            math::trunc(self.x),
+            math::trunc(self.y),
+            math::trunc(self.z),
+        )
     }
 
     /// Returns a vector containing `0.0` if `rhs < self` and 1.0 otherwise.
@@ -954,11 +942,7 @@ impl Vec3 {
     #[inline]
     #[must_use]
     pub fn recip(self) -> Self {
-        Self {
-            x: 1.0 / self.x,
-            y: 1.0 / self.y,
-            z: 1.0 / self.z,
-        }
+        Self::new(1.0 / self.x, 1.0 / self.y, 1.0 / self.z)
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
@@ -1433,11 +1417,7 @@ impl Div for Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -1485,11 +1465,7 @@ impl Div<f32> for Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -1537,11 +1513,7 @@ impl Div<Vec3> for f32 {
     type Output = Vec3;
     #[inline]
     fn div(self, rhs: Vec3) -> Vec3 {
-        Vec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        Vec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -1573,11 +1545,7 @@ impl Mul for Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1625,11 +1593,7 @@ impl Mul<f32> for Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1677,11 +1641,7 @@ impl Mul<Vec3> for f32 {
     type Output = Vec3;
     #[inline]
     fn mul(self, rhs: Vec3) -> Vec3 {
-        Vec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        Vec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1713,11 +1673,7 @@ impl Add for Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1765,11 +1721,7 @@ impl Add<f32> for Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1817,11 +1769,7 @@ impl Add<Vec3> for f32 {
     type Output = Vec3;
     #[inline]
     fn add(self, rhs: Vec3) -> Vec3 {
-        Vec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        Vec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1853,11 +1801,7 @@ impl Sub for Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1905,11 +1849,7 @@ impl Sub<f32> for Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1957,11 +1897,7 @@ impl Sub<Vec3> for f32 {
     type Output = Vec3;
     #[inline]
     fn sub(self, rhs: Vec3) -> Vec3 {
-        Vec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        Vec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -1993,11 +1929,7 @@ impl Rem for Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -2045,11 +1977,7 @@ impl Rem<f32> for Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: f32) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -2097,11 +2025,7 @@ impl Rem<Vec3> for f32 {
     type Output = Vec3;
     #[inline]
     fn rem(self, rhs: Vec3) -> Vec3 {
-        Vec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        Vec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -2187,11 +2111,7 @@ impl Neg for Vec3 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg())
     }
 }
 

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -103,7 +103,7 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: f64) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -124,10 +124,10 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -212,10 +212,10 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -227,10 +227,10 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`f64::clamp`].
@@ -388,10 +388,7 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: math::abs(self.x),
-            y: math::abs(self.y),
-        }
+        Self::new(math::abs(self.x), math::abs(self.y))
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -402,20 +399,14 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: math::signum(self.x),
-            y: math::signum(self.y),
-        }
+        Self::new(math::signum(self.x), math::signum(self.y))
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
     #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
-        Self {
-            x: math::copysign(self.x, rhs.x),
-            y: math::copysign(self.y, rhs.y),
-        }
+        Self::new(math::copysign(self.x, rhs.x), math::copysign(self.y, rhs.y))
     }
 
     /// Returns a bitmask with the lowest 2 bits set to the sign bits from the elements of `self`.
@@ -700,10 +691,7 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn round(self) -> Self {
-        Self {
-            x: math::round(self.x),
-            y: math::round(self.y),
-        }
+        Self::new(math::round(self.x), math::round(self.y))
     }
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
@@ -711,10 +699,7 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn floor(self) -> Self {
-        Self {
-            x: math::floor(self.x),
-            y: math::floor(self.y),
-        }
+        Self::new(math::floor(self.x), math::floor(self.y))
     }
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
@@ -722,10 +707,7 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn ceil(self) -> Self {
-        Self {
-            x: math::ceil(self.x),
-            y: math::ceil(self.y),
-        }
+        Self::new(math::ceil(self.x), math::ceil(self.y))
     }
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
@@ -733,10 +715,7 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn trunc(self) -> Self {
-        Self {
-            x: math::trunc(self.x),
-            y: math::trunc(self.y),
-        }
+        Self::new(math::trunc(self.x), math::trunc(self.y))
     }
 
     /// Returns a vector containing `0.0` if `rhs < self` and 1.0 otherwise.
@@ -853,10 +832,7 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn recip(self) -> Self {
-        Self {
-            x: 1.0 / self.x,
-            y: 1.0 / self.y,
-        }
+        Self::new(1.0 / self.x, 1.0 / self.y)
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
@@ -1027,7 +1003,7 @@ impl DVec2 {
     #[must_use]
     pub fn from_angle(angle: f64) -> Self {
         let (sin, cos) = math::sin_cos(angle);
-        Self { x: cos, y: sin }
+        Self::new(cos, sin)
     }
 
     /// Returns the angle (in radians) of this vector in the range `[-π, +π]`.
@@ -1065,10 +1041,7 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn perp(self) -> Self {
-        Self {
-            x: -self.y,
-            y: self.x,
-        }
+        Self::new(-self.y, self.x)
     }
 
     /// The perpendicular dot product of `self` and `rhs`.
@@ -1092,10 +1065,10 @@ impl DVec2 {
     #[inline]
     #[must_use]
     pub fn rotate(self, rhs: Self) -> Self {
-        Self {
-            x: self.x * rhs.x - self.y * rhs.y,
-            y: self.y * rhs.x + self.x * rhs.y,
-        }
+        Self::new(
+            self.x * rhs.x - self.y * rhs.y,
+            self.y * rhs.x + self.x * rhs.y,
+        )
     }
 
     /// Rotates `self` by `angle` (in radians), equivalent to
@@ -1220,10 +1193,7 @@ impl Div for DVec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -1270,10 +1240,7 @@ impl Div<f64> for DVec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -1320,10 +1287,7 @@ impl Div<DVec2> for f64 {
     type Output = DVec2;
     #[inline]
     fn div(self, rhs: DVec2) -> DVec2 {
-        DVec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        DVec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -1355,10 +1319,7 @@ impl Mul for DVec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -1405,10 +1366,7 @@ impl Mul<f64> for DVec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -1455,10 +1413,7 @@ impl Mul<DVec2> for f64 {
     type Output = DVec2;
     #[inline]
     fn mul(self, rhs: DVec2) -> DVec2 {
-        DVec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        DVec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -1490,10 +1445,7 @@ impl Add for DVec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1540,10 +1492,7 @@ impl Add<f64> for DVec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1590,10 +1539,7 @@ impl Add<DVec2> for f64 {
     type Output = DVec2;
     #[inline]
     fn add(self, rhs: DVec2) -> DVec2 {
-        DVec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        DVec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1625,10 +1571,7 @@ impl Sub for DVec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1675,10 +1618,7 @@ impl Sub<f64> for DVec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1725,10 +1665,7 @@ impl Sub<DVec2> for f64 {
     type Output = DVec2;
     #[inline]
     fn sub(self, rhs: DVec2) -> DVec2 {
-        DVec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        DVec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1760,10 +1697,7 @@ impl Rem for DVec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1810,10 +1744,7 @@ impl Rem<f64> for DVec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1860,10 +1791,7 @@ impl Rem<DVec2> for f64 {
     type Output = DVec2;
     #[inline]
     fn rem(self, rhs: DVec2) -> DVec2 {
-        DVec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        DVec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1949,10 +1877,7 @@ impl Neg for DVec2 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg())
     }
 }
 

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -109,7 +109,7 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: f64) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -130,11 +130,11 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -178,11 +178,7 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: DVec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -263,11 +259,11 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -279,11 +275,11 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -295,11 +291,11 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`f64::clamp`].
@@ -467,11 +463,7 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: math::abs(self.x),
-            y: math::abs(self.y),
-            z: math::abs(self.z),
-        }
+        Self::new(math::abs(self.x), math::abs(self.y), math::abs(self.z))
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -482,22 +474,22 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: math::signum(self.x),
-            y: math::signum(self.y),
-            z: math::signum(self.z),
-        }
+        Self::new(
+            math::signum(self.x),
+            math::signum(self.y),
+            math::signum(self.z),
+        )
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
     #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
-        Self {
-            x: math::copysign(self.x, rhs.x),
-            y: math::copysign(self.y, rhs.y),
-            z: math::copysign(self.z, rhs.z),
-        }
+        Self::new(
+            math::copysign(self.x, rhs.x),
+            math::copysign(self.y, rhs.y),
+            math::copysign(self.z, rhs.z),
+        )
     }
 
     /// Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
@@ -790,11 +782,11 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn round(self) -> Self {
-        Self {
-            x: math::round(self.x),
-            y: math::round(self.y),
-            z: math::round(self.z),
-        }
+        Self::new(
+            math::round(self.x),
+            math::round(self.y),
+            math::round(self.z),
+        )
     }
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
@@ -802,11 +794,11 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn floor(self) -> Self {
-        Self {
-            x: math::floor(self.x),
-            y: math::floor(self.y),
-            z: math::floor(self.z),
-        }
+        Self::new(
+            math::floor(self.x),
+            math::floor(self.y),
+            math::floor(self.z),
+        )
     }
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
@@ -814,11 +806,7 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn ceil(self) -> Self {
-        Self {
-            x: math::ceil(self.x),
-            y: math::ceil(self.y),
-            z: math::ceil(self.z),
-        }
+        Self::new(math::ceil(self.x), math::ceil(self.y), math::ceil(self.z))
     }
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
@@ -826,11 +814,11 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn trunc(self) -> Self {
-        Self {
-            x: math::trunc(self.x),
-            y: math::trunc(self.y),
-            z: math::trunc(self.z),
-        }
+        Self::new(
+            math::trunc(self.x),
+            math::trunc(self.y),
+            math::trunc(self.z),
+        )
     }
 
     /// Returns a vector containing `0.0` if `rhs < self` and 1.0 otherwise.
@@ -955,11 +943,7 @@ impl DVec3 {
     #[inline]
     #[must_use]
     pub fn recip(self) -> Self {
-        Self {
-            x: 1.0 / self.x,
-            y: 1.0 / self.y,
-            z: 1.0 / self.z,
-        }
+        Self::new(1.0 / self.x, 1.0 / self.y, 1.0 / self.z)
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
@@ -1440,11 +1424,7 @@ impl Div for DVec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -1492,11 +1472,7 @@ impl Div<f64> for DVec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -1544,11 +1520,7 @@ impl Div<DVec3> for f64 {
     type Output = DVec3;
     #[inline]
     fn div(self, rhs: DVec3) -> DVec3 {
-        DVec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        DVec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -1580,11 +1552,7 @@ impl Mul for DVec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1632,11 +1600,7 @@ impl Mul<f64> for DVec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1684,11 +1648,7 @@ impl Mul<DVec3> for f64 {
     type Output = DVec3;
     #[inline]
     fn mul(self, rhs: DVec3) -> DVec3 {
-        DVec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        DVec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1720,11 +1680,7 @@ impl Add for DVec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1772,11 +1728,7 @@ impl Add<f64> for DVec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1824,11 +1776,7 @@ impl Add<DVec3> for f64 {
     type Output = DVec3;
     #[inline]
     fn add(self, rhs: DVec3) -> DVec3 {
-        DVec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        DVec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1860,11 +1808,7 @@ impl Sub for DVec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1912,11 +1856,7 @@ impl Sub<f64> for DVec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1964,11 +1904,7 @@ impl Sub<DVec3> for f64 {
     type Output = DVec3;
     #[inline]
     fn sub(self, rhs: DVec3) -> DVec3 {
-        DVec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        DVec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -2000,11 +1936,7 @@ impl Rem for DVec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -2052,11 +1984,7 @@ impl Rem<f64> for DVec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -2104,11 +2032,7 @@ impl Rem<DVec3> for f64 {
     type Output = DVec3;
     #[inline]
     fn rem(self, rhs: DVec3) -> DVec3 {
-        DVec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        DVec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -2194,11 +2118,7 @@ impl Neg for DVec3 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg())
     }
 }
 

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -119,15 +119,7 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: f64) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -148,12 +140,12 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -268,12 +260,12 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -285,12 +277,12 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`f64::clamp`].
@@ -496,12 +488,12 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: math::abs(self.x),
-            y: math::abs(self.y),
-            z: math::abs(self.z),
-            w: math::abs(self.w),
-        }
+        Self::new(
+            math::abs(self.x),
+            math::abs(self.y),
+            math::abs(self.z),
+            math::abs(self.w),
+        )
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -512,24 +504,24 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: math::signum(self.x),
-            y: math::signum(self.y),
-            z: math::signum(self.z),
-            w: math::signum(self.w),
-        }
+        Self::new(
+            math::signum(self.x),
+            math::signum(self.y),
+            math::signum(self.z),
+            math::signum(self.w),
+        )
     }
 
     /// Returns a vector with signs of `rhs` and the magnitudes of `self`.
     #[inline]
     #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
-        Self {
-            x: math::copysign(self.x, rhs.x),
-            y: math::copysign(self.y, rhs.y),
-            z: math::copysign(self.z, rhs.z),
-            w: math::copysign(self.w, rhs.w),
-        }
+        Self::new(
+            math::copysign(self.x, rhs.x),
+            math::copysign(self.y, rhs.y),
+            math::copysign(self.z, rhs.z),
+            math::copysign(self.w, rhs.w),
+        )
     }
 
     /// Returns a bitmask with the lowest 4 bits set to the sign bits from the elements of `self`.
@@ -836,12 +828,12 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn round(self) -> Self {
-        Self {
-            x: math::round(self.x),
-            y: math::round(self.y),
-            z: math::round(self.z),
-            w: math::round(self.w),
-        }
+        Self::new(
+            math::round(self.x),
+            math::round(self.y),
+            math::round(self.z),
+            math::round(self.w),
+        )
     }
 
     /// Returns a vector containing the largest integer less than or equal to a number for each
@@ -849,12 +841,12 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn floor(self) -> Self {
-        Self {
-            x: math::floor(self.x),
-            y: math::floor(self.y),
-            z: math::floor(self.z),
-            w: math::floor(self.w),
-        }
+        Self::new(
+            math::floor(self.x),
+            math::floor(self.y),
+            math::floor(self.z),
+            math::floor(self.w),
+        )
     }
 
     /// Returns a vector containing the smallest integer greater than or equal to a number for
@@ -862,12 +854,12 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn ceil(self) -> Self {
-        Self {
-            x: math::ceil(self.x),
-            y: math::ceil(self.y),
-            z: math::ceil(self.z),
-            w: math::ceil(self.w),
-        }
+        Self::new(
+            math::ceil(self.x),
+            math::ceil(self.y),
+            math::ceil(self.z),
+            math::ceil(self.w),
+        )
     }
 
     /// Returns a vector containing the integer part each element of `self`. This means numbers are
@@ -875,12 +867,12 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn trunc(self) -> Self {
-        Self {
-            x: math::trunc(self.x),
-            y: math::trunc(self.y),
-            z: math::trunc(self.z),
-            w: math::trunc(self.w),
-        }
+        Self::new(
+            math::trunc(self.x),
+            math::trunc(self.y),
+            math::trunc(self.z),
+            math::trunc(self.w),
+        )
     }
 
     /// Returns a vector containing `0.0` if `rhs < self` and 1.0 otherwise.
@@ -1042,12 +1034,7 @@ impl DVec4 {
     #[inline]
     #[must_use]
     pub fn recip(self) -> Self {
-        Self {
-            x: 1.0 / self.x,
-            y: 1.0 / self.y,
-            z: 1.0 / self.z,
-            w: 1.0 / self.w,
-        }
+        Self::new(1.0 / self.x, 1.0 / self.y, 1.0 / self.z, 1.0 / self.w)
     }
 
     /// Performs a linear interpolation between `self` and `rhs` based on the value `s`.
@@ -1321,12 +1308,12 @@ impl Div for DVec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -1375,12 +1362,12 @@ impl Div<f64> for DVec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -1429,12 +1416,12 @@ impl Div<DVec4> for f64 {
     type Output = DVec4;
     #[inline]
     fn div(self, rhs: DVec4) -> DVec4 {
-        DVec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        DVec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1466,12 +1453,12 @@ impl Mul for DVec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1520,12 +1507,12 @@ impl Mul<f64> for DVec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1574,12 +1561,12 @@ impl Mul<DVec4> for f64 {
     type Output = DVec4;
     #[inline]
     fn mul(self, rhs: DVec4) -> DVec4 {
-        DVec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        DVec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1611,12 +1598,12 @@ impl Add for DVec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1665,12 +1652,12 @@ impl Add<f64> for DVec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1719,12 +1706,12 @@ impl Add<DVec4> for f64 {
     type Output = DVec4;
     #[inline]
     fn add(self, rhs: DVec4) -> DVec4 {
-        DVec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        DVec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1756,12 +1743,12 @@ impl Sub for DVec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1810,12 +1797,12 @@ impl Sub<f64> for DVec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1864,12 +1851,12 @@ impl Sub<DVec4> for f64 {
     type Output = DVec4;
     #[inline]
     fn sub(self, rhs: DVec4) -> DVec4 {
-        DVec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        DVec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1901,12 +1888,12 @@ impl Rem for DVec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1955,12 +1942,12 @@ impl Rem<f64> for DVec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: f64) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -2009,12 +1996,12 @@ impl Rem<DVec4> for f64 {
     type Output = DVec4;
     #[inline]
     fn rem(self, rhs: DVec4) -> DVec4 {
-        DVec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        DVec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -2100,12 +2087,7 @@ impl Neg for DVec4 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-            w: self.w.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg(), self.w.neg())
     }
 }
 

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -100,7 +100,7 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i16) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -121,10 +121,10 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -206,10 +206,10 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -218,10 +218,10 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i16::clamp`].
@@ -370,10 +370,7 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -384,10 +381,7 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-        }
+        Self::new(self.x.signum(), self.y.signum())
     }
 
     /// Returns a bitmask with the lowest 2 bits set to the sign bits from the elements of `self`.
@@ -493,10 +487,7 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn perp(self) -> Self {
-        Self {
-            x: -self.y,
-            y: self.x,
-        }
+        Self::new(-self.y, self.x)
     }
 
     /// The perpendicular dot product of `self` and `rhs`.
@@ -519,10 +510,10 @@ impl I16Vec2 {
     #[inline]
     #[must_use]
     pub fn rotate(self, rhs: Self) -> Self {
-        Self {
-            x: self.x * rhs.x - self.y * rhs.y,
-            y: self.y * rhs.x + self.x * rhs.y,
-        }
+        Self::new(
+            self.x * rhs.x - self.y * rhs.y,
+            self.y * rhs.x + self.x * rhs.y,
+        )
     }
 
     /// Casts all elements of `self` to `f32`.
@@ -882,10 +873,7 @@ impl Div for I16Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -932,10 +920,7 @@ impl Div<i16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -982,10 +967,7 @@ impl Div<I16Vec2> for i16 {
     type Output = I16Vec2;
     #[inline]
     fn div(self, rhs: I16Vec2) -> I16Vec2 {
-        I16Vec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        I16Vec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -1017,10 +999,7 @@ impl Mul for I16Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -1067,10 +1046,7 @@ impl Mul<i16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -1117,10 +1093,7 @@ impl Mul<I16Vec2> for i16 {
     type Output = I16Vec2;
     #[inline]
     fn mul(self, rhs: I16Vec2) -> I16Vec2 {
-        I16Vec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        I16Vec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -1152,10 +1125,7 @@ impl Add for I16Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1202,10 +1172,7 @@ impl Add<i16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1252,10 +1219,7 @@ impl Add<I16Vec2> for i16 {
     type Output = I16Vec2;
     #[inline]
     fn add(self, rhs: I16Vec2) -> I16Vec2 {
-        I16Vec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        I16Vec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1287,10 +1251,7 @@ impl Sub for I16Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1337,10 +1298,7 @@ impl Sub<i16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1387,10 +1345,7 @@ impl Sub<I16Vec2> for i16 {
     type Output = I16Vec2;
     #[inline]
     fn sub(self, rhs: I16Vec2) -> I16Vec2 {
-        I16Vec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        I16Vec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1422,10 +1377,7 @@ impl Rem for I16Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1472,10 +1424,7 @@ impl Rem<i16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1522,10 +1471,7 @@ impl Rem<I16Vec2> for i16 {
     type Output = I16Vec2;
     #[inline]
     fn rem(self, rhs: I16Vec2) -> I16Vec2 {
-        I16Vec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        I16Vec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1611,10 +1557,7 @@ impl Neg for I16Vec2 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg())
     }
 }
 
@@ -1630,10 +1573,7 @@ impl Not for I16Vec2 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-        }
+        Self::new(self.x.not(), self.y.not())
     }
 }
 
@@ -1649,10 +1589,7 @@ impl BitAnd for I16Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-        }
+        Self::new(self.x.bitand(rhs.x), self.y.bitand(rhs.y))
     }
 }
 
@@ -1698,10 +1635,7 @@ impl BitOr for I16Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-        }
+        Self::new(self.x.bitor(rhs.x), self.y.bitor(rhs.y))
     }
 }
 
@@ -1747,10 +1681,7 @@ impl BitXor for I16Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-        }
+        Self::new(self.x.bitxor(rhs.x), self.y.bitxor(rhs.y))
     }
 }
 
@@ -1796,10 +1727,7 @@ impl BitAnd<i16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs))
     }
 }
 
@@ -1845,10 +1773,7 @@ impl BitOr<i16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs))
     }
 }
 
@@ -1894,10 +1819,7 @@ impl BitXor<i16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs))
     }
 }
 
@@ -1943,10 +1865,7 @@ impl Shl<i8> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1992,10 +1911,7 @@ impl Shr<i8> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2041,10 +1957,7 @@ impl Shl<i16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2090,10 +2003,7 @@ impl Shr<i16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2139,10 +2049,7 @@ impl Shl<i32> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2188,10 +2095,7 @@ impl Shr<i32> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2237,10 +2141,7 @@ impl Shl<i64> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2286,10 +2187,7 @@ impl Shr<i64> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2335,10 +2233,7 @@ impl Shl<u8> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2384,10 +2279,7 @@ impl Shr<u8> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2433,10 +2325,7 @@ impl Shl<u16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2482,10 +2371,7 @@ impl Shr<u16> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2531,10 +2417,7 @@ impl Shl<u32> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2580,10 +2463,7 @@ impl Shr<u32> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2629,10 +2509,7 @@ impl Shl<u64> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2678,10 +2555,7 @@ impl Shr<u64> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2728,10 +2602,7 @@ impl Shl<IVec2> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2767,10 +2638,7 @@ impl Shr<IVec2> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 
@@ -2806,10 +2674,7 @@ impl Shl<UVec2> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2845,10 +2710,7 @@ impl Shr<UVec2> for I16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -106,7 +106,7 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i16) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -127,11 +127,11 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -175,11 +175,7 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: I16Vec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -241,11 +237,11 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -254,11 +250,11 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -267,11 +263,11 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i16::clamp`].
@@ -430,11 +426,7 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-            z: self.z.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs(), self.z.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -445,11 +437,7 @@ impl I16Vec3 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-            z: self.z.signum(),
-        }
+        Self::new(self.x.signum(), self.y.signum(), self.z.signum())
     }
 
     /// Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
@@ -970,11 +958,7 @@ impl Div for I16Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -1022,11 +1006,7 @@ impl Div<i16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -1074,11 +1054,7 @@ impl Div<I16Vec3> for i16 {
     type Output = I16Vec3;
     #[inline]
     fn div(self, rhs: I16Vec3) -> I16Vec3 {
-        I16Vec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        I16Vec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -1110,11 +1086,7 @@ impl Mul for I16Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1162,11 +1134,7 @@ impl Mul<i16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1214,11 +1182,7 @@ impl Mul<I16Vec3> for i16 {
     type Output = I16Vec3;
     #[inline]
     fn mul(self, rhs: I16Vec3) -> I16Vec3 {
-        I16Vec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        I16Vec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1250,11 +1214,7 @@ impl Add for I16Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1302,11 +1262,7 @@ impl Add<i16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1354,11 +1310,7 @@ impl Add<I16Vec3> for i16 {
     type Output = I16Vec3;
     #[inline]
     fn add(self, rhs: I16Vec3) -> I16Vec3 {
-        I16Vec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        I16Vec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1390,11 +1342,7 @@ impl Sub for I16Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1442,11 +1390,7 @@ impl Sub<i16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1494,11 +1438,7 @@ impl Sub<I16Vec3> for i16 {
     type Output = I16Vec3;
     #[inline]
     fn sub(self, rhs: I16Vec3) -> I16Vec3 {
-        I16Vec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        I16Vec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -1530,11 +1470,7 @@ impl Rem for I16Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -1582,11 +1518,7 @@ impl Rem<i16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -1634,11 +1566,7 @@ impl Rem<I16Vec3> for i16 {
     type Output = I16Vec3;
     #[inline]
     fn rem(self, rhs: I16Vec3) -> I16Vec3 {
-        I16Vec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        I16Vec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -1724,11 +1652,7 @@ impl Neg for I16Vec3 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg())
     }
 }
 
@@ -1744,11 +1668,7 @@ impl Not for I16Vec3 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not())
     }
 }
 
@@ -1764,11 +1684,11 @@ impl BitAnd for I16Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+        )
     }
 }
 
@@ -1814,11 +1734,11 @@ impl BitOr for I16Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+        )
     }
 }
 
@@ -1864,11 +1784,11 @@ impl BitXor for I16Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+        )
     }
 }
 
@@ -1914,11 +1834,7 @@ impl BitAnd<i16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs), self.z.bitand(rhs))
     }
 }
 
@@ -1964,11 +1880,7 @@ impl BitOr<i16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs), self.z.bitor(rhs))
     }
 }
 
@@ -2014,11 +1926,7 @@ impl BitXor<i16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs), self.z.bitxor(rhs))
     }
 }
 
@@ -2064,11 +1972,7 @@ impl Shl<i8> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2114,11 +2018,7 @@ impl Shr<i8> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2164,11 +2064,7 @@ impl Shl<i16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2214,11 +2110,7 @@ impl Shr<i16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2264,11 +2156,7 @@ impl Shl<i32> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2314,11 +2202,7 @@ impl Shr<i32> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2364,11 +2248,7 @@ impl Shl<i64> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2414,11 +2294,7 @@ impl Shr<i64> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2464,11 +2340,7 @@ impl Shl<u8> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2514,11 +2386,7 @@ impl Shr<u8> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2564,11 +2432,7 @@ impl Shl<u16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2614,11 +2478,7 @@ impl Shr<u16> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2664,11 +2524,7 @@ impl Shl<u32> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2714,11 +2570,7 @@ impl Shr<u32> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2764,11 +2616,7 @@ impl Shl<u64> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2814,11 +2662,7 @@ impl Shr<u64> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2865,11 +2709,7 @@ impl Shl<IVec3> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2905,11 +2745,7 @@ impl Shr<IVec3> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 
@@ -2945,11 +2781,7 @@ impl Shl<UVec3> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2985,11 +2817,7 @@ impl Shr<UVec3> for I16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -116,15 +116,7 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i16) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -145,12 +137,12 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -251,12 +243,12 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -265,12 +257,12 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i16::clamp`].
@@ -467,12 +459,7 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-            z: self.z.abs(),
-            w: self.w.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs(), self.z.abs(), self.w.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -483,12 +470,12 @@ impl I16Vec4 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-            z: self.z.signum(),
-            w: self.w.signum(),
-        }
+        Self::new(
+            self.x.signum(),
+            self.y.signum(),
+            self.z.signum(),
+            self.w.signum(),
+        )
     }
 
     /// Returns a bitmask with the lowest 4 bits set to the sign bits from the elements of `self`.
@@ -1057,12 +1044,12 @@ impl Div for I16Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -1111,12 +1098,12 @@ impl Div<i16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -1165,12 +1152,12 @@ impl Div<I16Vec4> for i16 {
     type Output = I16Vec4;
     #[inline]
     fn div(self, rhs: I16Vec4) -> I16Vec4 {
-        I16Vec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        I16Vec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1202,12 +1189,12 @@ impl Mul for I16Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1256,12 +1243,12 @@ impl Mul<i16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1310,12 +1297,12 @@ impl Mul<I16Vec4> for i16 {
     type Output = I16Vec4;
     #[inline]
     fn mul(self, rhs: I16Vec4) -> I16Vec4 {
-        I16Vec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        I16Vec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1347,12 +1334,12 @@ impl Add for I16Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1401,12 +1388,12 @@ impl Add<i16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1455,12 +1442,12 @@ impl Add<I16Vec4> for i16 {
     type Output = I16Vec4;
     #[inline]
     fn add(self, rhs: I16Vec4) -> I16Vec4 {
-        I16Vec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        I16Vec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1492,12 +1479,12 @@ impl Sub for I16Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1546,12 +1533,12 @@ impl Sub<i16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1600,12 +1587,12 @@ impl Sub<I16Vec4> for i16 {
     type Output = I16Vec4;
     #[inline]
     fn sub(self, rhs: I16Vec4) -> I16Vec4 {
-        I16Vec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        I16Vec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1637,12 +1624,12 @@ impl Rem for I16Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1691,12 +1678,12 @@ impl Rem<i16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i16) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -1745,12 +1732,12 @@ impl Rem<I16Vec4> for i16 {
     type Output = I16Vec4;
     #[inline]
     fn rem(self, rhs: I16Vec4) -> I16Vec4 {
-        I16Vec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        I16Vec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -1836,12 +1823,7 @@ impl Neg for I16Vec4 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-            w: self.w.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg(), self.w.neg())
     }
 }
 
@@ -1857,12 +1839,7 @@ impl Not for I16Vec4 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-            w: self.w.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not(), self.w.not())
     }
 }
 
@@ -1878,12 +1855,12 @@ impl BitAnd for I16Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-            w: self.w.bitand(rhs.w),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+            self.w.bitand(rhs.w),
+        )
     }
 }
 
@@ -1929,12 +1906,12 @@ impl BitOr for I16Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-            w: self.w.bitor(rhs.w),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+            self.w.bitor(rhs.w),
+        )
     }
 }
 
@@ -1980,12 +1957,12 @@ impl BitXor for I16Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-            w: self.w.bitxor(rhs.w),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+            self.w.bitxor(rhs.w),
+        )
     }
 }
 
@@ -2031,12 +2008,12 @@ impl BitAnd<i16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-            w: self.w.bitand(rhs),
-        }
+        Self::new(
+            self.x.bitand(rhs),
+            self.y.bitand(rhs),
+            self.z.bitand(rhs),
+            self.w.bitand(rhs),
+        )
     }
 }
 
@@ -2082,12 +2059,12 @@ impl BitOr<i16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-            w: self.w.bitor(rhs),
-        }
+        Self::new(
+            self.x.bitor(rhs),
+            self.y.bitor(rhs),
+            self.z.bitor(rhs),
+            self.w.bitor(rhs),
+        )
     }
 }
 
@@ -2133,12 +2110,12 @@ impl BitXor<i16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-            w: self.w.bitxor(rhs),
-        }
+        Self::new(
+            self.x.bitxor(rhs),
+            self.y.bitxor(rhs),
+            self.z.bitxor(rhs),
+            self.w.bitxor(rhs),
+        )
     }
 }
 
@@ -2184,12 +2161,12 @@ impl Shl<i8> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2235,12 +2212,12 @@ impl Shr<i8> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2286,12 +2263,12 @@ impl Shl<i16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2337,12 +2314,12 @@ impl Shr<i16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2388,12 +2365,12 @@ impl Shl<i32> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2439,12 +2416,12 @@ impl Shr<i32> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2490,12 +2467,12 @@ impl Shl<i64> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2541,12 +2518,12 @@ impl Shr<i64> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2592,12 +2569,12 @@ impl Shl<u8> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2643,12 +2620,12 @@ impl Shr<u8> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2694,12 +2671,12 @@ impl Shl<u16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2745,12 +2722,12 @@ impl Shr<u16> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2796,12 +2773,12 @@ impl Shl<u32> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2847,12 +2824,12 @@ impl Shr<u32> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2898,12 +2875,12 @@ impl Shl<u64> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2949,12 +2926,12 @@ impl Shr<u64> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -3001,12 +2978,12 @@ impl Shl<IVec4> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -3042,12 +3019,12 @@ impl Shr<IVec4> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 
@@ -3083,12 +3060,12 @@ impl Shl<UVec4> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -3124,12 +3101,12 @@ impl Shr<UVec4> for I16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -100,7 +100,7 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i32) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -121,10 +121,10 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -206,10 +206,10 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -218,10 +218,10 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i32::clamp`].
@@ -370,10 +370,7 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -384,10 +381,7 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-        }
+        Self::new(self.x.signum(), self.y.signum())
     }
 
     /// Returns a bitmask with the lowest 2 bits set to the sign bits from the elements of `self`.
@@ -493,10 +487,7 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn perp(self) -> Self {
-        Self {
-            x: -self.y,
-            y: self.x,
-        }
+        Self::new(-self.y, self.x)
     }
 
     /// The perpendicular dot product of `self` and `rhs`.
@@ -519,10 +510,10 @@ impl IVec2 {
     #[inline]
     #[must_use]
     pub fn rotate(self, rhs: Self) -> Self {
-        Self {
-            x: self.x * rhs.x - self.y * rhs.y,
-            y: self.y * rhs.x + self.x * rhs.y,
-        }
+        Self::new(
+            self.x * rhs.x - self.y * rhs.y,
+            self.y * rhs.x + self.x * rhs.y,
+        )
     }
 
     /// Casts all elements of `self` to `f32`.
@@ -882,10 +873,7 @@ impl Div for IVec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -932,10 +920,7 @@ impl Div<i32> for IVec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -982,10 +967,7 @@ impl Div<IVec2> for i32 {
     type Output = IVec2;
     #[inline]
     fn div(self, rhs: IVec2) -> IVec2 {
-        IVec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        IVec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -1017,10 +999,7 @@ impl Mul for IVec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -1067,10 +1046,7 @@ impl Mul<i32> for IVec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -1117,10 +1093,7 @@ impl Mul<IVec2> for i32 {
     type Output = IVec2;
     #[inline]
     fn mul(self, rhs: IVec2) -> IVec2 {
-        IVec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        IVec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -1152,10 +1125,7 @@ impl Add for IVec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1202,10 +1172,7 @@ impl Add<i32> for IVec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1252,10 +1219,7 @@ impl Add<IVec2> for i32 {
     type Output = IVec2;
     #[inline]
     fn add(self, rhs: IVec2) -> IVec2 {
-        IVec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        IVec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1287,10 +1251,7 @@ impl Sub for IVec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1337,10 +1298,7 @@ impl Sub<i32> for IVec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1387,10 +1345,7 @@ impl Sub<IVec2> for i32 {
     type Output = IVec2;
     #[inline]
     fn sub(self, rhs: IVec2) -> IVec2 {
-        IVec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        IVec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1422,10 +1377,7 @@ impl Rem for IVec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1472,10 +1424,7 @@ impl Rem<i32> for IVec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1522,10 +1471,7 @@ impl Rem<IVec2> for i32 {
     type Output = IVec2;
     #[inline]
     fn rem(self, rhs: IVec2) -> IVec2 {
-        IVec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        IVec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1611,10 +1557,7 @@ impl Neg for IVec2 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg())
     }
 }
 
@@ -1630,10 +1573,7 @@ impl Not for IVec2 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-        }
+        Self::new(self.x.not(), self.y.not())
     }
 }
 
@@ -1649,10 +1589,7 @@ impl BitAnd for IVec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-        }
+        Self::new(self.x.bitand(rhs.x), self.y.bitand(rhs.y))
     }
 }
 
@@ -1698,10 +1635,7 @@ impl BitOr for IVec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-        }
+        Self::new(self.x.bitor(rhs.x), self.y.bitor(rhs.y))
     }
 }
 
@@ -1747,10 +1681,7 @@ impl BitXor for IVec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-        }
+        Self::new(self.x.bitxor(rhs.x), self.y.bitxor(rhs.y))
     }
 }
 
@@ -1796,10 +1727,7 @@ impl BitAnd<i32> for IVec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs))
     }
 }
 
@@ -1845,10 +1773,7 @@ impl BitOr<i32> for IVec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs))
     }
 }
 
@@ -1894,10 +1819,7 @@ impl BitXor<i32> for IVec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs))
     }
 }
 
@@ -1943,10 +1865,7 @@ impl Shl<i8> for IVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1992,10 +1911,7 @@ impl Shr<i8> for IVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2041,10 +1957,7 @@ impl Shl<i16> for IVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2090,10 +2003,7 @@ impl Shr<i16> for IVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2139,10 +2049,7 @@ impl Shl<i32> for IVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2188,10 +2095,7 @@ impl Shr<i32> for IVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2237,10 +2141,7 @@ impl Shl<i64> for IVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2286,10 +2187,7 @@ impl Shr<i64> for IVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2335,10 +2233,7 @@ impl Shl<u8> for IVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2384,10 +2279,7 @@ impl Shr<u8> for IVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2433,10 +2325,7 @@ impl Shl<u16> for IVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2482,10 +2371,7 @@ impl Shr<u16> for IVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2531,10 +2417,7 @@ impl Shl<u32> for IVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2580,10 +2463,7 @@ impl Shr<u32> for IVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2629,10 +2509,7 @@ impl Shl<u64> for IVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2678,10 +2555,7 @@ impl Shr<u64> for IVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2727,10 +2601,7 @@ impl Shl for IVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2762,10 +2633,7 @@ impl Shr for IVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 
@@ -2798,10 +2666,7 @@ impl Shl<UVec2> for IVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2837,10 +2702,7 @@ impl Shr<UVec2> for IVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -106,7 +106,7 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i32) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -127,11 +127,11 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -175,11 +175,7 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: IVec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -241,11 +237,11 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -254,11 +250,11 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -267,11 +263,11 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i32::clamp`].
@@ -430,11 +426,7 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-            z: self.z.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs(), self.z.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -445,11 +437,7 @@ impl IVec3 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-            z: self.z.signum(),
-        }
+        Self::new(self.x.signum(), self.y.signum(), self.z.signum())
     }
 
     /// Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
@@ -970,11 +958,7 @@ impl Div for IVec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -1022,11 +1006,7 @@ impl Div<i32> for IVec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -1074,11 +1054,7 @@ impl Div<IVec3> for i32 {
     type Output = IVec3;
     #[inline]
     fn div(self, rhs: IVec3) -> IVec3 {
-        IVec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        IVec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -1110,11 +1086,7 @@ impl Mul for IVec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1162,11 +1134,7 @@ impl Mul<i32> for IVec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1214,11 +1182,7 @@ impl Mul<IVec3> for i32 {
     type Output = IVec3;
     #[inline]
     fn mul(self, rhs: IVec3) -> IVec3 {
-        IVec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        IVec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1250,11 +1214,7 @@ impl Add for IVec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1302,11 +1262,7 @@ impl Add<i32> for IVec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1354,11 +1310,7 @@ impl Add<IVec3> for i32 {
     type Output = IVec3;
     #[inline]
     fn add(self, rhs: IVec3) -> IVec3 {
-        IVec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        IVec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1390,11 +1342,7 @@ impl Sub for IVec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1442,11 +1390,7 @@ impl Sub<i32> for IVec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1494,11 +1438,7 @@ impl Sub<IVec3> for i32 {
     type Output = IVec3;
     #[inline]
     fn sub(self, rhs: IVec3) -> IVec3 {
-        IVec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        IVec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -1530,11 +1470,7 @@ impl Rem for IVec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -1582,11 +1518,7 @@ impl Rem<i32> for IVec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -1634,11 +1566,7 @@ impl Rem<IVec3> for i32 {
     type Output = IVec3;
     #[inline]
     fn rem(self, rhs: IVec3) -> IVec3 {
-        IVec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        IVec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -1724,11 +1652,7 @@ impl Neg for IVec3 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg())
     }
 }
 
@@ -1744,11 +1668,7 @@ impl Not for IVec3 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not())
     }
 }
 
@@ -1764,11 +1684,11 @@ impl BitAnd for IVec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+        )
     }
 }
 
@@ -1814,11 +1734,11 @@ impl BitOr for IVec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+        )
     }
 }
 
@@ -1864,11 +1784,11 @@ impl BitXor for IVec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+        )
     }
 }
 
@@ -1914,11 +1834,7 @@ impl BitAnd<i32> for IVec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs), self.z.bitand(rhs))
     }
 }
 
@@ -1964,11 +1880,7 @@ impl BitOr<i32> for IVec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs), self.z.bitor(rhs))
     }
 }
 
@@ -2014,11 +1926,7 @@ impl BitXor<i32> for IVec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs), self.z.bitxor(rhs))
     }
 }
 
@@ -2064,11 +1972,7 @@ impl Shl<i8> for IVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2114,11 +2018,7 @@ impl Shr<i8> for IVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2164,11 +2064,7 @@ impl Shl<i16> for IVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2214,11 +2110,7 @@ impl Shr<i16> for IVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2264,11 +2156,7 @@ impl Shl<i32> for IVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2314,11 +2202,7 @@ impl Shr<i32> for IVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2364,11 +2248,7 @@ impl Shl<i64> for IVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2414,11 +2294,7 @@ impl Shr<i64> for IVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2464,11 +2340,7 @@ impl Shl<u8> for IVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2514,11 +2386,7 @@ impl Shr<u8> for IVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2564,11 +2432,7 @@ impl Shl<u16> for IVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2614,11 +2478,7 @@ impl Shr<u16> for IVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2664,11 +2524,7 @@ impl Shl<u32> for IVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2714,11 +2570,7 @@ impl Shr<u32> for IVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2764,11 +2616,7 @@ impl Shl<u64> for IVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2814,11 +2662,7 @@ impl Shr<u64> for IVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2864,11 +2708,7 @@ impl Shl for IVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2900,11 +2740,7 @@ impl Shr for IVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 
@@ -2937,11 +2773,7 @@ impl Shl<UVec3> for IVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2977,11 +2809,7 @@ impl Shr<UVec3> for IVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -116,15 +116,7 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i32) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -145,12 +137,12 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -251,12 +243,12 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -265,12 +257,12 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i32::clamp`].
@@ -467,12 +459,7 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-            z: self.z.abs(),
-            w: self.w.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs(), self.z.abs(), self.w.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -483,12 +470,12 @@ impl IVec4 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-            z: self.z.signum(),
-            w: self.w.signum(),
-        }
+        Self::new(
+            self.x.signum(),
+            self.y.signum(),
+            self.z.signum(),
+            self.w.signum(),
+        )
     }
 
     /// Returns a bitmask with the lowest 4 bits set to the sign bits from the elements of `self`.
@@ -1057,12 +1044,12 @@ impl Div for IVec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -1111,12 +1098,12 @@ impl Div<i32> for IVec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -1165,12 +1152,12 @@ impl Div<IVec4> for i32 {
     type Output = IVec4;
     #[inline]
     fn div(self, rhs: IVec4) -> IVec4 {
-        IVec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        IVec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1202,12 +1189,12 @@ impl Mul for IVec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1256,12 +1243,12 @@ impl Mul<i32> for IVec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1310,12 +1297,12 @@ impl Mul<IVec4> for i32 {
     type Output = IVec4;
     #[inline]
     fn mul(self, rhs: IVec4) -> IVec4 {
-        IVec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        IVec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1347,12 +1334,12 @@ impl Add for IVec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1401,12 +1388,12 @@ impl Add<i32> for IVec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1455,12 +1442,12 @@ impl Add<IVec4> for i32 {
     type Output = IVec4;
     #[inline]
     fn add(self, rhs: IVec4) -> IVec4 {
-        IVec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        IVec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1492,12 +1479,12 @@ impl Sub for IVec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1546,12 +1533,12 @@ impl Sub<i32> for IVec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1600,12 +1587,12 @@ impl Sub<IVec4> for i32 {
     type Output = IVec4;
     #[inline]
     fn sub(self, rhs: IVec4) -> IVec4 {
-        IVec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        IVec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1637,12 +1624,12 @@ impl Rem for IVec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1691,12 +1678,12 @@ impl Rem<i32> for IVec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i32) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -1745,12 +1732,12 @@ impl Rem<IVec4> for i32 {
     type Output = IVec4;
     #[inline]
     fn rem(self, rhs: IVec4) -> IVec4 {
-        IVec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        IVec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -1836,12 +1823,7 @@ impl Neg for IVec4 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-            w: self.w.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg(), self.w.neg())
     }
 }
 
@@ -1857,12 +1839,7 @@ impl Not for IVec4 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-            w: self.w.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not(), self.w.not())
     }
 }
 
@@ -1878,12 +1855,12 @@ impl BitAnd for IVec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-            w: self.w.bitand(rhs.w),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+            self.w.bitand(rhs.w),
+        )
     }
 }
 
@@ -1929,12 +1906,12 @@ impl BitOr for IVec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-            w: self.w.bitor(rhs.w),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+            self.w.bitor(rhs.w),
+        )
     }
 }
 
@@ -1980,12 +1957,12 @@ impl BitXor for IVec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-            w: self.w.bitxor(rhs.w),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+            self.w.bitxor(rhs.w),
+        )
     }
 }
 
@@ -2031,12 +2008,12 @@ impl BitAnd<i32> for IVec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-            w: self.w.bitand(rhs),
-        }
+        Self::new(
+            self.x.bitand(rhs),
+            self.y.bitand(rhs),
+            self.z.bitand(rhs),
+            self.w.bitand(rhs),
+        )
     }
 }
 
@@ -2082,12 +2059,12 @@ impl BitOr<i32> for IVec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-            w: self.w.bitor(rhs),
-        }
+        Self::new(
+            self.x.bitor(rhs),
+            self.y.bitor(rhs),
+            self.z.bitor(rhs),
+            self.w.bitor(rhs),
+        )
     }
 }
 
@@ -2133,12 +2110,12 @@ impl BitXor<i32> for IVec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-            w: self.w.bitxor(rhs),
-        }
+        Self::new(
+            self.x.bitxor(rhs),
+            self.y.bitxor(rhs),
+            self.z.bitxor(rhs),
+            self.w.bitxor(rhs),
+        )
     }
 }
 
@@ -2184,12 +2161,12 @@ impl Shl<i8> for IVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2235,12 +2212,12 @@ impl Shr<i8> for IVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2286,12 +2263,12 @@ impl Shl<i16> for IVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2337,12 +2314,12 @@ impl Shr<i16> for IVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2388,12 +2365,12 @@ impl Shl<i32> for IVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2439,12 +2416,12 @@ impl Shr<i32> for IVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2490,12 +2467,12 @@ impl Shl<i64> for IVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2541,12 +2518,12 @@ impl Shr<i64> for IVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2592,12 +2569,12 @@ impl Shl<u8> for IVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2643,12 +2620,12 @@ impl Shr<u8> for IVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2694,12 +2671,12 @@ impl Shl<u16> for IVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2745,12 +2722,12 @@ impl Shr<u16> for IVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2796,12 +2773,12 @@ impl Shl<u32> for IVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2847,12 +2824,12 @@ impl Shr<u32> for IVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2898,12 +2875,12 @@ impl Shl<u64> for IVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2949,12 +2926,12 @@ impl Shr<u64> for IVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -3000,12 +2977,12 @@ impl Shl for IVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -3037,12 +3014,12 @@ impl Shr for IVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 
@@ -3075,12 +3052,12 @@ impl Shl<UVec4> for IVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -3116,12 +3093,12 @@ impl Shr<UVec4> for IVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -100,7 +100,7 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i64) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -121,10 +121,10 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -206,10 +206,10 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -218,10 +218,10 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i64::clamp`].
@@ -370,10 +370,7 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -384,10 +381,7 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-        }
+        Self::new(self.x.signum(), self.y.signum())
     }
 
     /// Returns a bitmask with the lowest 2 bits set to the sign bits from the elements of `self`.
@@ -493,10 +487,7 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn perp(self) -> Self {
-        Self {
-            x: -self.y,
-            y: self.x,
-        }
+        Self::new(-self.y, self.x)
     }
 
     /// The perpendicular dot product of `self` and `rhs`.
@@ -519,10 +510,10 @@ impl I64Vec2 {
     #[inline]
     #[must_use]
     pub fn rotate(self, rhs: Self) -> Self {
-        Self {
-            x: self.x * rhs.x - self.y * rhs.y,
-            y: self.y * rhs.x + self.x * rhs.y,
-        }
+        Self::new(
+            self.x * rhs.x - self.y * rhs.y,
+            self.y * rhs.x + self.x * rhs.y,
+        )
     }
 
     /// Casts all elements of `self` to `f32`.
@@ -882,10 +873,7 @@ impl Div for I64Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -932,10 +920,7 @@ impl Div<i64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -982,10 +967,7 @@ impl Div<I64Vec2> for i64 {
     type Output = I64Vec2;
     #[inline]
     fn div(self, rhs: I64Vec2) -> I64Vec2 {
-        I64Vec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        I64Vec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -1017,10 +999,7 @@ impl Mul for I64Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -1067,10 +1046,7 @@ impl Mul<i64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -1117,10 +1093,7 @@ impl Mul<I64Vec2> for i64 {
     type Output = I64Vec2;
     #[inline]
     fn mul(self, rhs: I64Vec2) -> I64Vec2 {
-        I64Vec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        I64Vec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -1152,10 +1125,7 @@ impl Add for I64Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1202,10 +1172,7 @@ impl Add<i64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1252,10 +1219,7 @@ impl Add<I64Vec2> for i64 {
     type Output = I64Vec2;
     #[inline]
     fn add(self, rhs: I64Vec2) -> I64Vec2 {
-        I64Vec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        I64Vec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1287,10 +1251,7 @@ impl Sub for I64Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1337,10 +1298,7 @@ impl Sub<i64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1387,10 +1345,7 @@ impl Sub<I64Vec2> for i64 {
     type Output = I64Vec2;
     #[inline]
     fn sub(self, rhs: I64Vec2) -> I64Vec2 {
-        I64Vec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        I64Vec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1422,10 +1377,7 @@ impl Rem for I64Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1472,10 +1424,7 @@ impl Rem<i64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1522,10 +1471,7 @@ impl Rem<I64Vec2> for i64 {
     type Output = I64Vec2;
     #[inline]
     fn rem(self, rhs: I64Vec2) -> I64Vec2 {
-        I64Vec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        I64Vec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1611,10 +1557,7 @@ impl Neg for I64Vec2 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg())
     }
 }
 
@@ -1630,10 +1573,7 @@ impl Not for I64Vec2 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-        }
+        Self::new(self.x.not(), self.y.not())
     }
 }
 
@@ -1649,10 +1589,7 @@ impl BitAnd for I64Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-        }
+        Self::new(self.x.bitand(rhs.x), self.y.bitand(rhs.y))
     }
 }
 
@@ -1698,10 +1635,7 @@ impl BitOr for I64Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-        }
+        Self::new(self.x.bitor(rhs.x), self.y.bitor(rhs.y))
     }
 }
 
@@ -1747,10 +1681,7 @@ impl BitXor for I64Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-        }
+        Self::new(self.x.bitxor(rhs.x), self.y.bitxor(rhs.y))
     }
 }
 
@@ -1796,10 +1727,7 @@ impl BitAnd<i64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs))
     }
 }
 
@@ -1845,10 +1773,7 @@ impl BitOr<i64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs))
     }
 }
 
@@ -1894,10 +1819,7 @@ impl BitXor<i64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs))
     }
 }
 
@@ -1943,10 +1865,7 @@ impl Shl<i8> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1992,10 +1911,7 @@ impl Shr<i8> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2041,10 +1957,7 @@ impl Shl<i16> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2090,10 +2003,7 @@ impl Shr<i16> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2139,10 +2049,7 @@ impl Shl<i32> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2188,10 +2095,7 @@ impl Shr<i32> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2237,10 +2141,7 @@ impl Shl<i64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2286,10 +2187,7 @@ impl Shr<i64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2335,10 +2233,7 @@ impl Shl<u8> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2384,10 +2279,7 @@ impl Shr<u8> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2433,10 +2325,7 @@ impl Shl<u16> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2482,10 +2371,7 @@ impl Shr<u16> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2531,10 +2417,7 @@ impl Shl<u32> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2580,10 +2463,7 @@ impl Shr<u32> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2629,10 +2509,7 @@ impl Shl<u64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2678,10 +2555,7 @@ impl Shr<u64> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2728,10 +2602,7 @@ impl Shl<IVec2> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2767,10 +2638,7 @@ impl Shr<IVec2> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 
@@ -2806,10 +2674,7 @@ impl Shl<UVec2> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2845,10 +2710,7 @@ impl Shr<UVec2> for I64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -106,7 +106,7 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i64) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -127,11 +127,11 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -175,11 +175,7 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: I64Vec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -241,11 +237,11 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -254,11 +250,11 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -267,11 +263,11 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i64::clamp`].
@@ -430,11 +426,7 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-            z: self.z.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs(), self.z.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -445,11 +437,7 @@ impl I64Vec3 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-            z: self.z.signum(),
-        }
+        Self::new(self.x.signum(), self.y.signum(), self.z.signum())
     }
 
     /// Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
@@ -970,11 +958,7 @@ impl Div for I64Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -1022,11 +1006,7 @@ impl Div<i64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -1074,11 +1054,7 @@ impl Div<I64Vec3> for i64 {
     type Output = I64Vec3;
     #[inline]
     fn div(self, rhs: I64Vec3) -> I64Vec3 {
-        I64Vec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        I64Vec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -1110,11 +1086,7 @@ impl Mul for I64Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1162,11 +1134,7 @@ impl Mul<i64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1214,11 +1182,7 @@ impl Mul<I64Vec3> for i64 {
     type Output = I64Vec3;
     #[inline]
     fn mul(self, rhs: I64Vec3) -> I64Vec3 {
-        I64Vec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        I64Vec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1250,11 +1214,7 @@ impl Add for I64Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1302,11 +1262,7 @@ impl Add<i64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1354,11 +1310,7 @@ impl Add<I64Vec3> for i64 {
     type Output = I64Vec3;
     #[inline]
     fn add(self, rhs: I64Vec3) -> I64Vec3 {
-        I64Vec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        I64Vec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1390,11 +1342,7 @@ impl Sub for I64Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1442,11 +1390,7 @@ impl Sub<i64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1494,11 +1438,7 @@ impl Sub<I64Vec3> for i64 {
     type Output = I64Vec3;
     #[inline]
     fn sub(self, rhs: I64Vec3) -> I64Vec3 {
-        I64Vec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        I64Vec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -1530,11 +1470,7 @@ impl Rem for I64Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -1582,11 +1518,7 @@ impl Rem<i64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -1634,11 +1566,7 @@ impl Rem<I64Vec3> for i64 {
     type Output = I64Vec3;
     #[inline]
     fn rem(self, rhs: I64Vec3) -> I64Vec3 {
-        I64Vec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        I64Vec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -1724,11 +1652,7 @@ impl Neg for I64Vec3 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg())
     }
 }
 
@@ -1744,11 +1668,7 @@ impl Not for I64Vec3 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not())
     }
 }
 
@@ -1764,11 +1684,11 @@ impl BitAnd for I64Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+        )
     }
 }
 
@@ -1814,11 +1734,11 @@ impl BitOr for I64Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+        )
     }
 }
 
@@ -1864,11 +1784,11 @@ impl BitXor for I64Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+        )
     }
 }
 
@@ -1914,11 +1834,7 @@ impl BitAnd<i64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs), self.z.bitand(rhs))
     }
 }
 
@@ -1964,11 +1880,7 @@ impl BitOr<i64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs), self.z.bitor(rhs))
     }
 }
 
@@ -2014,11 +1926,7 @@ impl BitXor<i64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs), self.z.bitxor(rhs))
     }
 }
 
@@ -2064,11 +1972,7 @@ impl Shl<i8> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2114,11 +2018,7 @@ impl Shr<i8> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2164,11 +2064,7 @@ impl Shl<i16> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2214,11 +2110,7 @@ impl Shr<i16> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2264,11 +2156,7 @@ impl Shl<i32> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2314,11 +2202,7 @@ impl Shr<i32> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2364,11 +2248,7 @@ impl Shl<i64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2414,11 +2294,7 @@ impl Shr<i64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2464,11 +2340,7 @@ impl Shl<u8> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2514,11 +2386,7 @@ impl Shr<u8> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2564,11 +2432,7 @@ impl Shl<u16> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2614,11 +2478,7 @@ impl Shr<u16> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2664,11 +2524,7 @@ impl Shl<u32> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2714,11 +2570,7 @@ impl Shr<u32> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2764,11 +2616,7 @@ impl Shl<u64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2814,11 +2662,7 @@ impl Shr<u64> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2865,11 +2709,7 @@ impl Shl<IVec3> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2905,11 +2745,7 @@ impl Shr<IVec3> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 
@@ -2945,11 +2781,7 @@ impl Shl<UVec3> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2985,11 +2817,7 @@ impl Shr<UVec3> for I64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -116,15 +116,7 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i64) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -145,12 +137,12 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -251,12 +243,12 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -265,12 +257,12 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i64::clamp`].
@@ -467,12 +459,7 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-            z: self.z.abs(),
-            w: self.w.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs(), self.z.abs(), self.w.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -483,12 +470,12 @@ impl I64Vec4 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-            z: self.z.signum(),
-            w: self.w.signum(),
-        }
+        Self::new(
+            self.x.signum(),
+            self.y.signum(),
+            self.z.signum(),
+            self.w.signum(),
+        )
     }
 
     /// Returns a bitmask with the lowest 4 bits set to the sign bits from the elements of `self`.
@@ -1057,12 +1044,12 @@ impl Div for I64Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -1111,12 +1098,12 @@ impl Div<i64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -1165,12 +1152,12 @@ impl Div<I64Vec4> for i64 {
     type Output = I64Vec4;
     #[inline]
     fn div(self, rhs: I64Vec4) -> I64Vec4 {
-        I64Vec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        I64Vec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1202,12 +1189,12 @@ impl Mul for I64Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1256,12 +1243,12 @@ impl Mul<i64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1310,12 +1297,12 @@ impl Mul<I64Vec4> for i64 {
     type Output = I64Vec4;
     #[inline]
     fn mul(self, rhs: I64Vec4) -> I64Vec4 {
-        I64Vec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        I64Vec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1347,12 +1334,12 @@ impl Add for I64Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1401,12 +1388,12 @@ impl Add<i64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1455,12 +1442,12 @@ impl Add<I64Vec4> for i64 {
     type Output = I64Vec4;
     #[inline]
     fn add(self, rhs: I64Vec4) -> I64Vec4 {
-        I64Vec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        I64Vec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1492,12 +1479,12 @@ impl Sub for I64Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1546,12 +1533,12 @@ impl Sub<i64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1600,12 +1587,12 @@ impl Sub<I64Vec4> for i64 {
     type Output = I64Vec4;
     #[inline]
     fn sub(self, rhs: I64Vec4) -> I64Vec4 {
-        I64Vec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        I64Vec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1637,12 +1624,12 @@ impl Rem for I64Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1691,12 +1678,12 @@ impl Rem<i64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i64) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -1745,12 +1732,12 @@ impl Rem<I64Vec4> for i64 {
     type Output = I64Vec4;
     #[inline]
     fn rem(self, rhs: I64Vec4) -> I64Vec4 {
-        I64Vec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        I64Vec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -1836,12 +1823,7 @@ impl Neg for I64Vec4 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-            w: self.w.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg(), self.w.neg())
     }
 }
 
@@ -1857,12 +1839,7 @@ impl Not for I64Vec4 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-            w: self.w.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not(), self.w.not())
     }
 }
 
@@ -1878,12 +1855,12 @@ impl BitAnd for I64Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-            w: self.w.bitand(rhs.w),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+            self.w.bitand(rhs.w),
+        )
     }
 }
 
@@ -1929,12 +1906,12 @@ impl BitOr for I64Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-            w: self.w.bitor(rhs.w),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+            self.w.bitor(rhs.w),
+        )
     }
 }
 
@@ -1980,12 +1957,12 @@ impl BitXor for I64Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-            w: self.w.bitxor(rhs.w),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+            self.w.bitxor(rhs.w),
+        )
     }
 }
 
@@ -2031,12 +2008,12 @@ impl BitAnd<i64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-            w: self.w.bitand(rhs),
-        }
+        Self::new(
+            self.x.bitand(rhs),
+            self.y.bitand(rhs),
+            self.z.bitand(rhs),
+            self.w.bitand(rhs),
+        )
     }
 }
 
@@ -2082,12 +2059,12 @@ impl BitOr<i64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-            w: self.w.bitor(rhs),
-        }
+        Self::new(
+            self.x.bitor(rhs),
+            self.y.bitor(rhs),
+            self.z.bitor(rhs),
+            self.w.bitor(rhs),
+        )
     }
 }
 
@@ -2133,12 +2110,12 @@ impl BitXor<i64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-            w: self.w.bitxor(rhs),
-        }
+        Self::new(
+            self.x.bitxor(rhs),
+            self.y.bitxor(rhs),
+            self.z.bitxor(rhs),
+            self.w.bitxor(rhs),
+        )
     }
 }
 
@@ -2184,12 +2161,12 @@ impl Shl<i8> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2235,12 +2212,12 @@ impl Shr<i8> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2286,12 +2263,12 @@ impl Shl<i16> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2337,12 +2314,12 @@ impl Shr<i16> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2388,12 +2365,12 @@ impl Shl<i32> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2439,12 +2416,12 @@ impl Shr<i32> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2490,12 +2467,12 @@ impl Shl<i64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2541,12 +2518,12 @@ impl Shr<i64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2592,12 +2569,12 @@ impl Shl<u8> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2643,12 +2620,12 @@ impl Shr<u8> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2694,12 +2671,12 @@ impl Shl<u16> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2745,12 +2722,12 @@ impl Shr<u16> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2796,12 +2773,12 @@ impl Shl<u32> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2847,12 +2824,12 @@ impl Shr<u32> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2898,12 +2875,12 @@ impl Shl<u64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2949,12 +2926,12 @@ impl Shr<u64> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -3001,12 +2978,12 @@ impl Shl<IVec4> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -3042,12 +3019,12 @@ impl Shr<IVec4> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 
@@ -3083,12 +3060,12 @@ impl Shl<UVec4> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -3124,12 +3101,12 @@ impl Shr<UVec4> for I64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -100,7 +100,7 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i8) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -121,10 +121,10 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -206,10 +206,10 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -218,10 +218,10 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i8::clamp`].
@@ -370,10 +370,7 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -384,10 +381,7 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-        }
+        Self::new(self.x.signum(), self.y.signum())
     }
 
     /// Returns a bitmask with the lowest 2 bits set to the sign bits from the elements of `self`.
@@ -493,10 +487,7 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn perp(self) -> Self {
-        Self {
-            x: -self.y,
-            y: self.x,
-        }
+        Self::new(-self.y, self.x)
     }
 
     /// The perpendicular dot product of `self` and `rhs`.
@@ -519,10 +510,10 @@ impl I8Vec2 {
     #[inline]
     #[must_use]
     pub fn rotate(self, rhs: Self) -> Self {
-        Self {
-            x: self.x * rhs.x - self.y * rhs.y,
-            y: self.y * rhs.x + self.x * rhs.y,
-        }
+        Self::new(
+            self.x * rhs.x - self.y * rhs.y,
+            self.y * rhs.x + self.x * rhs.y,
+        )
     }
 
     /// Casts all elements of `self` to `f32`.
@@ -882,10 +873,7 @@ impl Div for I8Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -932,10 +920,7 @@ impl Div<i8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -982,10 +967,7 @@ impl Div<I8Vec2> for i8 {
     type Output = I8Vec2;
     #[inline]
     fn div(self, rhs: I8Vec2) -> I8Vec2 {
-        I8Vec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        I8Vec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -1017,10 +999,7 @@ impl Mul for I8Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -1067,10 +1046,7 @@ impl Mul<i8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -1117,10 +1093,7 @@ impl Mul<I8Vec2> for i8 {
     type Output = I8Vec2;
     #[inline]
     fn mul(self, rhs: I8Vec2) -> I8Vec2 {
-        I8Vec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        I8Vec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -1152,10 +1125,7 @@ impl Add for I8Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1202,10 +1172,7 @@ impl Add<i8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1252,10 +1219,7 @@ impl Add<I8Vec2> for i8 {
     type Output = I8Vec2;
     #[inline]
     fn add(self, rhs: I8Vec2) -> I8Vec2 {
-        I8Vec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        I8Vec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1287,10 +1251,7 @@ impl Sub for I8Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1337,10 +1298,7 @@ impl Sub<i8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1387,10 +1345,7 @@ impl Sub<I8Vec2> for i8 {
     type Output = I8Vec2;
     #[inline]
     fn sub(self, rhs: I8Vec2) -> I8Vec2 {
-        I8Vec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        I8Vec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1422,10 +1377,7 @@ impl Rem for I8Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1472,10 +1424,7 @@ impl Rem<i8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1522,10 +1471,7 @@ impl Rem<I8Vec2> for i8 {
     type Output = I8Vec2;
     #[inline]
     fn rem(self, rhs: I8Vec2) -> I8Vec2 {
-        I8Vec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        I8Vec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1611,10 +1557,7 @@ impl Neg for I8Vec2 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg())
     }
 }
 
@@ -1630,10 +1573,7 @@ impl Not for I8Vec2 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-        }
+        Self::new(self.x.not(), self.y.not())
     }
 }
 
@@ -1649,10 +1589,7 @@ impl BitAnd for I8Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-        }
+        Self::new(self.x.bitand(rhs.x), self.y.bitand(rhs.y))
     }
 }
 
@@ -1698,10 +1635,7 @@ impl BitOr for I8Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-        }
+        Self::new(self.x.bitor(rhs.x), self.y.bitor(rhs.y))
     }
 }
 
@@ -1747,10 +1681,7 @@ impl BitXor for I8Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-        }
+        Self::new(self.x.bitxor(rhs.x), self.y.bitxor(rhs.y))
     }
 }
 
@@ -1796,10 +1727,7 @@ impl BitAnd<i8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs))
     }
 }
 
@@ -1845,10 +1773,7 @@ impl BitOr<i8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs))
     }
 }
 
@@ -1894,10 +1819,7 @@ impl BitXor<i8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs))
     }
 }
 
@@ -1943,10 +1865,7 @@ impl Shl<i8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1992,10 +1911,7 @@ impl Shr<i8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2041,10 +1957,7 @@ impl Shl<i16> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2090,10 +2003,7 @@ impl Shr<i16> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2139,10 +2049,7 @@ impl Shl<i32> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2188,10 +2095,7 @@ impl Shr<i32> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2237,10 +2141,7 @@ impl Shl<i64> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2286,10 +2187,7 @@ impl Shr<i64> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2335,10 +2233,7 @@ impl Shl<u8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2384,10 +2279,7 @@ impl Shr<u8> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2433,10 +2325,7 @@ impl Shl<u16> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2482,10 +2371,7 @@ impl Shr<u16> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2531,10 +2417,7 @@ impl Shl<u32> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2580,10 +2463,7 @@ impl Shr<u32> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2629,10 +2509,7 @@ impl Shl<u64> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2678,10 +2555,7 @@ impl Shr<u64> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2728,10 +2602,7 @@ impl Shl<IVec2> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2767,10 +2638,7 @@ impl Shr<IVec2> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 
@@ -2806,10 +2674,7 @@ impl Shl<UVec2> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2845,10 +2710,7 @@ impl Shr<UVec2> for I8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -106,7 +106,7 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i8) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -127,11 +127,11 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -175,11 +175,7 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: I8Vec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -241,11 +237,11 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -254,11 +250,11 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -267,11 +263,11 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i8::clamp`].
@@ -430,11 +426,7 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-            z: self.z.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs(), self.z.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -445,11 +437,7 @@ impl I8Vec3 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-            z: self.z.signum(),
-        }
+        Self::new(self.x.signum(), self.y.signum(), self.z.signum())
     }
 
     /// Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
@@ -970,11 +958,7 @@ impl Div for I8Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -1022,11 +1006,7 @@ impl Div<i8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -1074,11 +1054,7 @@ impl Div<I8Vec3> for i8 {
     type Output = I8Vec3;
     #[inline]
     fn div(self, rhs: I8Vec3) -> I8Vec3 {
-        I8Vec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        I8Vec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -1110,11 +1086,7 @@ impl Mul for I8Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1162,11 +1134,7 @@ impl Mul<i8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1214,11 +1182,7 @@ impl Mul<I8Vec3> for i8 {
     type Output = I8Vec3;
     #[inline]
     fn mul(self, rhs: I8Vec3) -> I8Vec3 {
-        I8Vec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        I8Vec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1250,11 +1214,7 @@ impl Add for I8Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1302,11 +1262,7 @@ impl Add<i8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1354,11 +1310,7 @@ impl Add<I8Vec3> for i8 {
     type Output = I8Vec3;
     #[inline]
     fn add(self, rhs: I8Vec3) -> I8Vec3 {
-        I8Vec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        I8Vec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1390,11 +1342,7 @@ impl Sub for I8Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1442,11 +1390,7 @@ impl Sub<i8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1494,11 +1438,7 @@ impl Sub<I8Vec3> for i8 {
     type Output = I8Vec3;
     #[inline]
     fn sub(self, rhs: I8Vec3) -> I8Vec3 {
-        I8Vec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        I8Vec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -1530,11 +1470,7 @@ impl Rem for I8Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -1582,11 +1518,7 @@ impl Rem<i8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -1634,11 +1566,7 @@ impl Rem<I8Vec3> for i8 {
     type Output = I8Vec3;
     #[inline]
     fn rem(self, rhs: I8Vec3) -> I8Vec3 {
-        I8Vec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        I8Vec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -1724,11 +1652,7 @@ impl Neg for I8Vec3 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg())
     }
 }
 
@@ -1744,11 +1668,7 @@ impl Not for I8Vec3 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not())
     }
 }
 
@@ -1764,11 +1684,11 @@ impl BitAnd for I8Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+        )
     }
 }
 
@@ -1814,11 +1734,11 @@ impl BitOr for I8Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+        )
     }
 }
 
@@ -1864,11 +1784,11 @@ impl BitXor for I8Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+        )
     }
 }
 
@@ -1914,11 +1834,7 @@ impl BitAnd<i8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs), self.z.bitand(rhs))
     }
 }
 
@@ -1964,11 +1880,7 @@ impl BitOr<i8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs), self.z.bitor(rhs))
     }
 }
 
@@ -2014,11 +1926,7 @@ impl BitXor<i8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs), self.z.bitxor(rhs))
     }
 }
 
@@ -2064,11 +1972,7 @@ impl Shl<i8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2114,11 +2018,7 @@ impl Shr<i8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2164,11 +2064,7 @@ impl Shl<i16> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2214,11 +2110,7 @@ impl Shr<i16> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2264,11 +2156,7 @@ impl Shl<i32> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2314,11 +2202,7 @@ impl Shr<i32> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2364,11 +2248,7 @@ impl Shl<i64> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2414,11 +2294,7 @@ impl Shr<i64> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2464,11 +2340,7 @@ impl Shl<u8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2514,11 +2386,7 @@ impl Shr<u8> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2564,11 +2432,7 @@ impl Shl<u16> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2614,11 +2478,7 @@ impl Shr<u16> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2664,11 +2524,7 @@ impl Shl<u32> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2714,11 +2570,7 @@ impl Shr<u32> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2764,11 +2616,7 @@ impl Shl<u64> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2814,11 +2662,7 @@ impl Shr<u64> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2865,11 +2709,7 @@ impl Shl<IVec3> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2905,11 +2745,7 @@ impl Shr<IVec3> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 
@@ -2945,11 +2781,7 @@ impl Shl<UVec3> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2985,11 +2817,7 @@ impl Shr<UVec3> for I8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -116,15 +116,7 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: i8) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -145,12 +137,12 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -251,12 +243,12 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -265,12 +257,12 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`i8::clamp`].
@@ -467,12 +459,7 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-            z: self.z.abs(),
-            w: self.w.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs(), self.z.abs(), self.w.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -483,12 +470,12 @@ impl I8Vec4 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-            z: self.z.signum(),
-            w: self.w.signum(),
-        }
+        Self::new(
+            self.x.signum(),
+            self.y.signum(),
+            self.z.signum(),
+            self.w.signum(),
+        )
     }
 
     /// Returns a bitmask with the lowest 4 bits set to the sign bits from the elements of `self`.
@@ -1057,12 +1044,12 @@ impl Div for I8Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -1111,12 +1098,12 @@ impl Div<i8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -1165,12 +1152,12 @@ impl Div<I8Vec4> for i8 {
     type Output = I8Vec4;
     #[inline]
     fn div(self, rhs: I8Vec4) -> I8Vec4 {
-        I8Vec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        I8Vec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1202,12 +1189,12 @@ impl Mul for I8Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1256,12 +1243,12 @@ impl Mul<i8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1310,12 +1297,12 @@ impl Mul<I8Vec4> for i8 {
     type Output = I8Vec4;
     #[inline]
     fn mul(self, rhs: I8Vec4) -> I8Vec4 {
-        I8Vec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        I8Vec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1347,12 +1334,12 @@ impl Add for I8Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1401,12 +1388,12 @@ impl Add<i8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1455,12 +1442,12 @@ impl Add<I8Vec4> for i8 {
     type Output = I8Vec4;
     #[inline]
     fn add(self, rhs: I8Vec4) -> I8Vec4 {
-        I8Vec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        I8Vec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1492,12 +1479,12 @@ impl Sub for I8Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1546,12 +1533,12 @@ impl Sub<i8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1600,12 +1587,12 @@ impl Sub<I8Vec4> for i8 {
     type Output = I8Vec4;
     #[inline]
     fn sub(self, rhs: I8Vec4) -> I8Vec4 {
-        I8Vec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        I8Vec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1637,12 +1624,12 @@ impl Rem for I8Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1691,12 +1678,12 @@ impl Rem<i8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: i8) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -1745,12 +1732,12 @@ impl Rem<I8Vec4> for i8 {
     type Output = I8Vec4;
     #[inline]
     fn rem(self, rhs: I8Vec4) -> I8Vec4 {
-        I8Vec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        I8Vec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -1836,12 +1823,7 @@ impl Neg for I8Vec4 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-            w: self.w.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg(), self.w.neg())
     }
 }
 
@@ -1857,12 +1839,7 @@ impl Not for I8Vec4 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-            w: self.w.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not(), self.w.not())
     }
 }
 
@@ -1878,12 +1855,12 @@ impl BitAnd for I8Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-            w: self.w.bitand(rhs.w),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+            self.w.bitand(rhs.w),
+        )
     }
 }
 
@@ -1929,12 +1906,12 @@ impl BitOr for I8Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-            w: self.w.bitor(rhs.w),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+            self.w.bitor(rhs.w),
+        )
     }
 }
 
@@ -1980,12 +1957,12 @@ impl BitXor for I8Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-            w: self.w.bitxor(rhs.w),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+            self.w.bitxor(rhs.w),
+        )
     }
 }
 
@@ -2031,12 +2008,12 @@ impl BitAnd<i8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-            w: self.w.bitand(rhs),
-        }
+        Self::new(
+            self.x.bitand(rhs),
+            self.y.bitand(rhs),
+            self.z.bitand(rhs),
+            self.w.bitand(rhs),
+        )
     }
 }
 
@@ -2082,12 +2059,12 @@ impl BitOr<i8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-            w: self.w.bitor(rhs),
-        }
+        Self::new(
+            self.x.bitor(rhs),
+            self.y.bitor(rhs),
+            self.z.bitor(rhs),
+            self.w.bitor(rhs),
+        )
     }
 }
 
@@ -2133,12 +2110,12 @@ impl BitXor<i8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-            w: self.w.bitxor(rhs),
-        }
+        Self::new(
+            self.x.bitxor(rhs),
+            self.y.bitxor(rhs),
+            self.z.bitxor(rhs),
+            self.w.bitxor(rhs),
+        )
     }
 }
 
@@ -2184,12 +2161,12 @@ impl Shl<i8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2235,12 +2212,12 @@ impl Shr<i8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2286,12 +2263,12 @@ impl Shl<i16> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2337,12 +2314,12 @@ impl Shr<i16> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2388,12 +2365,12 @@ impl Shl<i32> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2439,12 +2416,12 @@ impl Shr<i32> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2490,12 +2467,12 @@ impl Shl<i64> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2541,12 +2518,12 @@ impl Shr<i64> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2592,12 +2569,12 @@ impl Shl<u8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2643,12 +2620,12 @@ impl Shr<u8> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2694,12 +2671,12 @@ impl Shl<u16> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2745,12 +2722,12 @@ impl Shr<u16> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2796,12 +2773,12 @@ impl Shl<u32> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2847,12 +2824,12 @@ impl Shr<u32> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2898,12 +2875,12 @@ impl Shl<u64> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2949,12 +2926,12 @@ impl Shr<u64> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -3001,12 +2978,12 @@ impl Shl<IVec4> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -3042,12 +3019,12 @@ impl Shr<IVec4> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 
@@ -3083,12 +3060,12 @@ impl Shl<UVec4> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -3124,12 +3101,12 @@ impl Shr<UVec4> for I8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 

--- a/src/isize/isizevec2.rs
+++ b/src/isize/isizevec2.rs
@@ -100,7 +100,7 @@ impl ISizeVec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: isize) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -121,10 +121,10 @@ impl ISizeVec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -206,10 +206,10 @@ impl ISizeVec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -218,10 +218,10 @@ impl ISizeVec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`isize::clamp`].
@@ -370,10 +370,7 @@ impl ISizeVec2 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -384,10 +381,7 @@ impl ISizeVec2 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-        }
+        Self::new(self.x.signum(), self.y.signum())
     }
 
     /// Returns a bitmask with the lowest 2 bits set to the sign bits from the elements of `self`.
@@ -493,10 +487,7 @@ impl ISizeVec2 {
     #[inline]
     #[must_use]
     pub fn perp(self) -> Self {
-        Self {
-            x: -self.y,
-            y: self.x,
-        }
+        Self::new(-self.y, self.x)
     }
 
     /// The perpendicular dot product of `self` and `rhs`.
@@ -519,10 +510,10 @@ impl ISizeVec2 {
     #[inline]
     #[must_use]
     pub fn rotate(self, rhs: Self) -> Self {
-        Self {
-            x: self.x * rhs.x - self.y * rhs.y,
-            y: self.y * rhs.x + self.x * rhs.y,
-        }
+        Self::new(
+            self.x * rhs.x - self.y * rhs.y,
+            self.y * rhs.x + self.x * rhs.y,
+        )
     }
 
     /// Casts all elements of `self` to `f32`.
@@ -882,10 +873,7 @@ impl Div for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -932,10 +920,7 @@ impl Div<isize> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -982,10 +967,7 @@ impl Div<ISizeVec2> for isize {
     type Output = ISizeVec2;
     #[inline]
     fn div(self, rhs: ISizeVec2) -> ISizeVec2 {
-        ISizeVec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        ISizeVec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -1017,10 +999,7 @@ impl Mul for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -1067,10 +1046,7 @@ impl Mul<isize> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -1117,10 +1093,7 @@ impl Mul<ISizeVec2> for isize {
     type Output = ISizeVec2;
     #[inline]
     fn mul(self, rhs: ISizeVec2) -> ISizeVec2 {
-        ISizeVec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        ISizeVec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -1152,10 +1125,7 @@ impl Add for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1202,10 +1172,7 @@ impl Add<isize> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1252,10 +1219,7 @@ impl Add<ISizeVec2> for isize {
     type Output = ISizeVec2;
     #[inline]
     fn add(self, rhs: ISizeVec2) -> ISizeVec2 {
-        ISizeVec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        ISizeVec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1287,10 +1251,7 @@ impl Sub for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1337,10 +1298,7 @@ impl Sub<isize> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1387,10 +1345,7 @@ impl Sub<ISizeVec2> for isize {
     type Output = ISizeVec2;
     #[inline]
     fn sub(self, rhs: ISizeVec2) -> ISizeVec2 {
-        ISizeVec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        ISizeVec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1422,10 +1377,7 @@ impl Rem for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1472,10 +1424,7 @@ impl Rem<isize> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1522,10 +1471,7 @@ impl Rem<ISizeVec2> for isize {
     type Output = ISizeVec2;
     #[inline]
     fn rem(self, rhs: ISizeVec2) -> ISizeVec2 {
-        ISizeVec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        ISizeVec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1611,10 +1557,7 @@ impl Neg for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg())
     }
 }
 
@@ -1630,10 +1573,7 @@ impl Not for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-        }
+        Self::new(self.x.not(), self.y.not())
     }
 }
 
@@ -1649,10 +1589,7 @@ impl BitAnd for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-        }
+        Self::new(self.x.bitand(rhs.x), self.y.bitand(rhs.y))
     }
 }
 
@@ -1698,10 +1635,7 @@ impl BitOr for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-        }
+        Self::new(self.x.bitor(rhs.x), self.y.bitor(rhs.y))
     }
 }
 
@@ -1747,10 +1681,7 @@ impl BitXor for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-        }
+        Self::new(self.x.bitxor(rhs.x), self.y.bitxor(rhs.y))
     }
 }
 
@@ -1796,10 +1727,7 @@ impl BitAnd<isize> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: isize) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs))
     }
 }
 
@@ -1845,10 +1773,7 @@ impl BitOr<isize> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: isize) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs))
     }
 }
 
@@ -1894,10 +1819,7 @@ impl BitXor<isize> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: isize) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs))
     }
 }
 
@@ -1943,10 +1865,7 @@ impl Shl<i8> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1992,10 +1911,7 @@ impl Shr<i8> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2041,10 +1957,7 @@ impl Shl<i16> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2090,10 +2003,7 @@ impl Shr<i16> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2139,10 +2049,7 @@ impl Shl<i32> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2188,10 +2095,7 @@ impl Shr<i32> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2237,10 +2141,7 @@ impl Shl<i64> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2286,10 +2187,7 @@ impl Shr<i64> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2335,10 +2233,7 @@ impl Shl<u8> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2384,10 +2279,7 @@ impl Shr<u8> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2433,10 +2325,7 @@ impl Shl<u16> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2482,10 +2371,7 @@ impl Shr<u16> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2531,10 +2417,7 @@ impl Shl<u32> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2580,10 +2463,7 @@ impl Shr<u32> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2629,10 +2509,7 @@ impl Shl<u64> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2678,10 +2555,7 @@ impl Shr<u64> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2728,10 +2602,7 @@ impl Shl<IVec2> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2767,10 +2638,7 @@ impl Shr<IVec2> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 
@@ -2806,10 +2674,7 @@ impl Shl<UVec2> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2845,10 +2710,7 @@ impl Shr<UVec2> for ISizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 

--- a/src/isize/isizevec3.rs
+++ b/src/isize/isizevec3.rs
@@ -106,7 +106,7 @@ impl ISizeVec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: isize) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -127,11 +127,11 @@ impl ISizeVec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -175,11 +175,7 @@ impl ISizeVec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: ISizeVec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -241,11 +237,11 @@ impl ISizeVec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -254,11 +250,11 @@ impl ISizeVec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -267,11 +263,11 @@ impl ISizeVec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`isize::clamp`].
@@ -430,11 +426,7 @@ impl ISizeVec3 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-            z: self.z.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs(), self.z.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -445,11 +437,7 @@ impl ISizeVec3 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-            z: self.z.signum(),
-        }
+        Self::new(self.x.signum(), self.y.signum(), self.z.signum())
     }
 
     /// Returns a bitmask with the lowest 3 bits set to the sign bits from the elements of `self`.
@@ -970,11 +958,7 @@ impl Div for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -1022,11 +1006,7 @@ impl Div<isize> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -1074,11 +1054,7 @@ impl Div<ISizeVec3> for isize {
     type Output = ISizeVec3;
     #[inline]
     fn div(self, rhs: ISizeVec3) -> ISizeVec3 {
-        ISizeVec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        ISizeVec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -1110,11 +1086,7 @@ impl Mul for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1162,11 +1134,7 @@ impl Mul<isize> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1214,11 +1182,7 @@ impl Mul<ISizeVec3> for isize {
     type Output = ISizeVec3;
     #[inline]
     fn mul(self, rhs: ISizeVec3) -> ISizeVec3 {
-        ISizeVec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        ISizeVec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1250,11 +1214,7 @@ impl Add for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1302,11 +1262,7 @@ impl Add<isize> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1354,11 +1310,7 @@ impl Add<ISizeVec3> for isize {
     type Output = ISizeVec3;
     #[inline]
     fn add(self, rhs: ISizeVec3) -> ISizeVec3 {
-        ISizeVec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        ISizeVec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1390,11 +1342,7 @@ impl Sub for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1442,11 +1390,7 @@ impl Sub<isize> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1494,11 +1438,7 @@ impl Sub<ISizeVec3> for isize {
     type Output = ISizeVec3;
     #[inline]
     fn sub(self, rhs: ISizeVec3) -> ISizeVec3 {
-        ISizeVec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        ISizeVec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -1530,11 +1470,7 @@ impl Rem for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -1582,11 +1518,7 @@ impl Rem<isize> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -1634,11 +1566,7 @@ impl Rem<ISizeVec3> for isize {
     type Output = ISizeVec3;
     #[inline]
     fn rem(self, rhs: ISizeVec3) -> ISizeVec3 {
-        ISizeVec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        ISizeVec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -1724,11 +1652,7 @@ impl Neg for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg())
     }
 }
 
@@ -1744,11 +1668,7 @@ impl Not for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not())
     }
 }
 
@@ -1764,11 +1684,11 @@ impl BitAnd for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+        )
     }
 }
 
@@ -1814,11 +1734,11 @@ impl BitOr for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+        )
     }
 }
 
@@ -1864,11 +1784,11 @@ impl BitXor for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+        )
     }
 }
 
@@ -1914,11 +1834,7 @@ impl BitAnd<isize> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: isize) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs), self.z.bitand(rhs))
     }
 }
 
@@ -1964,11 +1880,7 @@ impl BitOr<isize> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: isize) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs), self.z.bitor(rhs))
     }
 }
 
@@ -2014,11 +1926,7 @@ impl BitXor<isize> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: isize) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs), self.z.bitxor(rhs))
     }
 }
 
@@ -2064,11 +1972,7 @@ impl Shl<i8> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2114,11 +2018,7 @@ impl Shr<i8> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2164,11 +2064,7 @@ impl Shl<i16> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2214,11 +2110,7 @@ impl Shr<i16> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2264,11 +2156,7 @@ impl Shl<i32> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2314,11 +2202,7 @@ impl Shr<i32> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2364,11 +2248,7 @@ impl Shl<i64> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2414,11 +2294,7 @@ impl Shr<i64> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2464,11 +2340,7 @@ impl Shl<u8> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2514,11 +2386,7 @@ impl Shr<u8> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2564,11 +2432,7 @@ impl Shl<u16> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2614,11 +2478,7 @@ impl Shr<u16> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2664,11 +2524,7 @@ impl Shl<u32> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2714,11 +2570,7 @@ impl Shr<u32> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2764,11 +2616,7 @@ impl Shl<u64> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2814,11 +2662,7 @@ impl Shr<u64> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2865,11 +2709,7 @@ impl Shl<IVec3> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2905,11 +2745,7 @@ impl Shr<IVec3> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 
@@ -2945,11 +2781,7 @@ impl Shl<UVec3> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2985,11 +2817,7 @@ impl Shr<UVec3> for ISizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 

--- a/src/isize/isizevec4.rs
+++ b/src/isize/isizevec4.rs
@@ -116,15 +116,7 @@ impl ISizeVec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: isize) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -145,12 +137,12 @@ impl ISizeVec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -251,12 +243,12 @@ impl ISizeVec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -265,12 +257,12 @@ impl ISizeVec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`isize::clamp`].
@@ -467,12 +459,7 @@ impl ISizeVec4 {
     #[inline]
     #[must_use]
     pub fn abs(self) -> Self {
-        Self {
-            x: self.x.abs(),
-            y: self.y.abs(),
-            z: self.z.abs(),
-            w: self.w.abs(),
-        }
+        Self::new(self.x.abs(), self.y.abs(), self.z.abs(), self.w.abs())
     }
 
     /// Returns a vector with elements representing the sign of `self`.
@@ -483,12 +470,12 @@ impl ISizeVec4 {
     #[inline]
     #[must_use]
     pub fn signum(self) -> Self {
-        Self {
-            x: self.x.signum(),
-            y: self.y.signum(),
-            z: self.z.signum(),
-            w: self.w.signum(),
-        }
+        Self::new(
+            self.x.signum(),
+            self.y.signum(),
+            self.z.signum(),
+            self.w.signum(),
+        )
     }
 
     /// Returns a bitmask with the lowest 4 bits set to the sign bits from the elements of `self`.
@@ -1052,12 +1039,12 @@ impl Div for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -1106,12 +1093,12 @@ impl Div<isize> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -1160,12 +1147,12 @@ impl Div<ISizeVec4> for isize {
     type Output = ISizeVec4;
     #[inline]
     fn div(self, rhs: ISizeVec4) -> ISizeVec4 {
-        ISizeVec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        ISizeVec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1197,12 +1184,12 @@ impl Mul for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1251,12 +1238,12 @@ impl Mul<isize> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1305,12 +1292,12 @@ impl Mul<ISizeVec4> for isize {
     type Output = ISizeVec4;
     #[inline]
     fn mul(self, rhs: ISizeVec4) -> ISizeVec4 {
-        ISizeVec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        ISizeVec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1342,12 +1329,12 @@ impl Add for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1396,12 +1383,12 @@ impl Add<isize> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1450,12 +1437,12 @@ impl Add<ISizeVec4> for isize {
     type Output = ISizeVec4;
     #[inline]
     fn add(self, rhs: ISizeVec4) -> ISizeVec4 {
-        ISizeVec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        ISizeVec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1487,12 +1474,12 @@ impl Sub for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1541,12 +1528,12 @@ impl Sub<isize> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1595,12 +1582,12 @@ impl Sub<ISizeVec4> for isize {
     type Output = ISizeVec4;
     #[inline]
     fn sub(self, rhs: ISizeVec4) -> ISizeVec4 {
-        ISizeVec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        ISizeVec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1632,12 +1619,12 @@ impl Rem for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1686,12 +1673,12 @@ impl Rem<isize> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: isize) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -1740,12 +1727,12 @@ impl Rem<ISizeVec4> for isize {
     type Output = ISizeVec4;
     #[inline]
     fn rem(self, rhs: ISizeVec4) -> ISizeVec4 {
-        ISizeVec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        ISizeVec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -1831,12 +1818,7 @@ impl Neg for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn neg(self) -> Self {
-        Self {
-            x: self.x.neg(),
-            y: self.y.neg(),
-            z: self.z.neg(),
-            w: self.w.neg(),
-        }
+        Self::new(self.x.neg(), self.y.neg(), self.z.neg(), self.w.neg())
     }
 }
 
@@ -1852,12 +1834,7 @@ impl Not for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-            w: self.w.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not(), self.w.not())
     }
 }
 
@@ -1873,12 +1850,12 @@ impl BitAnd for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-            w: self.w.bitand(rhs.w),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+            self.w.bitand(rhs.w),
+        )
     }
 }
 
@@ -1924,12 +1901,12 @@ impl BitOr for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-            w: self.w.bitor(rhs.w),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+            self.w.bitor(rhs.w),
+        )
     }
 }
 
@@ -1975,12 +1952,12 @@ impl BitXor for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-            w: self.w.bitxor(rhs.w),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+            self.w.bitxor(rhs.w),
+        )
     }
 }
 
@@ -2026,12 +2003,12 @@ impl BitAnd<isize> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: isize) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-            w: self.w.bitand(rhs),
-        }
+        Self::new(
+            self.x.bitand(rhs),
+            self.y.bitand(rhs),
+            self.z.bitand(rhs),
+            self.w.bitand(rhs),
+        )
     }
 }
 
@@ -2077,12 +2054,12 @@ impl BitOr<isize> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: isize) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-            w: self.w.bitor(rhs),
-        }
+        Self::new(
+            self.x.bitor(rhs),
+            self.y.bitor(rhs),
+            self.z.bitor(rhs),
+            self.w.bitor(rhs),
+        )
     }
 }
 
@@ -2128,12 +2105,12 @@ impl BitXor<isize> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: isize) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-            w: self.w.bitxor(rhs),
-        }
+        Self::new(
+            self.x.bitxor(rhs),
+            self.y.bitxor(rhs),
+            self.z.bitxor(rhs),
+            self.w.bitxor(rhs),
+        )
     }
 }
 
@@ -2179,12 +2156,12 @@ impl Shl<i8> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2230,12 +2207,12 @@ impl Shr<i8> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2281,12 +2258,12 @@ impl Shl<i16> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2332,12 +2309,12 @@ impl Shr<i16> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2383,12 +2360,12 @@ impl Shl<i32> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2434,12 +2411,12 @@ impl Shr<i32> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2485,12 +2462,12 @@ impl Shl<i64> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2536,12 +2513,12 @@ impl Shr<i64> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2587,12 +2564,12 @@ impl Shl<u8> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2638,12 +2615,12 @@ impl Shr<u8> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2689,12 +2666,12 @@ impl Shl<u16> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2740,12 +2717,12 @@ impl Shr<u16> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2791,12 +2768,12 @@ impl Shl<u32> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2842,12 +2819,12 @@ impl Shr<u32> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2893,12 +2870,12 @@ impl Shl<u64> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2944,12 +2921,12 @@ impl Shr<u64> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2996,12 +2973,12 @@ impl Shl<IVec4> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -3037,12 +3014,12 @@ impl Shr<IVec4> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 
@@ -3078,12 +3055,12 @@ impl Shl<UVec4> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -3119,12 +3096,12 @@ impl Shr<UVec4> for ISizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -91,7 +91,7 @@ impl U16Vec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u16) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -112,10 +112,10 @@ impl U16Vec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -197,10 +197,10 @@ impl U16Vec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -209,10 +209,10 @@ impl U16Vec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u16::clamp`].
@@ -716,10 +716,7 @@ impl Div for U16Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -766,10 +763,7 @@ impl Div<u16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -816,10 +810,7 @@ impl Div<U16Vec2> for u16 {
     type Output = U16Vec2;
     #[inline]
     fn div(self, rhs: U16Vec2) -> U16Vec2 {
-        U16Vec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        U16Vec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -851,10 +842,7 @@ impl Mul for U16Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -901,10 +889,7 @@ impl Mul<u16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -951,10 +936,7 @@ impl Mul<U16Vec2> for u16 {
     type Output = U16Vec2;
     #[inline]
     fn mul(self, rhs: U16Vec2) -> U16Vec2 {
-        U16Vec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        U16Vec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -986,10 +968,7 @@ impl Add for U16Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1036,10 +1015,7 @@ impl Add<u16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1086,10 +1062,7 @@ impl Add<U16Vec2> for u16 {
     type Output = U16Vec2;
     #[inline]
     fn add(self, rhs: U16Vec2) -> U16Vec2 {
-        U16Vec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        U16Vec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1121,10 +1094,7 @@ impl Sub for U16Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1171,10 +1141,7 @@ impl Sub<u16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1221,10 +1188,7 @@ impl Sub<U16Vec2> for u16 {
     type Output = U16Vec2;
     #[inline]
     fn sub(self, rhs: U16Vec2) -> U16Vec2 {
-        U16Vec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        U16Vec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1256,10 +1220,7 @@ impl Rem for U16Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1306,10 +1267,7 @@ impl Rem<u16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1356,10 +1314,7 @@ impl Rem<U16Vec2> for u16 {
     type Output = U16Vec2;
     #[inline]
     fn rem(self, rhs: U16Vec2) -> U16Vec2 {
-        U16Vec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        U16Vec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1445,10 +1400,7 @@ impl Not for U16Vec2 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-        }
+        Self::new(self.x.not(), self.y.not())
     }
 }
 
@@ -1464,10 +1416,7 @@ impl BitAnd for U16Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-        }
+        Self::new(self.x.bitand(rhs.x), self.y.bitand(rhs.y))
     }
 }
 
@@ -1513,10 +1462,7 @@ impl BitOr for U16Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-        }
+        Self::new(self.x.bitor(rhs.x), self.y.bitor(rhs.y))
     }
 }
 
@@ -1562,10 +1508,7 @@ impl BitXor for U16Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-        }
+        Self::new(self.x.bitxor(rhs.x), self.y.bitxor(rhs.y))
     }
 }
 
@@ -1611,10 +1554,7 @@ impl BitAnd<u16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs))
     }
 }
 
@@ -1660,10 +1600,7 @@ impl BitOr<u16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs))
     }
 }
 
@@ -1709,10 +1646,7 @@ impl BitXor<u16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs))
     }
 }
 
@@ -1758,10 +1692,7 @@ impl Shl<i8> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1807,10 +1738,7 @@ impl Shr<i8> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -1856,10 +1784,7 @@ impl Shl<i16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1905,10 +1830,7 @@ impl Shr<i16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -1954,10 +1876,7 @@ impl Shl<i32> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2003,10 +1922,7 @@ impl Shr<i32> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2052,10 +1968,7 @@ impl Shl<i64> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2101,10 +2014,7 @@ impl Shr<i64> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2150,10 +2060,7 @@ impl Shl<u8> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2199,10 +2106,7 @@ impl Shr<u8> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2248,10 +2152,7 @@ impl Shl<u16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2297,10 +2198,7 @@ impl Shr<u16> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2346,10 +2244,7 @@ impl Shl<u32> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2395,10 +2290,7 @@ impl Shr<u32> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2444,10 +2336,7 @@ impl Shl<u64> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2493,10 +2382,7 @@ impl Shr<u64> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2543,10 +2429,7 @@ impl Shl<IVec2> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2582,10 +2465,7 @@ impl Shr<IVec2> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 
@@ -2621,10 +2501,7 @@ impl Shl<UVec2> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2660,10 +2537,7 @@ impl Shr<UVec2> for U16Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -94,7 +94,7 @@ impl U16Vec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u16) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -115,11 +115,11 @@ impl U16Vec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -163,11 +163,7 @@ impl U16Vec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: U16Vec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -229,11 +225,11 @@ impl U16Vec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -242,11 +238,11 @@ impl U16Vec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -255,11 +251,11 @@ impl U16Vec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u16::clamp`].
@@ -815,11 +811,7 @@ impl Div for U16Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -867,11 +859,7 @@ impl Div<u16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -919,11 +907,7 @@ impl Div<U16Vec3> for u16 {
     type Output = U16Vec3;
     #[inline]
     fn div(self, rhs: U16Vec3) -> U16Vec3 {
-        U16Vec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        U16Vec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -955,11 +939,7 @@ impl Mul for U16Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1007,11 +987,7 @@ impl Mul<u16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1059,11 +1035,7 @@ impl Mul<U16Vec3> for u16 {
     type Output = U16Vec3;
     #[inline]
     fn mul(self, rhs: U16Vec3) -> U16Vec3 {
-        U16Vec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        U16Vec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1095,11 +1067,7 @@ impl Add for U16Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1147,11 +1115,7 @@ impl Add<u16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1199,11 +1163,7 @@ impl Add<U16Vec3> for u16 {
     type Output = U16Vec3;
     #[inline]
     fn add(self, rhs: U16Vec3) -> U16Vec3 {
-        U16Vec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        U16Vec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1235,11 +1195,7 @@ impl Sub for U16Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1287,11 +1243,7 @@ impl Sub<u16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1339,11 +1291,7 @@ impl Sub<U16Vec3> for u16 {
     type Output = U16Vec3;
     #[inline]
     fn sub(self, rhs: U16Vec3) -> U16Vec3 {
-        U16Vec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        U16Vec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -1375,11 +1323,7 @@ impl Rem for U16Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -1427,11 +1371,7 @@ impl Rem<u16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -1479,11 +1419,7 @@ impl Rem<U16Vec3> for u16 {
     type Output = U16Vec3;
     #[inline]
     fn rem(self, rhs: U16Vec3) -> U16Vec3 {
-        U16Vec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        U16Vec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -1569,11 +1505,7 @@ impl Not for U16Vec3 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not())
     }
 }
 
@@ -1589,11 +1521,11 @@ impl BitAnd for U16Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+        )
     }
 }
 
@@ -1639,11 +1571,11 @@ impl BitOr for U16Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+        )
     }
 }
 
@@ -1689,11 +1621,11 @@ impl BitXor for U16Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+        )
     }
 }
 
@@ -1739,11 +1671,7 @@ impl BitAnd<u16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs), self.z.bitand(rhs))
     }
 }
 
@@ -1789,11 +1717,7 @@ impl BitOr<u16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs), self.z.bitor(rhs))
     }
 }
 
@@ -1839,11 +1763,7 @@ impl BitXor<u16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs), self.z.bitxor(rhs))
     }
 }
 
@@ -1889,11 +1809,7 @@ impl Shl<i8> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -1939,11 +1855,7 @@ impl Shr<i8> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -1989,11 +1901,7 @@ impl Shl<i16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2039,11 +1947,7 @@ impl Shr<i16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2089,11 +1993,7 @@ impl Shl<i32> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2139,11 +2039,7 @@ impl Shr<i32> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2189,11 +2085,7 @@ impl Shl<i64> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2239,11 +2131,7 @@ impl Shr<i64> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2289,11 +2177,7 @@ impl Shl<u8> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2339,11 +2223,7 @@ impl Shr<u8> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2389,11 +2269,7 @@ impl Shl<u16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2439,11 +2315,7 @@ impl Shr<u16> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2489,11 +2361,7 @@ impl Shl<u32> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2539,11 +2407,7 @@ impl Shr<u32> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2589,11 +2453,7 @@ impl Shl<u64> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2639,11 +2499,7 @@ impl Shr<u64> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2690,11 +2546,7 @@ impl Shl<IVec3> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2730,11 +2582,7 @@ impl Shr<IVec3> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 
@@ -2770,11 +2618,7 @@ impl Shl<UVec3> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2810,11 +2654,7 @@ impl Shr<UVec3> for U16Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -101,15 +101,7 @@ impl U16Vec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u16) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -130,12 +122,12 @@ impl U16Vec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -236,12 +228,12 @@ impl U16Vec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -250,12 +242,12 @@ impl U16Vec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u16::clamp`].
@@ -887,12 +879,12 @@ impl Div for U16Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -941,12 +933,12 @@ impl Div<u16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -995,12 +987,12 @@ impl Div<U16Vec4> for u16 {
     type Output = U16Vec4;
     #[inline]
     fn div(self, rhs: U16Vec4) -> U16Vec4 {
-        U16Vec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        U16Vec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1032,12 +1024,12 @@ impl Mul for U16Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1086,12 +1078,12 @@ impl Mul<u16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1140,12 +1132,12 @@ impl Mul<U16Vec4> for u16 {
     type Output = U16Vec4;
     #[inline]
     fn mul(self, rhs: U16Vec4) -> U16Vec4 {
-        U16Vec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        U16Vec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1177,12 +1169,12 @@ impl Add for U16Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1231,12 +1223,12 @@ impl Add<u16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1285,12 +1277,12 @@ impl Add<U16Vec4> for u16 {
     type Output = U16Vec4;
     #[inline]
     fn add(self, rhs: U16Vec4) -> U16Vec4 {
-        U16Vec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        U16Vec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1322,12 +1314,12 @@ impl Sub for U16Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1376,12 +1368,12 @@ impl Sub<u16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1430,12 +1422,12 @@ impl Sub<U16Vec4> for u16 {
     type Output = U16Vec4;
     #[inline]
     fn sub(self, rhs: U16Vec4) -> U16Vec4 {
-        U16Vec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        U16Vec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1467,12 +1459,12 @@ impl Rem for U16Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1521,12 +1513,12 @@ impl Rem<u16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u16) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -1575,12 +1567,12 @@ impl Rem<U16Vec4> for u16 {
     type Output = U16Vec4;
     #[inline]
     fn rem(self, rhs: U16Vec4) -> U16Vec4 {
-        U16Vec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        U16Vec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -1666,12 +1658,7 @@ impl Not for U16Vec4 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-            w: self.w.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not(), self.w.not())
     }
 }
 
@@ -1687,12 +1674,12 @@ impl BitAnd for U16Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-            w: self.w.bitand(rhs.w),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+            self.w.bitand(rhs.w),
+        )
     }
 }
 
@@ -1738,12 +1725,12 @@ impl BitOr for U16Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-            w: self.w.bitor(rhs.w),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+            self.w.bitor(rhs.w),
+        )
     }
 }
 
@@ -1789,12 +1776,12 @@ impl BitXor for U16Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-            w: self.w.bitxor(rhs.w),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+            self.w.bitxor(rhs.w),
+        )
     }
 }
 
@@ -1840,12 +1827,12 @@ impl BitAnd<u16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-            w: self.w.bitand(rhs),
-        }
+        Self::new(
+            self.x.bitand(rhs),
+            self.y.bitand(rhs),
+            self.z.bitand(rhs),
+            self.w.bitand(rhs),
+        )
     }
 }
 
@@ -1891,12 +1878,12 @@ impl BitOr<u16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-            w: self.w.bitor(rhs),
-        }
+        Self::new(
+            self.x.bitor(rhs),
+            self.y.bitor(rhs),
+            self.z.bitor(rhs),
+            self.w.bitor(rhs),
+        )
     }
 }
 
@@ -1942,12 +1929,12 @@ impl BitXor<u16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-            w: self.w.bitxor(rhs),
-        }
+        Self::new(
+            self.x.bitxor(rhs),
+            self.y.bitxor(rhs),
+            self.z.bitxor(rhs),
+            self.w.bitxor(rhs),
+        )
     }
 }
 
@@ -1993,12 +1980,12 @@ impl Shl<i8> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2044,12 +2031,12 @@ impl Shr<i8> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2095,12 +2082,12 @@ impl Shl<i16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2146,12 +2133,12 @@ impl Shr<i16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2197,12 +2184,12 @@ impl Shl<i32> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2248,12 +2235,12 @@ impl Shr<i32> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2299,12 +2286,12 @@ impl Shl<i64> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2350,12 +2337,12 @@ impl Shr<i64> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2401,12 +2388,12 @@ impl Shl<u8> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2452,12 +2439,12 @@ impl Shr<u8> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2503,12 +2490,12 @@ impl Shl<u16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2554,12 +2541,12 @@ impl Shr<u16> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2605,12 +2592,12 @@ impl Shl<u32> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2656,12 +2643,12 @@ impl Shr<u32> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2707,12 +2694,12 @@ impl Shl<u64> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2758,12 +2745,12 @@ impl Shr<u64> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2810,12 +2797,12 @@ impl Shl<IVec4> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -2851,12 +2838,12 @@ impl Shr<IVec4> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 
@@ -2892,12 +2879,12 @@ impl Shl<UVec4> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -2933,12 +2920,12 @@ impl Shr<UVec4> for U16Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -91,7 +91,7 @@ impl UVec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u32) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -112,10 +112,10 @@ impl UVec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -197,10 +197,10 @@ impl UVec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -209,10 +209,10 @@ impl UVec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u32::clamp`].
@@ -716,10 +716,7 @@ impl Div for UVec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -766,10 +763,7 @@ impl Div<u32> for UVec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -816,10 +810,7 @@ impl Div<UVec2> for u32 {
     type Output = UVec2;
     #[inline]
     fn div(self, rhs: UVec2) -> UVec2 {
-        UVec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        UVec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -851,10 +842,7 @@ impl Mul for UVec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -901,10 +889,7 @@ impl Mul<u32> for UVec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -951,10 +936,7 @@ impl Mul<UVec2> for u32 {
     type Output = UVec2;
     #[inline]
     fn mul(self, rhs: UVec2) -> UVec2 {
-        UVec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        UVec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -986,10 +968,7 @@ impl Add for UVec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1036,10 +1015,7 @@ impl Add<u32> for UVec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1086,10 +1062,7 @@ impl Add<UVec2> for u32 {
     type Output = UVec2;
     #[inline]
     fn add(self, rhs: UVec2) -> UVec2 {
-        UVec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        UVec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1121,10 +1094,7 @@ impl Sub for UVec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1171,10 +1141,7 @@ impl Sub<u32> for UVec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1221,10 +1188,7 @@ impl Sub<UVec2> for u32 {
     type Output = UVec2;
     #[inline]
     fn sub(self, rhs: UVec2) -> UVec2 {
-        UVec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        UVec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1256,10 +1220,7 @@ impl Rem for UVec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1306,10 +1267,7 @@ impl Rem<u32> for UVec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1356,10 +1314,7 @@ impl Rem<UVec2> for u32 {
     type Output = UVec2;
     #[inline]
     fn rem(self, rhs: UVec2) -> UVec2 {
-        UVec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        UVec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1445,10 +1400,7 @@ impl Not for UVec2 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-        }
+        Self::new(self.x.not(), self.y.not())
     }
 }
 
@@ -1464,10 +1416,7 @@ impl BitAnd for UVec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-        }
+        Self::new(self.x.bitand(rhs.x), self.y.bitand(rhs.y))
     }
 }
 
@@ -1513,10 +1462,7 @@ impl BitOr for UVec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-        }
+        Self::new(self.x.bitor(rhs.x), self.y.bitor(rhs.y))
     }
 }
 
@@ -1562,10 +1508,7 @@ impl BitXor for UVec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-        }
+        Self::new(self.x.bitxor(rhs.x), self.y.bitxor(rhs.y))
     }
 }
 
@@ -1611,10 +1554,7 @@ impl BitAnd<u32> for UVec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs))
     }
 }
 
@@ -1660,10 +1600,7 @@ impl BitOr<u32> for UVec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs))
     }
 }
 
@@ -1709,10 +1646,7 @@ impl BitXor<u32> for UVec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs))
     }
 }
 
@@ -1758,10 +1692,7 @@ impl Shl<i8> for UVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1807,10 +1738,7 @@ impl Shr<i8> for UVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -1856,10 +1784,7 @@ impl Shl<i16> for UVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1905,10 +1830,7 @@ impl Shr<i16> for UVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -1954,10 +1876,7 @@ impl Shl<i32> for UVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2003,10 +1922,7 @@ impl Shr<i32> for UVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2052,10 +1968,7 @@ impl Shl<i64> for UVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2101,10 +2014,7 @@ impl Shr<i64> for UVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2150,10 +2060,7 @@ impl Shl<u8> for UVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2199,10 +2106,7 @@ impl Shr<u8> for UVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2248,10 +2152,7 @@ impl Shl<u16> for UVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2297,10 +2198,7 @@ impl Shr<u16> for UVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2346,10 +2244,7 @@ impl Shl<u32> for UVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2395,10 +2290,7 @@ impl Shr<u32> for UVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2444,10 +2336,7 @@ impl Shl<u64> for UVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2493,10 +2382,7 @@ impl Shr<u64> for UVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2543,10 +2429,7 @@ impl Shl<IVec2> for UVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2582,10 +2465,7 @@ impl Shr<IVec2> for UVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 
@@ -2620,10 +2500,7 @@ impl Shl for UVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2655,10 +2532,7 @@ impl Shr for UVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -94,7 +94,7 @@ impl UVec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u32) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -115,11 +115,11 @@ impl UVec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -163,11 +163,7 @@ impl UVec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: UVec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -229,11 +225,11 @@ impl UVec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -242,11 +238,11 @@ impl UVec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -255,11 +251,11 @@ impl UVec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u32::clamp`].
@@ -815,11 +811,7 @@ impl Div for UVec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -867,11 +859,7 @@ impl Div<u32> for UVec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -919,11 +907,7 @@ impl Div<UVec3> for u32 {
     type Output = UVec3;
     #[inline]
     fn div(self, rhs: UVec3) -> UVec3 {
-        UVec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        UVec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -955,11 +939,7 @@ impl Mul for UVec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1007,11 +987,7 @@ impl Mul<u32> for UVec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1059,11 +1035,7 @@ impl Mul<UVec3> for u32 {
     type Output = UVec3;
     #[inline]
     fn mul(self, rhs: UVec3) -> UVec3 {
-        UVec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        UVec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1095,11 +1067,7 @@ impl Add for UVec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1147,11 +1115,7 @@ impl Add<u32> for UVec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1199,11 +1163,7 @@ impl Add<UVec3> for u32 {
     type Output = UVec3;
     #[inline]
     fn add(self, rhs: UVec3) -> UVec3 {
-        UVec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        UVec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1235,11 +1195,7 @@ impl Sub for UVec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1287,11 +1243,7 @@ impl Sub<u32> for UVec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1339,11 +1291,7 @@ impl Sub<UVec3> for u32 {
     type Output = UVec3;
     #[inline]
     fn sub(self, rhs: UVec3) -> UVec3 {
-        UVec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        UVec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -1375,11 +1323,7 @@ impl Rem for UVec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -1427,11 +1371,7 @@ impl Rem<u32> for UVec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -1479,11 +1419,7 @@ impl Rem<UVec3> for u32 {
     type Output = UVec3;
     #[inline]
     fn rem(self, rhs: UVec3) -> UVec3 {
-        UVec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        UVec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -1569,11 +1505,7 @@ impl Not for UVec3 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not())
     }
 }
 
@@ -1589,11 +1521,11 @@ impl BitAnd for UVec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+        )
     }
 }
 
@@ -1639,11 +1571,11 @@ impl BitOr for UVec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+        )
     }
 }
 
@@ -1689,11 +1621,11 @@ impl BitXor for UVec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+        )
     }
 }
 
@@ -1739,11 +1671,7 @@ impl BitAnd<u32> for UVec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs), self.z.bitand(rhs))
     }
 }
 
@@ -1789,11 +1717,7 @@ impl BitOr<u32> for UVec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs), self.z.bitor(rhs))
     }
 }
 
@@ -1839,11 +1763,7 @@ impl BitXor<u32> for UVec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs), self.z.bitxor(rhs))
     }
 }
 
@@ -1889,11 +1809,7 @@ impl Shl<i8> for UVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -1939,11 +1855,7 @@ impl Shr<i8> for UVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -1989,11 +1901,7 @@ impl Shl<i16> for UVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2039,11 +1947,7 @@ impl Shr<i16> for UVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2089,11 +1993,7 @@ impl Shl<i32> for UVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2139,11 +2039,7 @@ impl Shr<i32> for UVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2189,11 +2085,7 @@ impl Shl<i64> for UVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2239,11 +2131,7 @@ impl Shr<i64> for UVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2289,11 +2177,7 @@ impl Shl<u8> for UVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2339,11 +2223,7 @@ impl Shr<u8> for UVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2389,11 +2269,7 @@ impl Shl<u16> for UVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2439,11 +2315,7 @@ impl Shr<u16> for UVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2489,11 +2361,7 @@ impl Shl<u32> for UVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2539,11 +2407,7 @@ impl Shr<u32> for UVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2589,11 +2453,7 @@ impl Shl<u64> for UVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2639,11 +2499,7 @@ impl Shr<u64> for UVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2690,11 +2546,7 @@ impl Shl<IVec3> for UVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2730,11 +2582,7 @@ impl Shr<IVec3> for UVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 
@@ -2769,11 +2617,7 @@ impl Shl for UVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2805,11 +2649,7 @@ impl Shr for UVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -101,15 +101,7 @@ impl UVec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u32) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -130,12 +122,12 @@ impl UVec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -236,12 +228,12 @@ impl UVec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -250,12 +242,12 @@ impl UVec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u32::clamp`].
@@ -887,12 +879,12 @@ impl Div for UVec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -941,12 +933,12 @@ impl Div<u32> for UVec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -995,12 +987,12 @@ impl Div<UVec4> for u32 {
     type Output = UVec4;
     #[inline]
     fn div(self, rhs: UVec4) -> UVec4 {
-        UVec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        UVec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1032,12 +1024,12 @@ impl Mul for UVec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1086,12 +1078,12 @@ impl Mul<u32> for UVec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1140,12 +1132,12 @@ impl Mul<UVec4> for u32 {
     type Output = UVec4;
     #[inline]
     fn mul(self, rhs: UVec4) -> UVec4 {
-        UVec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        UVec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1177,12 +1169,12 @@ impl Add for UVec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1231,12 +1223,12 @@ impl Add<u32> for UVec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1285,12 +1277,12 @@ impl Add<UVec4> for u32 {
     type Output = UVec4;
     #[inline]
     fn add(self, rhs: UVec4) -> UVec4 {
-        UVec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        UVec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1322,12 +1314,12 @@ impl Sub for UVec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1376,12 +1368,12 @@ impl Sub<u32> for UVec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1430,12 +1422,12 @@ impl Sub<UVec4> for u32 {
     type Output = UVec4;
     #[inline]
     fn sub(self, rhs: UVec4) -> UVec4 {
-        UVec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        UVec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1467,12 +1459,12 @@ impl Rem for UVec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1521,12 +1513,12 @@ impl Rem<u32> for UVec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u32) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -1575,12 +1567,12 @@ impl Rem<UVec4> for u32 {
     type Output = UVec4;
     #[inline]
     fn rem(self, rhs: UVec4) -> UVec4 {
-        UVec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        UVec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -1666,12 +1658,7 @@ impl Not for UVec4 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-            w: self.w.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not(), self.w.not())
     }
 }
 
@@ -1687,12 +1674,12 @@ impl BitAnd for UVec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-            w: self.w.bitand(rhs.w),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+            self.w.bitand(rhs.w),
+        )
     }
 }
 
@@ -1738,12 +1725,12 @@ impl BitOr for UVec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-            w: self.w.bitor(rhs.w),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+            self.w.bitor(rhs.w),
+        )
     }
 }
 
@@ -1789,12 +1776,12 @@ impl BitXor for UVec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-            w: self.w.bitxor(rhs.w),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+            self.w.bitxor(rhs.w),
+        )
     }
 }
 
@@ -1840,12 +1827,12 @@ impl BitAnd<u32> for UVec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-            w: self.w.bitand(rhs),
-        }
+        Self::new(
+            self.x.bitand(rhs),
+            self.y.bitand(rhs),
+            self.z.bitand(rhs),
+            self.w.bitand(rhs),
+        )
     }
 }
 
@@ -1891,12 +1878,12 @@ impl BitOr<u32> for UVec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-            w: self.w.bitor(rhs),
-        }
+        Self::new(
+            self.x.bitor(rhs),
+            self.y.bitor(rhs),
+            self.z.bitor(rhs),
+            self.w.bitor(rhs),
+        )
     }
 }
 
@@ -1942,12 +1929,12 @@ impl BitXor<u32> for UVec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-            w: self.w.bitxor(rhs),
-        }
+        Self::new(
+            self.x.bitxor(rhs),
+            self.y.bitxor(rhs),
+            self.z.bitxor(rhs),
+            self.w.bitxor(rhs),
+        )
     }
 }
 
@@ -1993,12 +1980,12 @@ impl Shl<i8> for UVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2044,12 +2031,12 @@ impl Shr<i8> for UVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2095,12 +2082,12 @@ impl Shl<i16> for UVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2146,12 +2133,12 @@ impl Shr<i16> for UVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2197,12 +2184,12 @@ impl Shl<i32> for UVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2248,12 +2235,12 @@ impl Shr<i32> for UVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2299,12 +2286,12 @@ impl Shl<i64> for UVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2350,12 +2337,12 @@ impl Shr<i64> for UVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2401,12 +2388,12 @@ impl Shl<u8> for UVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2452,12 +2439,12 @@ impl Shr<u8> for UVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2503,12 +2490,12 @@ impl Shl<u16> for UVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2554,12 +2541,12 @@ impl Shr<u16> for UVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2605,12 +2592,12 @@ impl Shl<u32> for UVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2656,12 +2643,12 @@ impl Shr<u32> for UVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2707,12 +2694,12 @@ impl Shl<u64> for UVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2758,12 +2745,12 @@ impl Shr<u64> for UVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2810,12 +2797,12 @@ impl Shl<IVec4> for UVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -2851,12 +2838,12 @@ impl Shr<IVec4> for UVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 
@@ -2891,12 +2878,12 @@ impl Shl for UVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -2928,12 +2915,12 @@ impl Shr for UVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -91,7 +91,7 @@ impl U64Vec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u64) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -112,10 +112,10 @@ impl U64Vec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -197,10 +197,10 @@ impl U64Vec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -209,10 +209,10 @@ impl U64Vec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u64::clamp`].
@@ -716,10 +716,7 @@ impl Div for U64Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -766,10 +763,7 @@ impl Div<u64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -816,10 +810,7 @@ impl Div<U64Vec2> for u64 {
     type Output = U64Vec2;
     #[inline]
     fn div(self, rhs: U64Vec2) -> U64Vec2 {
-        U64Vec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        U64Vec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -851,10 +842,7 @@ impl Mul for U64Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -901,10 +889,7 @@ impl Mul<u64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -951,10 +936,7 @@ impl Mul<U64Vec2> for u64 {
     type Output = U64Vec2;
     #[inline]
     fn mul(self, rhs: U64Vec2) -> U64Vec2 {
-        U64Vec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        U64Vec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -986,10 +968,7 @@ impl Add for U64Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1036,10 +1015,7 @@ impl Add<u64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1086,10 +1062,7 @@ impl Add<U64Vec2> for u64 {
     type Output = U64Vec2;
     #[inline]
     fn add(self, rhs: U64Vec2) -> U64Vec2 {
-        U64Vec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        U64Vec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1121,10 +1094,7 @@ impl Sub for U64Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1171,10 +1141,7 @@ impl Sub<u64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1221,10 +1188,7 @@ impl Sub<U64Vec2> for u64 {
     type Output = U64Vec2;
     #[inline]
     fn sub(self, rhs: U64Vec2) -> U64Vec2 {
-        U64Vec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        U64Vec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1256,10 +1220,7 @@ impl Rem for U64Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1306,10 +1267,7 @@ impl Rem<u64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1356,10 +1314,7 @@ impl Rem<U64Vec2> for u64 {
     type Output = U64Vec2;
     #[inline]
     fn rem(self, rhs: U64Vec2) -> U64Vec2 {
-        U64Vec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        U64Vec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1445,10 +1400,7 @@ impl Not for U64Vec2 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-        }
+        Self::new(self.x.not(), self.y.not())
     }
 }
 
@@ -1464,10 +1416,7 @@ impl BitAnd for U64Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-        }
+        Self::new(self.x.bitand(rhs.x), self.y.bitand(rhs.y))
     }
 }
 
@@ -1513,10 +1462,7 @@ impl BitOr for U64Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-        }
+        Self::new(self.x.bitor(rhs.x), self.y.bitor(rhs.y))
     }
 }
 
@@ -1562,10 +1508,7 @@ impl BitXor for U64Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-        }
+        Self::new(self.x.bitxor(rhs.x), self.y.bitxor(rhs.y))
     }
 }
 
@@ -1611,10 +1554,7 @@ impl BitAnd<u64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs))
     }
 }
 
@@ -1660,10 +1600,7 @@ impl BitOr<u64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs))
     }
 }
 
@@ -1709,10 +1646,7 @@ impl BitXor<u64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs))
     }
 }
 
@@ -1758,10 +1692,7 @@ impl Shl<i8> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1807,10 +1738,7 @@ impl Shr<i8> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -1856,10 +1784,7 @@ impl Shl<i16> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1905,10 +1830,7 @@ impl Shr<i16> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -1954,10 +1876,7 @@ impl Shl<i32> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2003,10 +1922,7 @@ impl Shr<i32> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2052,10 +1968,7 @@ impl Shl<i64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2101,10 +2014,7 @@ impl Shr<i64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2150,10 +2060,7 @@ impl Shl<u8> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2199,10 +2106,7 @@ impl Shr<u8> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2248,10 +2152,7 @@ impl Shl<u16> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2297,10 +2198,7 @@ impl Shr<u16> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2346,10 +2244,7 @@ impl Shl<u32> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2395,10 +2290,7 @@ impl Shr<u32> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2444,10 +2336,7 @@ impl Shl<u64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2493,10 +2382,7 @@ impl Shr<u64> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2543,10 +2429,7 @@ impl Shl<IVec2> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2582,10 +2465,7 @@ impl Shr<IVec2> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 
@@ -2621,10 +2501,7 @@ impl Shl<UVec2> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2660,10 +2537,7 @@ impl Shr<UVec2> for U64Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -94,7 +94,7 @@ impl U64Vec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u64) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -115,11 +115,11 @@ impl U64Vec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -163,11 +163,7 @@ impl U64Vec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: U64Vec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -229,11 +225,11 @@ impl U64Vec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -242,11 +238,11 @@ impl U64Vec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -255,11 +251,11 @@ impl U64Vec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u64::clamp`].
@@ -815,11 +811,7 @@ impl Div for U64Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -867,11 +859,7 @@ impl Div<u64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -919,11 +907,7 @@ impl Div<U64Vec3> for u64 {
     type Output = U64Vec3;
     #[inline]
     fn div(self, rhs: U64Vec3) -> U64Vec3 {
-        U64Vec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        U64Vec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -955,11 +939,7 @@ impl Mul for U64Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1007,11 +987,7 @@ impl Mul<u64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1059,11 +1035,7 @@ impl Mul<U64Vec3> for u64 {
     type Output = U64Vec3;
     #[inline]
     fn mul(self, rhs: U64Vec3) -> U64Vec3 {
-        U64Vec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        U64Vec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1095,11 +1067,7 @@ impl Add for U64Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1147,11 +1115,7 @@ impl Add<u64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1199,11 +1163,7 @@ impl Add<U64Vec3> for u64 {
     type Output = U64Vec3;
     #[inline]
     fn add(self, rhs: U64Vec3) -> U64Vec3 {
-        U64Vec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        U64Vec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1235,11 +1195,7 @@ impl Sub for U64Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1287,11 +1243,7 @@ impl Sub<u64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1339,11 +1291,7 @@ impl Sub<U64Vec3> for u64 {
     type Output = U64Vec3;
     #[inline]
     fn sub(self, rhs: U64Vec3) -> U64Vec3 {
-        U64Vec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        U64Vec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -1375,11 +1323,7 @@ impl Rem for U64Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -1427,11 +1371,7 @@ impl Rem<u64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -1479,11 +1419,7 @@ impl Rem<U64Vec3> for u64 {
     type Output = U64Vec3;
     #[inline]
     fn rem(self, rhs: U64Vec3) -> U64Vec3 {
-        U64Vec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        U64Vec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -1569,11 +1505,7 @@ impl Not for U64Vec3 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not())
     }
 }
 
@@ -1589,11 +1521,11 @@ impl BitAnd for U64Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+        )
     }
 }
 
@@ -1639,11 +1571,11 @@ impl BitOr for U64Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+        )
     }
 }
 
@@ -1689,11 +1621,11 @@ impl BitXor for U64Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+        )
     }
 }
 
@@ -1739,11 +1671,7 @@ impl BitAnd<u64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs), self.z.bitand(rhs))
     }
 }
 
@@ -1789,11 +1717,7 @@ impl BitOr<u64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs), self.z.bitor(rhs))
     }
 }
 
@@ -1839,11 +1763,7 @@ impl BitXor<u64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs), self.z.bitxor(rhs))
     }
 }
 
@@ -1889,11 +1809,7 @@ impl Shl<i8> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -1939,11 +1855,7 @@ impl Shr<i8> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -1989,11 +1901,7 @@ impl Shl<i16> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2039,11 +1947,7 @@ impl Shr<i16> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2089,11 +1993,7 @@ impl Shl<i32> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2139,11 +2039,7 @@ impl Shr<i32> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2189,11 +2085,7 @@ impl Shl<i64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2239,11 +2131,7 @@ impl Shr<i64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2289,11 +2177,7 @@ impl Shl<u8> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2339,11 +2223,7 @@ impl Shr<u8> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2389,11 +2269,7 @@ impl Shl<u16> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2439,11 +2315,7 @@ impl Shr<u16> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2489,11 +2361,7 @@ impl Shl<u32> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2539,11 +2407,7 @@ impl Shr<u32> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2589,11 +2453,7 @@ impl Shl<u64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2639,11 +2499,7 @@ impl Shr<u64> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2690,11 +2546,7 @@ impl Shl<IVec3> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2730,11 +2582,7 @@ impl Shr<IVec3> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 
@@ -2770,11 +2618,7 @@ impl Shl<UVec3> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2810,11 +2654,7 @@ impl Shr<UVec3> for U64Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -101,15 +101,7 @@ impl U64Vec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u64) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -130,12 +122,12 @@ impl U64Vec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -236,12 +228,12 @@ impl U64Vec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -250,12 +242,12 @@ impl U64Vec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u64::clamp`].
@@ -887,12 +879,12 @@ impl Div for U64Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -941,12 +933,12 @@ impl Div<u64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -995,12 +987,12 @@ impl Div<U64Vec4> for u64 {
     type Output = U64Vec4;
     #[inline]
     fn div(self, rhs: U64Vec4) -> U64Vec4 {
-        U64Vec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        U64Vec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1032,12 +1024,12 @@ impl Mul for U64Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1086,12 +1078,12 @@ impl Mul<u64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1140,12 +1132,12 @@ impl Mul<U64Vec4> for u64 {
     type Output = U64Vec4;
     #[inline]
     fn mul(self, rhs: U64Vec4) -> U64Vec4 {
-        U64Vec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        U64Vec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1177,12 +1169,12 @@ impl Add for U64Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1231,12 +1223,12 @@ impl Add<u64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1285,12 +1277,12 @@ impl Add<U64Vec4> for u64 {
     type Output = U64Vec4;
     #[inline]
     fn add(self, rhs: U64Vec4) -> U64Vec4 {
-        U64Vec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        U64Vec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1322,12 +1314,12 @@ impl Sub for U64Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1376,12 +1368,12 @@ impl Sub<u64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1430,12 +1422,12 @@ impl Sub<U64Vec4> for u64 {
     type Output = U64Vec4;
     #[inline]
     fn sub(self, rhs: U64Vec4) -> U64Vec4 {
-        U64Vec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        U64Vec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1467,12 +1459,12 @@ impl Rem for U64Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1521,12 +1513,12 @@ impl Rem<u64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u64) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -1575,12 +1567,12 @@ impl Rem<U64Vec4> for u64 {
     type Output = U64Vec4;
     #[inline]
     fn rem(self, rhs: U64Vec4) -> U64Vec4 {
-        U64Vec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        U64Vec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -1666,12 +1658,7 @@ impl Not for U64Vec4 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-            w: self.w.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not(), self.w.not())
     }
 }
 
@@ -1687,12 +1674,12 @@ impl BitAnd for U64Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-            w: self.w.bitand(rhs.w),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+            self.w.bitand(rhs.w),
+        )
     }
 }
 
@@ -1738,12 +1725,12 @@ impl BitOr for U64Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-            w: self.w.bitor(rhs.w),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+            self.w.bitor(rhs.w),
+        )
     }
 }
 
@@ -1789,12 +1776,12 @@ impl BitXor for U64Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-            w: self.w.bitxor(rhs.w),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+            self.w.bitxor(rhs.w),
+        )
     }
 }
 
@@ -1840,12 +1827,12 @@ impl BitAnd<u64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-            w: self.w.bitand(rhs),
-        }
+        Self::new(
+            self.x.bitand(rhs),
+            self.y.bitand(rhs),
+            self.z.bitand(rhs),
+            self.w.bitand(rhs),
+        )
     }
 }
 
@@ -1891,12 +1878,12 @@ impl BitOr<u64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-            w: self.w.bitor(rhs),
-        }
+        Self::new(
+            self.x.bitor(rhs),
+            self.y.bitor(rhs),
+            self.z.bitor(rhs),
+            self.w.bitor(rhs),
+        )
     }
 }
 
@@ -1942,12 +1929,12 @@ impl BitXor<u64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-            w: self.w.bitxor(rhs),
-        }
+        Self::new(
+            self.x.bitxor(rhs),
+            self.y.bitxor(rhs),
+            self.z.bitxor(rhs),
+            self.w.bitxor(rhs),
+        )
     }
 }
 
@@ -1993,12 +1980,12 @@ impl Shl<i8> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2044,12 +2031,12 @@ impl Shr<i8> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2095,12 +2082,12 @@ impl Shl<i16> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2146,12 +2133,12 @@ impl Shr<i16> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2197,12 +2184,12 @@ impl Shl<i32> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2248,12 +2235,12 @@ impl Shr<i32> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2299,12 +2286,12 @@ impl Shl<i64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2350,12 +2337,12 @@ impl Shr<i64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2401,12 +2388,12 @@ impl Shl<u8> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2452,12 +2439,12 @@ impl Shr<u8> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2503,12 +2490,12 @@ impl Shl<u16> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2554,12 +2541,12 @@ impl Shr<u16> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2605,12 +2592,12 @@ impl Shl<u32> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2656,12 +2643,12 @@ impl Shr<u32> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2707,12 +2694,12 @@ impl Shl<u64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2758,12 +2745,12 @@ impl Shr<u64> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2810,12 +2797,12 @@ impl Shl<IVec4> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -2851,12 +2838,12 @@ impl Shr<IVec4> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 
@@ -2892,12 +2879,12 @@ impl Shl<UVec4> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -2933,12 +2920,12 @@ impl Shr<UVec4> for U64Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -91,7 +91,7 @@ impl U8Vec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u8) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -112,10 +112,10 @@ impl U8Vec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -197,10 +197,10 @@ impl U8Vec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -209,10 +209,10 @@ impl U8Vec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u8::clamp`].
@@ -716,10 +716,7 @@ impl Div for U8Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -766,10 +763,7 @@ impl Div<u8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -816,10 +810,7 @@ impl Div<U8Vec2> for u8 {
     type Output = U8Vec2;
     #[inline]
     fn div(self, rhs: U8Vec2) -> U8Vec2 {
-        U8Vec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        U8Vec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -851,10 +842,7 @@ impl Mul for U8Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -901,10 +889,7 @@ impl Mul<u8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -951,10 +936,7 @@ impl Mul<U8Vec2> for u8 {
     type Output = U8Vec2;
     #[inline]
     fn mul(self, rhs: U8Vec2) -> U8Vec2 {
-        U8Vec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        U8Vec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -986,10 +968,7 @@ impl Add for U8Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1036,10 +1015,7 @@ impl Add<u8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1086,10 +1062,7 @@ impl Add<U8Vec2> for u8 {
     type Output = U8Vec2;
     #[inline]
     fn add(self, rhs: U8Vec2) -> U8Vec2 {
-        U8Vec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        U8Vec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1121,10 +1094,7 @@ impl Sub for U8Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1171,10 +1141,7 @@ impl Sub<u8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1221,10 +1188,7 @@ impl Sub<U8Vec2> for u8 {
     type Output = U8Vec2;
     #[inline]
     fn sub(self, rhs: U8Vec2) -> U8Vec2 {
-        U8Vec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        U8Vec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1256,10 +1220,7 @@ impl Rem for U8Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1306,10 +1267,7 @@ impl Rem<u8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1356,10 +1314,7 @@ impl Rem<U8Vec2> for u8 {
     type Output = U8Vec2;
     #[inline]
     fn rem(self, rhs: U8Vec2) -> U8Vec2 {
-        U8Vec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        U8Vec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1445,10 +1400,7 @@ impl Not for U8Vec2 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-        }
+        Self::new(self.x.not(), self.y.not())
     }
 }
 
@@ -1464,10 +1416,7 @@ impl BitAnd for U8Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-        }
+        Self::new(self.x.bitand(rhs.x), self.y.bitand(rhs.y))
     }
 }
 
@@ -1513,10 +1462,7 @@ impl BitOr for U8Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-        }
+        Self::new(self.x.bitor(rhs.x), self.y.bitor(rhs.y))
     }
 }
 
@@ -1562,10 +1508,7 @@ impl BitXor for U8Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-        }
+        Self::new(self.x.bitxor(rhs.x), self.y.bitxor(rhs.y))
     }
 }
 
@@ -1611,10 +1554,7 @@ impl BitAnd<u8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs))
     }
 }
 
@@ -1660,10 +1600,7 @@ impl BitOr<u8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs))
     }
 }
 
@@ -1709,10 +1646,7 @@ impl BitXor<u8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs))
     }
 }
 
@@ -1758,10 +1692,7 @@ impl Shl<i8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1807,10 +1738,7 @@ impl Shr<i8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -1856,10 +1784,7 @@ impl Shl<i16> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1905,10 +1830,7 @@ impl Shr<i16> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -1954,10 +1876,7 @@ impl Shl<i32> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2003,10 +1922,7 @@ impl Shr<i32> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2052,10 +1968,7 @@ impl Shl<i64> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2101,10 +2014,7 @@ impl Shr<i64> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2150,10 +2060,7 @@ impl Shl<u8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2199,10 +2106,7 @@ impl Shr<u8> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2248,10 +2152,7 @@ impl Shl<u16> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2297,10 +2198,7 @@ impl Shr<u16> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2346,10 +2244,7 @@ impl Shl<u32> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2395,10 +2290,7 @@ impl Shr<u32> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2444,10 +2336,7 @@ impl Shl<u64> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2493,10 +2382,7 @@ impl Shr<u64> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2543,10 +2429,7 @@ impl Shl<IVec2> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2582,10 +2465,7 @@ impl Shr<IVec2> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 
@@ -2621,10 +2501,7 @@ impl Shl<UVec2> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2660,10 +2537,7 @@ impl Shr<UVec2> for U8Vec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -94,7 +94,7 @@ impl U8Vec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u8) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -115,11 +115,11 @@ impl U8Vec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -163,11 +163,7 @@ impl U8Vec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: U8Vec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -229,11 +225,11 @@ impl U8Vec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -242,11 +238,11 @@ impl U8Vec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -255,11 +251,11 @@ impl U8Vec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u8::clamp`].
@@ -815,11 +811,7 @@ impl Div for U8Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -867,11 +859,7 @@ impl Div<u8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -919,11 +907,7 @@ impl Div<U8Vec3> for u8 {
     type Output = U8Vec3;
     #[inline]
     fn div(self, rhs: U8Vec3) -> U8Vec3 {
-        U8Vec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        U8Vec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -955,11 +939,7 @@ impl Mul for U8Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1007,11 +987,7 @@ impl Mul<u8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1059,11 +1035,7 @@ impl Mul<U8Vec3> for u8 {
     type Output = U8Vec3;
     #[inline]
     fn mul(self, rhs: U8Vec3) -> U8Vec3 {
-        U8Vec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        U8Vec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1095,11 +1067,7 @@ impl Add for U8Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1147,11 +1115,7 @@ impl Add<u8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1199,11 +1163,7 @@ impl Add<U8Vec3> for u8 {
     type Output = U8Vec3;
     #[inline]
     fn add(self, rhs: U8Vec3) -> U8Vec3 {
-        U8Vec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        U8Vec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1235,11 +1195,7 @@ impl Sub for U8Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1287,11 +1243,7 @@ impl Sub<u8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1339,11 +1291,7 @@ impl Sub<U8Vec3> for u8 {
     type Output = U8Vec3;
     #[inline]
     fn sub(self, rhs: U8Vec3) -> U8Vec3 {
-        U8Vec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        U8Vec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -1375,11 +1323,7 @@ impl Rem for U8Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -1427,11 +1371,7 @@ impl Rem<u8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -1479,11 +1419,7 @@ impl Rem<U8Vec3> for u8 {
     type Output = U8Vec3;
     #[inline]
     fn rem(self, rhs: U8Vec3) -> U8Vec3 {
-        U8Vec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        U8Vec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -1569,11 +1505,7 @@ impl Not for U8Vec3 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not())
     }
 }
 
@@ -1589,11 +1521,11 @@ impl BitAnd for U8Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+        )
     }
 }
 
@@ -1639,11 +1571,11 @@ impl BitOr for U8Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+        )
     }
 }
 
@@ -1689,11 +1621,11 @@ impl BitXor for U8Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+        )
     }
 }
 
@@ -1739,11 +1671,7 @@ impl BitAnd<u8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs), self.z.bitand(rhs))
     }
 }
 
@@ -1789,11 +1717,7 @@ impl BitOr<u8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs), self.z.bitor(rhs))
     }
 }
 
@@ -1839,11 +1763,7 @@ impl BitXor<u8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs), self.z.bitxor(rhs))
     }
 }
 
@@ -1889,11 +1809,7 @@ impl Shl<i8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -1939,11 +1855,7 @@ impl Shr<i8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -1989,11 +1901,7 @@ impl Shl<i16> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2039,11 +1947,7 @@ impl Shr<i16> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2089,11 +1993,7 @@ impl Shl<i32> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2139,11 +2039,7 @@ impl Shr<i32> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2189,11 +2085,7 @@ impl Shl<i64> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2239,11 +2131,7 @@ impl Shr<i64> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2289,11 +2177,7 @@ impl Shl<u8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2339,11 +2223,7 @@ impl Shr<u8> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2389,11 +2269,7 @@ impl Shl<u16> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2439,11 +2315,7 @@ impl Shr<u16> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2489,11 +2361,7 @@ impl Shl<u32> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2539,11 +2407,7 @@ impl Shr<u32> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2589,11 +2453,7 @@ impl Shl<u64> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2639,11 +2499,7 @@ impl Shr<u64> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2690,11 +2546,7 @@ impl Shl<IVec3> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2730,11 +2582,7 @@ impl Shr<IVec3> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 
@@ -2770,11 +2618,7 @@ impl Shl<UVec3> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2810,11 +2654,7 @@ impl Shr<UVec3> for U8Vec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -101,15 +101,7 @@ impl U8Vec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: u8) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -130,12 +122,12 @@ impl U8Vec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -236,12 +228,12 @@ impl U8Vec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -250,12 +242,12 @@ impl U8Vec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`u8::clamp`].
@@ -887,12 +879,12 @@ impl Div for U8Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -941,12 +933,12 @@ impl Div<u8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -995,12 +987,12 @@ impl Div<U8Vec4> for u8 {
     type Output = U8Vec4;
     #[inline]
     fn div(self, rhs: U8Vec4) -> U8Vec4 {
-        U8Vec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        U8Vec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1032,12 +1024,12 @@ impl Mul for U8Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1086,12 +1078,12 @@ impl Mul<u8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1140,12 +1132,12 @@ impl Mul<U8Vec4> for u8 {
     type Output = U8Vec4;
     #[inline]
     fn mul(self, rhs: U8Vec4) -> U8Vec4 {
-        U8Vec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        U8Vec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1177,12 +1169,12 @@ impl Add for U8Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1231,12 +1223,12 @@ impl Add<u8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1285,12 +1277,12 @@ impl Add<U8Vec4> for u8 {
     type Output = U8Vec4;
     #[inline]
     fn add(self, rhs: U8Vec4) -> U8Vec4 {
-        U8Vec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        U8Vec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1322,12 +1314,12 @@ impl Sub for U8Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1376,12 +1368,12 @@ impl Sub<u8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1430,12 +1422,12 @@ impl Sub<U8Vec4> for u8 {
     type Output = U8Vec4;
     #[inline]
     fn sub(self, rhs: U8Vec4) -> U8Vec4 {
-        U8Vec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        U8Vec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1467,12 +1459,12 @@ impl Rem for U8Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1521,12 +1513,12 @@ impl Rem<u8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: u8) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -1575,12 +1567,12 @@ impl Rem<U8Vec4> for u8 {
     type Output = U8Vec4;
     #[inline]
     fn rem(self, rhs: U8Vec4) -> U8Vec4 {
-        U8Vec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        U8Vec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -1666,12 +1658,7 @@ impl Not for U8Vec4 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-            w: self.w.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not(), self.w.not())
     }
 }
 
@@ -1687,12 +1674,12 @@ impl BitAnd for U8Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-            w: self.w.bitand(rhs.w),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+            self.w.bitand(rhs.w),
+        )
     }
 }
 
@@ -1738,12 +1725,12 @@ impl BitOr for U8Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-            w: self.w.bitor(rhs.w),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+            self.w.bitor(rhs.w),
+        )
     }
 }
 
@@ -1789,12 +1776,12 @@ impl BitXor for U8Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-            w: self.w.bitxor(rhs.w),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+            self.w.bitxor(rhs.w),
+        )
     }
 }
 
@@ -1840,12 +1827,12 @@ impl BitAnd<u8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-            w: self.w.bitand(rhs),
-        }
+        Self::new(
+            self.x.bitand(rhs),
+            self.y.bitand(rhs),
+            self.z.bitand(rhs),
+            self.w.bitand(rhs),
+        )
     }
 }
 
@@ -1891,12 +1878,12 @@ impl BitOr<u8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-            w: self.w.bitor(rhs),
-        }
+        Self::new(
+            self.x.bitor(rhs),
+            self.y.bitor(rhs),
+            self.z.bitor(rhs),
+            self.w.bitor(rhs),
+        )
     }
 }
 
@@ -1942,12 +1929,12 @@ impl BitXor<u8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-            w: self.w.bitxor(rhs),
-        }
+        Self::new(
+            self.x.bitxor(rhs),
+            self.y.bitxor(rhs),
+            self.z.bitxor(rhs),
+            self.w.bitxor(rhs),
+        )
     }
 }
 
@@ -1993,12 +1980,12 @@ impl Shl<i8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2044,12 +2031,12 @@ impl Shr<i8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2095,12 +2082,12 @@ impl Shl<i16> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2146,12 +2133,12 @@ impl Shr<i16> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2197,12 +2184,12 @@ impl Shl<i32> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2248,12 +2235,12 @@ impl Shr<i32> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2299,12 +2286,12 @@ impl Shl<i64> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2350,12 +2337,12 @@ impl Shr<i64> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2401,12 +2388,12 @@ impl Shl<u8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2452,12 +2439,12 @@ impl Shr<u8> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2503,12 +2490,12 @@ impl Shl<u16> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2554,12 +2541,12 @@ impl Shr<u16> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2605,12 +2592,12 @@ impl Shl<u32> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2656,12 +2643,12 @@ impl Shr<u32> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2707,12 +2694,12 @@ impl Shl<u64> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2758,12 +2745,12 @@ impl Shr<u64> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2810,12 +2797,12 @@ impl Shl<IVec4> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -2851,12 +2838,12 @@ impl Shr<IVec4> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 
@@ -2892,12 +2879,12 @@ impl Shl<UVec4> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -2933,12 +2920,12 @@ impl Shr<UVec4> for U8Vec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 

--- a/src/usize/usizevec2.rs
+++ b/src/usize/usizevec2.rs
@@ -91,7 +91,7 @@ impl USizeVec2 {
     #[inline]
     #[must_use]
     pub const fn splat(v: usize) -> Self {
-        Self { x: v, y: v }
+        Self::new(v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -112,10 +112,10 @@ impl USizeVec2 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec2, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -197,10 +197,10 @@ impl USizeVec2 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -209,10 +209,10 @@ impl USizeVec2 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`usize::clamp`].
@@ -716,10 +716,7 @@ impl Div for USizeVec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y))
     }
 }
 
@@ -766,10 +763,7 @@ impl Div<usize> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs))
     }
 }
 
@@ -816,10 +810,7 @@ impl Div<USizeVec2> for usize {
     type Output = USizeVec2;
     #[inline]
     fn div(self, rhs: USizeVec2) -> USizeVec2 {
-        USizeVec2 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-        }
+        USizeVec2::new(self.div(rhs.x), self.div(rhs.y))
     }
 }
 
@@ -851,10 +842,7 @@ impl Mul for USizeVec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y))
     }
 }
 
@@ -901,10 +889,7 @@ impl Mul<usize> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs))
     }
 }
 
@@ -951,10 +936,7 @@ impl Mul<USizeVec2> for usize {
     type Output = USizeVec2;
     #[inline]
     fn mul(self, rhs: USizeVec2) -> USizeVec2 {
-        USizeVec2 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-        }
+        USizeVec2::new(self.mul(rhs.x), self.mul(rhs.y))
     }
 }
 
@@ -986,10 +968,7 @@ impl Add for USizeVec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y))
     }
 }
 
@@ -1036,10 +1015,7 @@ impl Add<usize> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs))
     }
 }
 
@@ -1086,10 +1062,7 @@ impl Add<USizeVec2> for usize {
     type Output = USizeVec2;
     #[inline]
     fn add(self, rhs: USizeVec2) -> USizeVec2 {
-        USizeVec2 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-        }
+        USizeVec2::new(self.add(rhs.x), self.add(rhs.y))
     }
 }
 
@@ -1121,10 +1094,7 @@ impl Sub for USizeVec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y))
     }
 }
 
@@ -1171,10 +1141,7 @@ impl Sub<usize> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs))
     }
 }
 
@@ -1221,10 +1188,7 @@ impl Sub<USizeVec2> for usize {
     type Output = USizeVec2;
     #[inline]
     fn sub(self, rhs: USizeVec2) -> USizeVec2 {
-        USizeVec2 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-        }
+        USizeVec2::new(self.sub(rhs.x), self.sub(rhs.y))
     }
 }
 
@@ -1256,10 +1220,7 @@ impl Rem for USizeVec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y))
     }
 }
 
@@ -1306,10 +1267,7 @@ impl Rem<usize> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs))
     }
 }
 
@@ -1356,10 +1314,7 @@ impl Rem<USizeVec2> for usize {
     type Output = USizeVec2;
     #[inline]
     fn rem(self, rhs: USizeVec2) -> USizeVec2 {
-        USizeVec2 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-        }
+        USizeVec2::new(self.rem(rhs.x), self.rem(rhs.y))
     }
 }
 
@@ -1445,10 +1400,7 @@ impl Not for USizeVec2 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-        }
+        Self::new(self.x.not(), self.y.not())
     }
 }
 
@@ -1464,10 +1416,7 @@ impl BitAnd for USizeVec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-        }
+        Self::new(self.x.bitand(rhs.x), self.y.bitand(rhs.y))
     }
 }
 
@@ -1513,10 +1462,7 @@ impl BitOr for USizeVec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-        }
+        Self::new(self.x.bitor(rhs.x), self.y.bitor(rhs.y))
     }
 }
 
@@ -1562,10 +1508,7 @@ impl BitXor for USizeVec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-        }
+        Self::new(self.x.bitxor(rhs.x), self.y.bitxor(rhs.y))
     }
 }
 
@@ -1611,10 +1554,7 @@ impl BitAnd<usize> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: usize) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs))
     }
 }
 
@@ -1660,10 +1600,7 @@ impl BitOr<usize> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: usize) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs))
     }
 }
 
@@ -1709,10 +1646,7 @@ impl BitXor<usize> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: usize) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs))
     }
 }
 
@@ -1758,10 +1692,7 @@ impl Shl<i8> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1807,10 +1738,7 @@ impl Shr<i8> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -1856,10 +1784,7 @@ impl Shl<i16> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -1905,10 +1830,7 @@ impl Shr<i16> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -1954,10 +1876,7 @@ impl Shl<i32> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2003,10 +1922,7 @@ impl Shr<i32> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2052,10 +1968,7 @@ impl Shl<i64> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2101,10 +2014,7 @@ impl Shr<i64> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2150,10 +2060,7 @@ impl Shl<u8> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2199,10 +2106,7 @@ impl Shr<u8> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2248,10 +2152,7 @@ impl Shl<u16> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2297,10 +2198,7 @@ impl Shr<u16> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2346,10 +2244,7 @@ impl Shl<u32> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2395,10 +2290,7 @@ impl Shr<u32> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2444,10 +2336,7 @@ impl Shl<u64> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs))
     }
 }
 
@@ -2493,10 +2382,7 @@ impl Shr<u64> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs))
     }
 }
 
@@ -2543,10 +2429,7 @@ impl Shl<IVec2> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2582,10 +2465,7 @@ impl Shr<IVec2> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 
@@ -2621,10 +2501,7 @@ impl Shl<UVec2> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y))
     }
 }
 
@@ -2660,10 +2537,7 @@ impl Shr<UVec2> for USizeVec2 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec2) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y))
     }
 }
 

--- a/src/usize/usizevec3.rs
+++ b/src/usize/usizevec3.rs
@@ -94,7 +94,7 @@ impl USizeVec3 {
     #[inline]
     #[must_use]
     pub const fn splat(v: usize) -> Self {
-        Self { x: v, y: v, z: v }
+        Self::new(v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -115,11 +115,11 @@ impl USizeVec3 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec3, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -163,11 +163,7 @@ impl USizeVec3 {
     #[inline]
     #[must_use]
     pub(crate) fn from_vec4(v: USizeVec4) -> Self {
-        Self {
-            x: v.x,
-            y: v.y,
-            z: v.z,
-        }
+        Self::new(v.x, v.y, v.z)
     }
 
     /// Creates a 4D vector from `self` and the given `w` value.
@@ -229,11 +225,11 @@ impl USizeVec3 {
     #[inline]
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
-        Self {
-            x: self.y * rhs.z - rhs.y * self.z,
-            y: self.z * rhs.x - rhs.z * self.x,
-            z: self.x * rhs.y - rhs.x * self.y,
-        }
+        Self::new(
+            self.y * rhs.z - rhs.y * self.z,
+            self.z * rhs.x - rhs.z * self.x,
+            self.x * rhs.y - rhs.x * self.y,
+        )
     }
 
     /// Returns a vector containing the minimum values for each element of `self` and `rhs`.
@@ -242,11 +238,11 @@ impl USizeVec3 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -255,11 +251,11 @@ impl USizeVec3 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`usize::clamp`].
@@ -815,11 +811,7 @@ impl Div for USizeVec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-        }
+        Self::new(self.x.div(rhs.x), self.y.div(rhs.y), self.z.div(rhs.z))
     }
 }
 
@@ -867,11 +859,7 @@ impl Div<usize> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-        }
+        Self::new(self.x.div(rhs), self.y.div(rhs), self.z.div(rhs))
     }
 }
 
@@ -919,11 +907,7 @@ impl Div<USizeVec3> for usize {
     type Output = USizeVec3;
     #[inline]
     fn div(self, rhs: USizeVec3) -> USizeVec3 {
-        USizeVec3 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-        }
+        USizeVec3::new(self.div(rhs.x), self.div(rhs.y), self.div(rhs.z))
     }
 }
 
@@ -955,11 +939,7 @@ impl Mul for USizeVec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-        }
+        Self::new(self.x.mul(rhs.x), self.y.mul(rhs.y), self.z.mul(rhs.z))
     }
 }
 
@@ -1007,11 +987,7 @@ impl Mul<usize> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-        }
+        Self::new(self.x.mul(rhs), self.y.mul(rhs), self.z.mul(rhs))
     }
 }
 
@@ -1059,11 +1035,7 @@ impl Mul<USizeVec3> for usize {
     type Output = USizeVec3;
     #[inline]
     fn mul(self, rhs: USizeVec3) -> USizeVec3 {
-        USizeVec3 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-        }
+        USizeVec3::new(self.mul(rhs.x), self.mul(rhs.y), self.mul(rhs.z))
     }
 }
 
@@ -1095,11 +1067,7 @@ impl Add for USizeVec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-        }
+        Self::new(self.x.add(rhs.x), self.y.add(rhs.y), self.z.add(rhs.z))
     }
 }
 
@@ -1147,11 +1115,7 @@ impl Add<usize> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-        }
+        Self::new(self.x.add(rhs), self.y.add(rhs), self.z.add(rhs))
     }
 }
 
@@ -1199,11 +1163,7 @@ impl Add<USizeVec3> for usize {
     type Output = USizeVec3;
     #[inline]
     fn add(self, rhs: USizeVec3) -> USizeVec3 {
-        USizeVec3 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-        }
+        USizeVec3::new(self.add(rhs.x), self.add(rhs.y), self.add(rhs.z))
     }
 }
 
@@ -1235,11 +1195,7 @@ impl Sub for USizeVec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-        }
+        Self::new(self.x.sub(rhs.x), self.y.sub(rhs.y), self.z.sub(rhs.z))
     }
 }
 
@@ -1287,11 +1243,7 @@ impl Sub<usize> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-        }
+        Self::new(self.x.sub(rhs), self.y.sub(rhs), self.z.sub(rhs))
     }
 }
 
@@ -1339,11 +1291,7 @@ impl Sub<USizeVec3> for usize {
     type Output = USizeVec3;
     #[inline]
     fn sub(self, rhs: USizeVec3) -> USizeVec3 {
-        USizeVec3 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-        }
+        USizeVec3::new(self.sub(rhs.x), self.sub(rhs.y), self.sub(rhs.z))
     }
 }
 
@@ -1375,11 +1323,7 @@ impl Rem for USizeVec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-        }
+        Self::new(self.x.rem(rhs.x), self.y.rem(rhs.y), self.z.rem(rhs.z))
     }
 }
 
@@ -1427,11 +1371,7 @@ impl Rem<usize> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-        }
+        Self::new(self.x.rem(rhs), self.y.rem(rhs), self.z.rem(rhs))
     }
 }
 
@@ -1479,11 +1419,7 @@ impl Rem<USizeVec3> for usize {
     type Output = USizeVec3;
     #[inline]
     fn rem(self, rhs: USizeVec3) -> USizeVec3 {
-        USizeVec3 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-        }
+        USizeVec3::new(self.rem(rhs.x), self.rem(rhs.y), self.rem(rhs.z))
     }
 }
 
@@ -1569,11 +1505,7 @@ impl Not for USizeVec3 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not())
     }
 }
 
@@ -1589,11 +1521,11 @@ impl BitAnd for USizeVec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+        )
     }
 }
 
@@ -1639,11 +1571,11 @@ impl BitOr for USizeVec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+        )
     }
 }
 
@@ -1689,11 +1621,11 @@ impl BitXor for USizeVec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+        )
     }
 }
 
@@ -1739,11 +1671,7 @@ impl BitAnd<usize> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: usize) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-        }
+        Self::new(self.x.bitand(rhs), self.y.bitand(rhs), self.z.bitand(rhs))
     }
 }
 
@@ -1789,11 +1717,7 @@ impl BitOr<usize> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: usize) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-        }
+        Self::new(self.x.bitor(rhs), self.y.bitor(rhs), self.z.bitor(rhs))
     }
 }
 
@@ -1839,11 +1763,7 @@ impl BitXor<usize> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: usize) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-        }
+        Self::new(self.x.bitxor(rhs), self.y.bitxor(rhs), self.z.bitxor(rhs))
     }
 }
 
@@ -1889,11 +1809,7 @@ impl Shl<i8> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -1939,11 +1855,7 @@ impl Shr<i8> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -1989,11 +1901,7 @@ impl Shl<i16> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2039,11 +1947,7 @@ impl Shr<i16> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2089,11 +1993,7 @@ impl Shl<i32> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2139,11 +2039,7 @@ impl Shr<i32> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2189,11 +2085,7 @@ impl Shl<i64> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2239,11 +2131,7 @@ impl Shr<i64> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2289,11 +2177,7 @@ impl Shl<u8> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2339,11 +2223,7 @@ impl Shr<u8> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2389,11 +2269,7 @@ impl Shl<u16> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2439,11 +2315,7 @@ impl Shr<u16> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2489,11 +2361,7 @@ impl Shl<u32> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2539,11 +2407,7 @@ impl Shr<u32> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2589,11 +2453,7 @@ impl Shl<u64> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-        }
+        Self::new(self.x.shl(rhs), self.y.shl(rhs), self.z.shl(rhs))
     }
 }
 
@@ -2639,11 +2499,7 @@ impl Shr<u64> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-        }
+        Self::new(self.x.shr(rhs), self.y.shr(rhs), self.z.shr(rhs))
     }
 }
 
@@ -2690,11 +2546,7 @@ impl Shl<IVec3> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2730,11 +2582,7 @@ impl Shr<IVec3> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 
@@ -2770,11 +2618,7 @@ impl Shl<UVec3> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-        }
+        Self::new(self.x.shl(rhs.x), self.y.shl(rhs.y), self.z.shl(rhs.z))
     }
 }
 
@@ -2810,11 +2654,7 @@ impl Shr<UVec3> for USizeVec3 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec3) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-        }
+        Self::new(self.x.shr(rhs.x), self.y.shr(rhs.y), self.z.shr(rhs.z))
     }
 }
 

--- a/src/usize/usizevec4.rs
+++ b/src/usize/usizevec4.rs
@@ -101,15 +101,7 @@ impl USizeVec4 {
     #[inline]
     #[must_use]
     pub const fn splat(v: usize) -> Self {
-        Self {
-            x: v,
-
-            y: v,
-
-            z: v,
-
-            w: v,
-        }
+        Self::new(v, v, v, v)
     }
 
     /// Returns a vector containing each element of `self` modified by a mapping function `f`.
@@ -130,12 +122,12 @@ impl USizeVec4 {
     #[inline]
     #[must_use]
     pub fn select(mask: BVec4, if_true: Self, if_false: Self) -> Self {
-        Self {
-            x: if mask.test(0) { if_true.x } else { if_false.x },
-            y: if mask.test(1) { if_true.y } else { if_false.y },
-            z: if mask.test(2) { if_true.z } else { if_false.z },
-            w: if mask.test(3) { if_true.w } else { if_false.w },
-        }
+        Self::new(
+            if mask.test(0) { if_true.x } else { if_false.x },
+            if mask.test(1) { if_true.y } else { if_false.y },
+            if mask.test(2) { if_true.z } else { if_false.z },
+            if mask.test(3) { if_true.w } else { if_false.w },
+        )
     }
 
     /// Creates a new vector from an array.
@@ -236,12 +228,12 @@ impl USizeVec4 {
     #[inline]
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x < rhs.x { self.x } else { rhs.x },
-            y: if self.y < rhs.y { self.y } else { rhs.y },
-            z: if self.z < rhs.z { self.z } else { rhs.z },
-            w: if self.w < rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x < rhs.x { self.x } else { rhs.x },
+            if self.y < rhs.y { self.y } else { rhs.y },
+            if self.z < rhs.z { self.z } else { rhs.z },
+            if self.w < rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Returns a vector containing the maximum values for each element of `self` and `rhs`.
@@ -250,12 +242,12 @@ impl USizeVec4 {
     #[inline]
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
-        Self {
-            x: if self.x > rhs.x { self.x } else { rhs.x },
-            y: if self.y > rhs.y { self.y } else { rhs.y },
-            z: if self.z > rhs.z { self.z } else { rhs.z },
-            w: if self.w > rhs.w { self.w } else { rhs.w },
-        }
+        Self::new(
+            if self.x > rhs.x { self.x } else { rhs.x },
+            if self.y > rhs.y { self.y } else { rhs.y },
+            if self.z > rhs.z { self.z } else { rhs.z },
+            if self.w > rhs.w { self.w } else { rhs.w },
+        )
     }
 
     /// Component-wise clamping of values, similar to [`usize::clamp`].
@@ -882,12 +874,12 @@ impl Div for USizeVec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.div(rhs.x),
-            y: self.y.div(rhs.y),
-            z: self.z.div(rhs.z),
-            w: self.w.div(rhs.w),
-        }
+        Self::new(
+            self.x.div(rhs.x),
+            self.y.div(rhs.y),
+            self.z.div(rhs.z),
+            self.w.div(rhs.w),
+        )
     }
 }
 
@@ -936,12 +928,12 @@ impl Div<usize> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn div(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.div(rhs),
-            y: self.y.div(rhs),
-            z: self.z.div(rhs),
-            w: self.w.div(rhs),
-        }
+        Self::new(
+            self.x.div(rhs),
+            self.y.div(rhs),
+            self.z.div(rhs),
+            self.w.div(rhs),
+        )
     }
 }
 
@@ -990,12 +982,12 @@ impl Div<USizeVec4> for usize {
     type Output = USizeVec4;
     #[inline]
     fn div(self, rhs: USizeVec4) -> USizeVec4 {
-        USizeVec4 {
-            x: self.div(rhs.x),
-            y: self.div(rhs.y),
-            z: self.div(rhs.z),
-            w: self.div(rhs.w),
-        }
+        USizeVec4::new(
+            self.div(rhs.x),
+            self.div(rhs.y),
+            self.div(rhs.z),
+            self.div(rhs.w),
+        )
     }
 }
 
@@ -1027,12 +1019,12 @@ impl Mul for USizeVec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.mul(rhs.x),
-            y: self.y.mul(rhs.y),
-            z: self.z.mul(rhs.z),
-            w: self.w.mul(rhs.w),
-        }
+        Self::new(
+            self.x.mul(rhs.x),
+            self.y.mul(rhs.y),
+            self.z.mul(rhs.z),
+            self.w.mul(rhs.w),
+        )
     }
 }
 
@@ -1081,12 +1073,12 @@ impl Mul<usize> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn mul(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.mul(rhs),
-            y: self.y.mul(rhs),
-            z: self.z.mul(rhs),
-            w: self.w.mul(rhs),
-        }
+        Self::new(
+            self.x.mul(rhs),
+            self.y.mul(rhs),
+            self.z.mul(rhs),
+            self.w.mul(rhs),
+        )
     }
 }
 
@@ -1135,12 +1127,12 @@ impl Mul<USizeVec4> for usize {
     type Output = USizeVec4;
     #[inline]
     fn mul(self, rhs: USizeVec4) -> USizeVec4 {
-        USizeVec4 {
-            x: self.mul(rhs.x),
-            y: self.mul(rhs.y),
-            z: self.mul(rhs.z),
-            w: self.mul(rhs.w),
-        }
+        USizeVec4::new(
+            self.mul(rhs.x),
+            self.mul(rhs.y),
+            self.mul(rhs.z),
+            self.mul(rhs.w),
+        )
     }
 }
 
@@ -1172,12 +1164,12 @@ impl Add for USizeVec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.add(rhs.x),
-            y: self.y.add(rhs.y),
-            z: self.z.add(rhs.z),
-            w: self.w.add(rhs.w),
-        }
+        Self::new(
+            self.x.add(rhs.x),
+            self.y.add(rhs.y),
+            self.z.add(rhs.z),
+            self.w.add(rhs.w),
+        )
     }
 }
 
@@ -1226,12 +1218,12 @@ impl Add<usize> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn add(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.add(rhs),
-            y: self.y.add(rhs),
-            z: self.z.add(rhs),
-            w: self.w.add(rhs),
-        }
+        Self::new(
+            self.x.add(rhs),
+            self.y.add(rhs),
+            self.z.add(rhs),
+            self.w.add(rhs),
+        )
     }
 }
 
@@ -1280,12 +1272,12 @@ impl Add<USizeVec4> for usize {
     type Output = USizeVec4;
     #[inline]
     fn add(self, rhs: USizeVec4) -> USizeVec4 {
-        USizeVec4 {
-            x: self.add(rhs.x),
-            y: self.add(rhs.y),
-            z: self.add(rhs.z),
-            w: self.add(rhs.w),
-        }
+        USizeVec4::new(
+            self.add(rhs.x),
+            self.add(rhs.y),
+            self.add(rhs.z),
+            self.add(rhs.w),
+        )
     }
 }
 
@@ -1317,12 +1309,12 @@ impl Sub for USizeVec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.sub(rhs.x),
-            y: self.y.sub(rhs.y),
-            z: self.z.sub(rhs.z),
-            w: self.w.sub(rhs.w),
-        }
+        Self::new(
+            self.x.sub(rhs.x),
+            self.y.sub(rhs.y),
+            self.z.sub(rhs.z),
+            self.w.sub(rhs.w),
+        )
     }
 }
 
@@ -1371,12 +1363,12 @@ impl Sub<usize> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn sub(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.sub(rhs),
-            y: self.y.sub(rhs),
-            z: self.z.sub(rhs),
-            w: self.w.sub(rhs),
-        }
+        Self::new(
+            self.x.sub(rhs),
+            self.y.sub(rhs),
+            self.z.sub(rhs),
+            self.w.sub(rhs),
+        )
     }
 }
 
@@ -1425,12 +1417,12 @@ impl Sub<USizeVec4> for usize {
     type Output = USizeVec4;
     #[inline]
     fn sub(self, rhs: USizeVec4) -> USizeVec4 {
-        USizeVec4 {
-            x: self.sub(rhs.x),
-            y: self.sub(rhs.y),
-            z: self.sub(rhs.z),
-            w: self.sub(rhs.w),
-        }
+        USizeVec4::new(
+            self.sub(rhs.x),
+            self.sub(rhs.y),
+            self.sub(rhs.z),
+            self.sub(rhs.w),
+        )
     }
 }
 
@@ -1462,12 +1454,12 @@ impl Rem for USizeVec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: Self) -> Self {
-        Self {
-            x: self.x.rem(rhs.x),
-            y: self.y.rem(rhs.y),
-            z: self.z.rem(rhs.z),
-            w: self.w.rem(rhs.w),
-        }
+        Self::new(
+            self.x.rem(rhs.x),
+            self.y.rem(rhs.y),
+            self.z.rem(rhs.z),
+            self.w.rem(rhs.w),
+        )
     }
 }
 
@@ -1516,12 +1508,12 @@ impl Rem<usize> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn rem(self, rhs: usize) -> Self {
-        Self {
-            x: self.x.rem(rhs),
-            y: self.y.rem(rhs),
-            z: self.z.rem(rhs),
-            w: self.w.rem(rhs),
-        }
+        Self::new(
+            self.x.rem(rhs),
+            self.y.rem(rhs),
+            self.z.rem(rhs),
+            self.w.rem(rhs),
+        )
     }
 }
 
@@ -1570,12 +1562,12 @@ impl Rem<USizeVec4> for usize {
     type Output = USizeVec4;
     #[inline]
     fn rem(self, rhs: USizeVec4) -> USizeVec4 {
-        USizeVec4 {
-            x: self.rem(rhs.x),
-            y: self.rem(rhs.y),
-            z: self.rem(rhs.z),
-            w: self.rem(rhs.w),
-        }
+        USizeVec4::new(
+            self.rem(rhs.x),
+            self.rem(rhs.y),
+            self.rem(rhs.z),
+            self.rem(rhs.w),
+        )
     }
 }
 
@@ -1661,12 +1653,7 @@ impl Not for USizeVec4 {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
-            x: self.x.not(),
-            y: self.y.not(),
-            z: self.z.not(),
-            w: self.w.not(),
-        }
+        Self::new(self.x.not(), self.y.not(), self.z.not(), self.w.not())
     }
 }
 
@@ -1682,12 +1669,12 @@ impl BitAnd for USizeVec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs.x),
-            y: self.y.bitand(rhs.y),
-            z: self.z.bitand(rhs.z),
-            w: self.w.bitand(rhs.w),
-        }
+        Self::new(
+            self.x.bitand(rhs.x),
+            self.y.bitand(rhs.y),
+            self.z.bitand(rhs.z),
+            self.w.bitand(rhs.w),
+        )
     }
 }
 
@@ -1733,12 +1720,12 @@ impl BitOr for USizeVec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs.x),
-            y: self.y.bitor(rhs.y),
-            z: self.z.bitor(rhs.z),
-            w: self.w.bitor(rhs.w),
-        }
+        Self::new(
+            self.x.bitor(rhs.x),
+            self.y.bitor(rhs.y),
+            self.z.bitor(rhs.z),
+            self.w.bitor(rhs.w),
+        )
     }
 }
 
@@ -1784,12 +1771,12 @@ impl BitXor for USizeVec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs.x),
-            y: self.y.bitxor(rhs.y),
-            z: self.z.bitxor(rhs.z),
-            w: self.w.bitxor(rhs.w),
-        }
+        Self::new(
+            self.x.bitxor(rhs.x),
+            self.y.bitxor(rhs.y),
+            self.z.bitxor(rhs.z),
+            self.w.bitxor(rhs.w),
+        )
     }
 }
 
@@ -1835,12 +1822,12 @@ impl BitAnd<usize> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: usize) -> Self::Output {
-        Self {
-            x: self.x.bitand(rhs),
-            y: self.y.bitand(rhs),
-            z: self.z.bitand(rhs),
-            w: self.w.bitand(rhs),
-        }
+        Self::new(
+            self.x.bitand(rhs),
+            self.y.bitand(rhs),
+            self.z.bitand(rhs),
+            self.w.bitand(rhs),
+        )
     }
 }
 
@@ -1886,12 +1873,12 @@ impl BitOr<usize> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: usize) -> Self::Output {
-        Self {
-            x: self.x.bitor(rhs),
-            y: self.y.bitor(rhs),
-            z: self.z.bitor(rhs),
-            w: self.w.bitor(rhs),
-        }
+        Self::new(
+            self.x.bitor(rhs),
+            self.y.bitor(rhs),
+            self.z.bitor(rhs),
+            self.w.bitor(rhs),
+        )
     }
 }
 
@@ -1937,12 +1924,12 @@ impl BitXor<usize> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: usize) -> Self::Output {
-        Self {
-            x: self.x.bitxor(rhs),
-            y: self.y.bitxor(rhs),
-            z: self.z.bitxor(rhs),
-            w: self.w.bitxor(rhs),
-        }
+        Self::new(
+            self.x.bitxor(rhs),
+            self.y.bitxor(rhs),
+            self.z.bitxor(rhs),
+            self.w.bitxor(rhs),
+        )
     }
 }
 
@@ -1988,12 +1975,12 @@ impl Shl<i8> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2039,12 +2026,12 @@ impl Shr<i8> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2090,12 +2077,12 @@ impl Shl<i16> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2141,12 +2128,12 @@ impl Shr<i16> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2192,12 +2179,12 @@ impl Shl<i32> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2243,12 +2230,12 @@ impl Shr<i32> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2294,12 +2281,12 @@ impl Shl<i64> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2345,12 +2332,12 @@ impl Shr<i64> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: i64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2396,12 +2383,12 @@ impl Shl<u8> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2447,12 +2434,12 @@ impl Shr<u8> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u8) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2498,12 +2485,12 @@ impl Shl<u16> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2549,12 +2536,12 @@ impl Shr<u16> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u16) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2600,12 +2587,12 @@ impl Shl<u32> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2651,12 +2638,12 @@ impl Shr<u32> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u32) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2702,12 +2689,12 @@ impl Shl<u64> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shl(rhs),
-            y: self.y.shl(rhs),
-            z: self.z.shl(rhs),
-            w: self.w.shl(rhs),
-        }
+        Self::new(
+            self.x.shl(rhs),
+            self.y.shl(rhs),
+            self.z.shl(rhs),
+            self.w.shl(rhs),
+        )
     }
 }
 
@@ -2753,12 +2740,12 @@ impl Shr<u64> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: u64) -> Self::Output {
-        Self {
-            x: self.x.shr(rhs),
-            y: self.y.shr(rhs),
-            z: self.z.shr(rhs),
-            w: self.w.shr(rhs),
-        }
+        Self::new(
+            self.x.shr(rhs),
+            self.y.shr(rhs),
+            self.z.shr(rhs),
+            self.w.shr(rhs),
+        )
     }
 }
 
@@ -2805,12 +2792,12 @@ impl Shl<IVec4> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -2846,12 +2833,12 @@ impl Shr<IVec4> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: IVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 
@@ -2887,12 +2874,12 @@ impl Shl<UVec4> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shl(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shl(rhs.x),
-            y: self.y.shl(rhs.y),
-            z: self.z.shl(rhs.z),
-            w: self.w.shl(rhs.w),
-        }
+        Self::new(
+            self.x.shl(rhs.x),
+            self.y.shl(rhs.y),
+            self.z.shl(rhs.z),
+            self.w.shl(rhs.w),
+        )
     }
 }
 
@@ -2928,12 +2915,12 @@ impl Shr<UVec4> for USizeVec4 {
     type Output = Self;
     #[inline]
     fn shr(self, rhs: UVec4) -> Self {
-        Self {
-            x: self.x.shr(rhs.x),
-            y: self.y.shr(rhs.y),
-            z: self.z.shr(rhs.z),
-            w: self.w.shr(rhs.w),
-        }
+        Self::new(
+            self.x.shr(rhs.x),
+            self.y.shr(rhs.y),
+            self.z.shr(rhs.z),
+            self.w.shr(rhs.w),
+        )
     }
 }
 

--- a/templates/affine.rs.tera
+++ b/templates/affine.rs.tera
@@ -90,7 +90,7 @@ use zerocopy_derive::*;
     derive(FromBytes, Immutable, KnownLayout))
 ]
 {%- elif self_t == "Affine3A" and is_scalar %}
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(all(feature = "zerocopy", not(feature = "core-simd")), derive(FromBytes, Immutable, KnownLayout))]
 #[cfg_attr(all(feature = "zerocopy", any(target_arch = "aarch64", target_feature = "sse2", target_feature = "simd128"), not(any(feature = "core-simd", feature = "scalar-math"))), derive(IntoBytes))]
 {%- else %}

--- a/templates/affine.rs.tera
+++ b/templates/affine.rs.tera
@@ -91,8 +91,7 @@ use zerocopy_derive::*;
 ]
 {%- elif self_t == "Affine3A" and is_scalar %}
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
-#[cfg_attr(all(feature = "zerocopy", not(feature = "core-simd")), derive(FromBytes, Immutable, KnownLayout))]
-#[cfg_attr(all(feature = "zerocopy", any(target_arch = "aarch64", target_feature = "sse2", target_feature = "simd128"), not(any(feature = "core-simd", feature = "scalar-math"))), derive(IntoBytes))]
+#[cfg_attr(all(feature = "zerocopy", not(feature = "core-simd")), derive(FromBytes, Immutable, IntoBytes, KnownLayout))]
 {%- else %}
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -192,16 +192,9 @@ pub const fn {{ self_t | lower }}(
 /// This type is 16 byte aligned.
 {%- endif %}
 #[derive(Clone, Copy)]
-{%- if self_t == "Mat3A" and is_scalar %}
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
-{%- if not is_coresimd %}
-#[cfg_attr(feature = "zerocopy", derive(FromBytes, Immutable, KnownLayout))]
-{%- endif %}
-{%- else %}
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 {%- if not is_coresimd %}
 #[cfg_attr(feature = "zerocopy", derive(FromBytes, Immutable, IntoBytes, KnownLayout))]
-{%- endif %}
 {%- endif %}
 {%- if self_t == "Mat4" and is_scalar %}
 #[cfg_attr(any(not(feature = "scalar-math"), feature = "cuda"), repr(align(16)))]

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -193,7 +193,7 @@ pub const fn {{ self_t | lower }}(
 {%- endif %}
 #[derive(Clone, Copy)]
 {%- if self_t == "Mat3A" and is_scalar %}
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 {%- if not is_coresimd %}
 #[cfg_attr(feature = "zerocopy", derive(FromBytes, Immutable, KnownLayout))]
 {%- endif %}

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -329,16 +329,9 @@ pub const fn {{ self_t | lower }}(
     Hash,
     {% endif %}
 )]
-{%- if self_t == "Vec3A" and is_scalar %}
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
-{%- if not is_coresimd %}
-#[cfg_attr(feature = "zerocopy", derive(FromBytes, Immutable, KnownLayout))]
-{%- endif %}
-{%- else %}
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 {%- if not is_coresimd %}
 #[cfg_attr(feature = "zerocopy", derive(FromBytes, Immutable, IntoBytes, KnownLayout))]
-{%- endif %}
 {%- endif %}
 {%- if self_t == "Vec3A" and is_scalar %}
 #[repr(align(16))]

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -321,16 +321,16 @@ pub const fn {{ self_t | lower }}(
 #[derive(
     Clone,
     Copy,
-    {% if is_scalar %}
+    {% if is_scalar and self_t != "Vec3A" %}
     PartialEq,
-    {% if not is_float %}
+    {% endif %}
+    {% if is_scalar and not is_float %}
     Eq,
     Hash,
     {% endif %}
-    {% endif %}
 )]
 {%- if self_t == "Vec3A" and is_scalar %}
-#[cfg_attr(feature = "bytemuck", derive(bytemuck::AnyBitPattern))]
+#[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 {%- if not is_coresimd %}
 #[cfg_attr(feature = "zerocopy", derive(FromBytes, Immutable, KnownLayout))]
 {%- endif %}
@@ -451,7 +451,7 @@ impl {{ self_t }} {
                     {{ c }},
                 {%- endfor %}
                 {%- if self_t == "Vec3A" %}
-                    _w: 0.0,
+                    _w: z,
                 {%- endif %}
             }
         {% elif is_sse2 %}
@@ -3493,6 +3493,13 @@ impl PartialEq for {{ self_t }} {
     #[inline]
     fn eq(&self, rhs: &Self) -> bool {
         self.cmpeq(*rhs).all()
+    }
+}
+{% elif self_t == "Vec3A" %}
+impl PartialEq for {{ self_t }} {
+    #[inline]
+    fn eq(&self, rhs: &Self) -> bool {
+        self.x == rhs.x && self.y == rhs.y && self.z == rhs.z
     }
 }
 {% endif %}

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -355,6 +355,9 @@ pub struct {{ self_t }}
     {% for c in components %}
         pub {{ c }}: {{ scalar_t }},
     {%- endfor %}
+    {%- if self_t == "Vec3A" %}
+        _w: f32,
+    {%- endif %}
 }
 {% else %}
 #[repr(transparent)]
@@ -447,6 +450,9 @@ impl {{ self_t }} {
                 {% for c in components %}
                     {{ c }},
                 {%- endfor %}
+                {%- if self_t == "Vec3A" %}
+                    _w: 0.0,
+                {%- endif %}
             }
         {% elif is_sse2 %}
             unsafe {
@@ -489,11 +495,11 @@ impl {{ self_t }} {
     #[must_use]
     pub const fn splat(v: {{ scalar_t }}) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: v,
+                    v,
                 {% endfor %}
-            }
+            )
         {% elif is_wasm %}
             Self(f32x4(v, v, v, v))
         {% elif is_coresimd %}
@@ -526,11 +532,11 @@ impl {{ self_t }} {
     #[must_use]
     pub fn select(mask: {{ mask_t }}, if_true: Self, if_false: Self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c  }}: if mask.test({{ loop.index0 }}) { if_true.{{ c }} } else { if_false.{{ c }} },
+                    if mask.test({{ loop.index0 }}) { if_true.{{ c }} } else { if_false.{{ c }} },
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_or_ps(_mm_andnot_ps(mask.0, if_false.0), _mm_and_ps(if_true.0, mask.0)) })
         {% elif is_wasm %}
@@ -618,7 +624,7 @@ impl {{ self_t }} {
     #[must_use]
     pub fn from_vec4(v: Vec4) -> Self {
         {% if is_scalar %}
-            Self { x: v.x, y: v.y, z: v.z }
+            Self::new(v.x, v.y, v.z)
         {% else %}
             Self(v.0)
         {% endif %}
@@ -630,7 +636,7 @@ impl {{ self_t }} {
     #[must_use]
     pub(crate) fn from_vec4(v: {{ vec4_t }}) -> Self {
         {% if is_scalar %}
-            Self { x: v.x, y: v.y, z: v.z }
+            Self::new(v.x, v.y, v.z)
         {% else %}
             Self(v.0)
         {% endif %}
@@ -783,11 +789,11 @@ impl {{ self_t }} {
     #[must_use]
     pub fn cross(self, rhs: Self) -> Self {
         {% if is_scalar %}
-            Self {
-                x: self.y * rhs.z - rhs.y * self.z,
-                y: self.z * rhs.x - rhs.z * self.x,
-                z: self.x * rhs.y - rhs.x * self.y,
-            }
+            Self::new(
+                self.y * rhs.z - rhs.y * self.z,
+                self.z * rhs.x - rhs.z * self.x,
+                self.x * rhs.y - rhs.x * self.y,
+            )
         {% elif is_sse2 %}
             unsafe {
                 // x  <-  a.y*b.z - a.z*b.y
@@ -858,11 +864,11 @@ impl {{ self_t }} {
     #[must_use]
     pub fn min(self, rhs: Self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: if self.{{ c }} < rhs.{{ c }} { self.{{ c }} } else { rhs.{{ c }} },
+                    if self.{{ c }} < rhs.{{ c }} { self.{{ c }} } else { rhs.{{ c }} },
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_min_ps(self.0, rhs.0) })
         {% elif is_wasm %}
@@ -888,11 +894,11 @@ impl {{ self_t }} {
     #[must_use]
     pub fn max(self, rhs: Self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: if self.{{ c }} > rhs.{{ c }} { self.{{ c }} } else { rhs.{{ c }} },
+                    if self.{{ c }} > rhs.{{ c }} { self.{{ c }} } else { rhs.{{ c }} },
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_max_ps(self.0, rhs.0) })
         {% elif is_wasm %}
@@ -1426,15 +1432,15 @@ impl {{ self_t }} {
     #[must_use]
     pub fn abs(self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
                     {%- if is_float %}
-                        {{ c }}: math::abs(self.{{ c }}),
+                        math::abs(self.{{ c }}),
                     {%- else %}
-                        {{ c }}: self.{{ c }}.abs(),
+                        self.{{ c }}.abs(),
                     {%- endif %}
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { crate::sse2::m128_abs(self.0) })
         {% elif is_wasm %}
@@ -1463,15 +1469,15 @@ impl {{ self_t }} {
     #[must_use]
     pub fn signum(self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
                     {%- if is_float %}
-                        {{ c }}: math::signum(self.{{ c }}),
+                        math::signum(self.{{ c }}),
                     {%- else %}
-                        {{ c }}: self.{{ c }}.signum(),
+                        self.{{ c }}.signum(),
                     {%- endif %}
                 {%- endfor %}
-            }
+            )
         {% elif is_coresimd %}
             Self(self.0.signum())
         {% elif is_sse2 %}
@@ -1504,11 +1510,11 @@ impl {{ self_t }} {
     #[must_use]
     pub fn copysign(self, rhs: Self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: math::copysign(self.{{ c }}, rhs.{{ c }}),
+                    math::copysign(self.{{ c }}, rhs.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_coresimd %}
             Self(self.0.copysign(rhs.0))
         {% elif is_sse2 %}
@@ -2016,11 +2022,11 @@ impl {{ self_t }} {
     #[must_use]
     pub fn round(self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: math::round(self.{{ c }}),
+                    math::round(self.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { m128_round(self.0) })
         {% elif is_wasm %}
@@ -2040,11 +2046,11 @@ impl {{ self_t }} {
     #[must_use]
     pub fn floor(self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: math::floor(self.{{ c }}),
+                    math::floor(self.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { m128_floor(self.0) })
         {% elif is_wasm %}
@@ -2064,11 +2070,11 @@ impl {{ self_t }} {
     #[must_use]
     pub fn ceil(self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: math::ceil(self.{{ c }}),
+                    math::ceil(self.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { m128_ceil(self.0) })
         {% elif is_wasm %}
@@ -2088,11 +2094,11 @@ impl {{ self_t }} {
     #[must_use]
     pub fn trunc(self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: math::trunc(self.{{ c }}),
+                    math::trunc(self.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { m128_trunc(self.0) })
         {% elif is_wasm %}
@@ -2265,11 +2271,11 @@ impl {{ self_t }} {
     #[must_use]
     pub fn recip(self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: 1.0 / self.{{ c }},
+                    1.0 / self.{{ c }},
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_div_ps(Self::ONE.0, self.0) })
         {% elif is_wasm %}
@@ -2464,10 +2470,7 @@ impl {{ self_t }} {
     #[must_use]
     pub fn from_angle(angle: {{ scalar_t }}) -> Self {
         let (sin, cos) = math::sin_cos(angle);
-        Self {
-            x: cos,
-            y: sin,
-        }
+        Self::new(cos, sin)
     }
 
     /// Returns the angle (in radians) of this vector in the range `[-π, +π]`.
@@ -2772,10 +2775,7 @@ impl {{ self_t }} {
     #[inline]
     #[must_use]
     pub fn perp(self) -> Self {
-        Self {
-            x: -self.y,
-            y: self.x,
-        }
+        Self::new(-self.y, self.x)
     }
 
     /// The perpendicular dot product of `self` and `rhs`.
@@ -2805,10 +2805,10 @@ impl {{ self_t }} {
     #[inline]
     #[must_use]
     pub fn rotate(self, rhs: Self) -> Self {
-        Self {
-            x: self.x * rhs.x - self.y * rhs.y,
-            y: self.y * rhs.x + self.x * rhs.y,
-        }
+        Self::new(
+            self.x * rhs.x - self.y * rhs.y,
+            self.y * rhs.x + self.x * rhs.y,
+        )
     }
 {% endif %}
 
@@ -3502,11 +3502,11 @@ impl Div for {{ self_t }} {
     #[inline]
     fn div(self, rhs: Self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.div(rhs.{{ c }}),
+                    self.{{ c }}.div(rhs.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_div_ps(self.0, rhs.0) })
         {% elif is_wasm %}
@@ -3551,11 +3551,11 @@ impl Div<{{ scalar_t }}> for {{ self_t }} {
     #[inline]
     fn div(self, rhs: {{ scalar_t }}) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.div(rhs),
+                    self.{{ c }}.div(rhs),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_div_ps(self.0, _mm_set1_ps(rhs)) })
         {% elif is_wasm %}
@@ -3600,11 +3600,11 @@ impl Div<{{ self_t }}> for {{ scalar_t }} {
     #[inline]
     fn div(self, rhs: {{ self_t }}) -> {{ self_t }} {
         {% if is_scalar %}
-            {{ self_t }} {
+            {{ self_t }}::new(
                 {% for c in components %}
-                    {{ c }}: self.div(rhs.{{ c }}),
+                    self.div(rhs.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             {{ self_t }}(unsafe { _mm_div_ps(_mm_set1_ps(self), rhs.0) })
         {% elif is_wasm %}
@@ -3626,11 +3626,11 @@ impl Mul for {{ self_t }} {
     #[inline]
     fn mul(self, rhs: Self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.mul(rhs.{{ c }}),
+                    self.{{ c }}.mul(rhs.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_mul_ps(self.0, rhs.0) })
         {% elif is_wasm %}
@@ -3675,11 +3675,11 @@ impl Mul<{{ scalar_t }}> for {{ self_t }} {
     #[inline]
     fn mul(self, rhs: {{ scalar_t }}) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.mul(rhs),
+                    self.{{ c }}.mul(rhs),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_mul_ps(self.0, _mm_set1_ps(rhs)) })
         {% elif is_wasm %}
@@ -3724,11 +3724,11 @@ impl Mul<{{ self_t }}> for {{ scalar_t }} {
     #[inline]
     fn mul(self, rhs: {{ self_t }}) -> {{ self_t }} {
         {% if is_scalar %}
-            {{ self_t }} {
+            {{ self_t }}::new(
                 {% for c in components %}
-                    {{ c }}: self.mul(rhs.{{ c }}),
+                    self.mul(rhs.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             {{ self_t }}(unsafe { _mm_mul_ps(_mm_set1_ps(self), rhs.0) })
         {% elif is_wasm %}
@@ -3750,11 +3750,11 @@ impl Add for {{ self_t }} {
     #[inline]
     fn add(self, rhs: Self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.add(rhs.{{ c }}),
+                    self.{{ c }}.add(rhs.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_add_ps(self.0, rhs.0) })
         {% elif is_wasm %}
@@ -3799,11 +3799,11 @@ impl Add<{{ scalar_t }}> for {{ self_t }} {
     #[inline]
     fn add(self, rhs: {{ scalar_t }}) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.add(rhs),
+                    self.{{ c }}.add(rhs),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_add_ps(self.0, _mm_set1_ps(rhs)) })
         {% elif is_wasm %}
@@ -3848,11 +3848,11 @@ impl Add<{{ self_t }}> for {{ scalar_t }} {
     #[inline]
     fn add(self, rhs: {{ self_t }}) -> {{ self_t }} {
         {% if is_scalar %}
-            {{ self_t }} {
+            {{ self_t }}::new(
                 {% for c in components %}
-                    {{ c }}: self.add(rhs.{{ c }}),
+                    self.add(rhs.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             {{ self_t }}(unsafe { _mm_add_ps(_mm_set1_ps(self), rhs.0) })
         {% elif is_wasm %}
@@ -3874,11 +3874,11 @@ impl Sub for {{ self_t }} {
     #[inline]
     fn sub(self, rhs: Self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.sub(rhs.{{ c }}),
+                    self.{{ c }}.sub(rhs.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_sub_ps(self.0, rhs.0) })
         {% elif is_wasm %}
@@ -3923,11 +3923,11 @@ impl Sub<{{ scalar_t }}> for {{ self_t }} {
     #[inline]
     fn sub(self, rhs: {{ scalar_t }}) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.sub(rhs),
+                    self.{{ c }}.sub(rhs),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_sub_ps(self.0, _mm_set1_ps(rhs)) })
         {% elif is_wasm %}
@@ -3972,11 +3972,11 @@ impl Sub<{{ self_t }}> for {{ scalar_t }} {
     #[inline]
     fn sub(self, rhs: {{ self_t }}) -> {{ self_t }} {
         {% if is_scalar %}
-            {{ self_t }} {
+            {{ self_t }}::new(
                 {% for c in components %}
-                    {{ c }}: self.sub(rhs.{{ c }}),
+                    self.sub(rhs.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             {{ self_t }}(unsafe { _mm_sub_ps(_mm_set1_ps(self), rhs.0) })
         {% elif is_wasm %}
@@ -3998,11 +3998,11 @@ impl Rem for {{ self_t }} {
     #[inline]
     fn rem(self, rhs: Self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.rem(rhs.{{ c }}),
+                    self.{{ c }}.rem(rhs.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             unsafe {
                 let n = m128_floor(_mm_div_ps(self.0, rhs.0));
@@ -4048,11 +4048,11 @@ impl Rem<{{ scalar_t }}> for {{ self_t }} {
     #[inline]
     fn rem(self, rhs: {{ scalar_t }}) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.rem(rhs),
+                    self.{{ c }}.rem(rhs),
                 {%- endfor %}
-            }
+            )
         {% else %}
             self.rem(Self::splat(rhs))
         {% endif %}
@@ -4083,11 +4083,11 @@ impl Rem<{{ self_t }}> for {{ scalar_t }} {
     #[inline]
     fn rem(self, rhs: {{ self_t }}) -> {{ self_t }} {
         {% if is_scalar %}
-            {{ self_t }} {
+            {{ self_t }}::new(
                 {% for c in components %}
-                    {{ c }}: self.rem(rhs.{{ c }}),
+                    self.rem(rhs.{{ c }}),
                 {%- endfor %}
-            }
+            )
         {% else %}
             {{ self_t }}::splat(self).rem(rhs)
         {% endif %}
@@ -4156,11 +4156,11 @@ impl Neg for {{ self_t }} {
     #[inline]
     fn neg(self) -> Self {
         {% if is_scalar %}
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.neg(),
+                    self.{{ c }}.neg(),
                 {%- endfor %}
-            }
+            )
         {% elif is_sse2 %}
             Self(unsafe { _mm_xor_ps(_mm_set1_ps(-0.0), self.0) })
         {% elif is_wasm %}
@@ -4183,11 +4183,11 @@ impl Not for {{ self_t }} {
     type Output = Self;
     #[inline]
     fn not(self) -> Self {
-        Self {
+        Self::new(
             {% for c in components %}
-                {{ c }}: self.{{ c }}.not(),
+                self.{{ c }}.not(),
             {%- endfor %}
-        }
+        )
     }
 }
 
@@ -4197,11 +4197,11 @@ impl BitAnd for {{ self_t }} {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: Self) -> Self::Output {
-        Self {
+        Self::new(
             {% for c in components %}
-                {{ c }}: self.{{ c }}.bitand(rhs.{{ c }}),
+                self.{{ c }}.bitand(rhs.{{ c }}),
             {%- endfor %}
-        }
+        )
     }
 }
 
@@ -4213,11 +4213,11 @@ impl BitOr for {{ self_t }} {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: Self) -> Self::Output {
-        Self {
+        Self::new(
             {% for c in components %}
-                {{ c }}: self.{{ c }}.bitor(rhs.{{ c }}),
+                self.{{ c }}.bitor(rhs.{{ c }}),
             {%- endfor %}
-        }
+        )
     }
 }
 
@@ -4229,11 +4229,11 @@ impl BitXor for {{ self_t }} {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: Self) -> Self::Output {
-        Self {
+        Self::new(
             {% for c in components %}
-                {{ c }}: self.{{ c }}.bitxor(rhs.{{ c }}),
+                self.{{ c }}.bitxor(rhs.{{ c }}),
             {%- endfor %}
-        }
+        )
     }
 }
 
@@ -4245,11 +4245,11 @@ impl BitAnd<{{ scalar_t }}> for {{ self_t }} {
     type Output = Self;
     #[inline]
     fn bitand(self, rhs: {{ scalar_t }}) -> Self::Output {
-        Self {
+        Self::new(
             {% for c in components %}
-                {{ c }}: self.{{ c }}.bitand(rhs),
+                self.{{ c }}.bitand(rhs),
             {%- endfor %}
-        }
+        )
     }
 }
 
@@ -4261,11 +4261,11 @@ impl BitOr<{{ scalar_t }}> for {{ self_t }} {
     type Output = Self;
     #[inline]
     fn bitor(self, rhs: {{ scalar_t }}) -> Self::Output {
-        Self {
+        Self::new(
             {% for c in components %}
-                {{ c }}: self.{{ c }}.bitor(rhs),
+                self.{{ c }}.bitor(rhs),
             {%- endfor %}
-        }
+        )
     }
 }
 
@@ -4277,11 +4277,11 @@ impl BitXor<{{ scalar_t }}> for {{ self_t }} {
     type Output = Self;
     #[inline]
     fn bitxor(self, rhs: {{ scalar_t }}) -> Self::Output {
-        Self {
+        Self::new(
             {% for c in components %}
-                {{ c }}: self.{{ c }}.bitxor(rhs),
+                self.{{ c }}.bitxor(rhs),
             {%- endfor %}
-        }
+        )
     }
 }
 
@@ -4294,11 +4294,11 @@ impl BitXor<{{ scalar_t }}> for {{ self_t }} {
         type Output = Self;
         #[inline]
         fn shl(self, rhs: {{ rhs_t }}) -> Self::Output {
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.shl(rhs),
+                    self.{{ c }}.shl(rhs),
                 {%- endfor %}
-            }
+            )
         }
     }
 
@@ -4310,11 +4310,11 @@ impl BitXor<{{ scalar_t }}> for {{ self_t }} {
         type Output = Self;
         #[inline]
         fn shr(self, rhs: {{ rhs_t }}) -> Self::Output {
-            Self {
+            Self::new(
                 {% for c in components %}
-                    {{ c }}: self.{{ c }}.shr(rhs),
+                    self.{{ c }}.shr(rhs),
                 {%- endfor %}
-            }
+            )
         }
     }
 
@@ -4331,11 +4331,11 @@ impl BitXor<{{ scalar_t }}> for {{ self_t }} {
             type Output = Self;
             #[inline]
             fn shl(self, rhs: {% if rhs_t != self_t %}{{ rhs_t }}{% else %}Self{% endif %}) -> Self {
-                Self {
+                Self::new(
                     {% for c in components %}
-                        {{ c }}: self.{{ c }}.shl(rhs.{{ c }}),
+                        self.{{ c }}.shl(rhs.{{ c }}),
                     {%- endfor %}
-                }
+                )
             }
         }
 
@@ -4348,11 +4348,11 @@ impl BitXor<{{ scalar_t }}> for {{ self_t }} {
             type Output = Self;
             #[inline]
             fn shr(self, rhs: {% if rhs_t != self_t %}{{ rhs_t }}{% else %}Self{% endif %}) -> Self {
-                Self {
+                Self::new(
                     {% for c in components %}
-                        {{ c }}: self.{{ c }}.shr(rhs.{{ c }}),
+                        self.{{ c }}.shr(rhs.{{ c }}),
                     {%- endfor %}
-                }
+                )
             }
         }
 
@@ -4541,11 +4541,7 @@ impl From<Vec3A> for Vec3 {
     #[inline]
     fn from(v: Vec3A) -> Self {
         {% if is_scalar %}
-            Self {
-                x: v.x,
-                y: v.y,
-                z: v.z,
-            }
+            Self::new(v.x, v.y, v.z)
         {% elif is_sse2 %}
             use crate::Align16;
             use core::mem::MaybeUninit;


### PR DESCRIPTION
Fixes #122

## Problem

`Vec3A` is a 16-byte aligned type containing three `f32`s, so its scalar
(`scalar-math`, and the no-SIMD fallback) representation has 4 bytes of
trailing padding. That padding is uninitialized, so bytemuck could only derive
`AnyBitPattern` for scalar `Vec3A` (and `Mat3A`/`Affine3A`), not `Pod` +
`Zeroable`. The SIMD backends don't have this problem because their fourth
lane is a real value (`new` stores `[x, y, z, z]`).

## Change

Add an explicit `_w: f32` padding field to scalar `Vec3A`, initialized to `z`
to mirror the SIMD backends' `[x, y, z, z]` storage. This means every byte is
now initialized, which unlocks:

- `bytemuck::Pod` + `Zeroable` for scalar `Vec3A`, `Mat3A`, and `Affine3A`
  (`NoUninit` and `AnyBitPattern` come along automatically via bytemuck's
  blanket impls).
- `zerocopy::IntoBytes` for the same types (previously only
  `FromBytes`/`Immutable`/`KnownLayout`).

Scalar `Vec3A` now implements `PartialEq` manually so `_w` is ignored.

## Performance

The only added work in the materializing path is a single store that defines
the padding lane. When the result is inlined and only `x`/`y`/`z` are read,
that store is dead-code eliminated and the generated code is unchanged.

Probe:

```rust
#![allow(improper_ctypes_definitions)]
use glam::Vec3A;

#[no_mangle]
pub extern "C" fn probe_vec3a_add(a: Vec3A, b: Vec3A) -> Vec3A { a + b }

#[no_mangle]
pub extern "C" fn probe_vec3a_add_sum(a: Vec3A, b: Vec3A) -> f32 {
    let r = a + b;
    r.x + r.y + r.z
}
```

`probe_vec3a_add` before (`a867ca86`):

```asm
addss   xmm1, xmm3
addps   xmm0, xmm2
movss   dword ptr [rsp - 8], xmm1
movsd   xmm1, qword ptr [rsp - 8]   ; upper 4 bytes are uninitialized padding
ret
```

`probe_vec3a_add` after (`b465490b`):

```asm
addss   xmm3, xmm1
addps   xmm0, xmm2
movss   dword ptr [rsp - 8], xmm3
movss   dword ptr [rsp - 4], xmm3   ; <-- only new instruction: padding = z
movsd   xmm1, qword ptr [rsp - 8]
ret
```

`probe_vec3a_add_sum` is byte-for-byte identical before and after. The padding
store is eliminated because the value never escapes with its padding observed:

```asm
movaps  xmm4, xmm0
movlhps xmm4, xmm1
shufps  xmm4, xmm4, 232
movaps  xmm1, xmm2
movlhps xmm1, xmm3
psrlq   xmm0, 32
shufps  xmm1, xmm1, 232
addps   xmm1, xmm4
shufps  xmm2, xmm2, 85
addss   xmm0, xmm2
addss   xmm0, xmm1
shufps  xmm1, xmm1, 85
addss   xmm0, xmm1
ret
```

Reproduce with:

```sh
cargo rustc --release --example asm_probe --features scalar-math -- --emit asm -C llvm-args=--x86-asm-syntax=intel
```
