### PR TITLE
feat(mat): add row constructors and set_row to the matrix types

### DIFF
--- a/src/f32/coresimd/mat2.rs
+++ b/src/f32/coresimd/mat2.rs
@@ -51,6 +51,19 @@ impl Mat2 {
         Self(f32x4::from_array([x_axis.x, x_axis.y, y_axis.x, y_axis.y]))
     }
 
+    /// Creates a 2x2 matrix from two row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec2, row1: Vec2) -> Self {
+        let [m00, m01] = row0.to_array();
+        let [m10, m11] = row1.to_array();
+        Self::new(m00, m10, m01, m11)
+    }
+
     /// Creates a 2x2 matrix from a `[f32; 4]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -83,6 +96,28 @@ impl Mat2 {
     #[must_use]
     pub const fn to_cols_array_2d(&self) -> [[f32; 2]; 2] {
         unsafe { *(self as *const Self as *const [[f32; 2]; 2]) }
+    }
+
+    /// Creates a 2x2 matrix from a `[f32; 4]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 4]) -> Self {
+        Self::new(m[0], m[2], m[1], m[3])
+    }
+
+    /// Creates a `[f32; 4]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 4] {
+        let m = self.to_cols_array();
+        [m[0], m[2], m[1], m[3]]
     }
 
     /// Creates a 2x2 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -194,6 +229,22 @@ impl Mat2 {
         slice[3] = self.y_axis.y;
     }
 
+    /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 4 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(slice[0], slice[2], slice[1], slice[3])
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -234,6 +285,30 @@ impl Mat2 {
         match index {
             0 => Vec2::new(self.x_axis.x, self.y_axis.x),
             1 => Vec2::new(self.x_axis.y, self.y_axis.y),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 2 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 1.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec2) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/coresimd/mat2.rs
+++ b/src/f32/coresimd/mat2.rs
@@ -53,7 +53,7 @@ impl Mat2 {
 
     /// Creates a 2x2 matrix from two row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -100,7 +100,7 @@ impl Mat2 {
 
     /// Creates a 2x2 matrix from a `[f32; 4]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -111,7 +111,7 @@ impl Mat2 {
 
     /// Creates a `[f32; 4]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -232,7 +232,7 @@ impl Mat2 {
     /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -291,7 +291,7 @@ impl Mat2 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 2 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -99,7 +99,7 @@ impl Mat3A {
 
     /// Creates a 3x3 matrix from three row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -162,7 +162,7 @@ impl Mat3A {
 
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -173,7 +173,7 @@ impl Mat3A {
 
     /// Creates a `[f32; 9]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -527,7 +527,7 @@ impl Mat3A {
     /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -592,7 +592,7 @@ impl Mat3A {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 3 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -97,6 +97,20 @@ impl Mat3A {
         }
     }
 
+    /// Creates a 3x3 matrix from three row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec3A, row1: Vec3A, row2: Vec3A) -> Self {
+        let [m00, m01, m02] = row0.to_array();
+        let [m10, m11, m12] = row1.to_array();
+        let [m20, m21, m22] = row2.to_array();
+        Self::new(m00, m10, m20, m01, m11, m21, m02, m12, m22)
+    }
+
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -144,6 +158,28 @@ impl Mat3A {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
         ]
+    }
+
+    /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 9]) -> Self {
+        Self::new(m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8])
+    }
+
+    /// Creates a `[f32; 9]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 9] {
+        let m = self.to_cols_array();
+        [m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]]
     }
 
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -488,6 +524,25 @@ impl Mat3A {
         slice[8] = self.z_axis.z;
     }
 
+    /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 9 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(
+            slice[0], slice[3], slice[6], slice[1], slice[4], slice[7], slice[2], slice[5],
+            slice[8],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -531,6 +586,37 @@ impl Mat3A {
             0 => Vec3A::new(self.x_axis.x, self.y_axis.x, self.z_axis.x),
             1 => Vec3A::new(self.x_axis.y, self.y_axis.y, self.z_axis.y),
             2 => Vec3A::new(self.x_axis.z, self.y_axis.z, self.z_axis.z),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 3 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 2.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec3A) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -99,6 +99,23 @@ impl Mat4 {
         }
     }
 
+    /// Creates a 4x4 matrix from four row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec4, row1: Vec4, row2: Vec4, row3: Vec4) -> Self {
+        let [m00, m01, m02, m03] = row0.to_array();
+        let [m10, m11, m12, m13] = row1.to_array();
+        let [m20, m21, m22, m23] = row2.to_array();
+        let [m30, m31, m32, m33] = row3.to_array();
+        Self::new(
+            m00, m10, m20, m30, m01, m11, m21, m31, m02, m12, m22, m32, m03, m13, m23, m33,
+        )
+    }
+
     /// Creates a 4x4 matrix from a `[f32; 16]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -151,6 +168,34 @@ impl Mat4 {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
             self.w_axis.to_array(),
+        ]
+    }
+
+    /// Creates a 4x4 matrix from a `[f32; 16]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 16]) -> Self {
+        Self::new(
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
+        )
+    }
+
+    /// Creates a `[f32; 16]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 16] {
+        let m = self.to_cols_array();
+        [
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
         ]
     }
 
@@ -525,6 +570,25 @@ impl Mat4 {
         slice[15] = self.w_axis.w;
     }
 
+    /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 16 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(
+            slice[0], slice[4], slice[8], slice[12], slice[1], slice[5], slice[9], slice[13],
+            slice[2], slice[6], slice[10], slice[14], slice[3], slice[7], slice[11], slice[15],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -571,6 +635,46 @@ impl Mat4 {
             1 => Vec4::new(self.x_axis.y, self.y_axis.y, self.z_axis.y, self.w_axis.y),
             2 => Vec4::new(self.x_axis.z, self.y_axis.z, self.z_axis.z, self.w_axis.z),
             3 => Vec4::new(self.x_axis.w, self.y_axis.w, self.z_axis.w, self.w_axis.w),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 4 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 3.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec4) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+                self.w_axis.x = row.w;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+                self.w_axis.y = row.w;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+                self.w_axis.z = row.w;
+            }
+            3 => {
+                self.x_axis.w = row.x;
+                self.y_axis.w = row.y;
+                self.z_axis.w = row.z;
+                self.w_axis.w = row.w;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -101,7 +101,7 @@ impl Mat4 {
 
     /// Creates a 4x4 matrix from four row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -173,7 +173,7 @@ impl Mat4 {
 
     /// Creates a 4x4 matrix from a `[f32; 16]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -187,7 +187,7 @@ impl Mat4 {
 
     /// Creates a `[f32; 16]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -573,7 +573,7 @@ impl Mat4 {
     /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -641,7 +641,7 @@ impl Mat4 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 4 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -102,6 +102,20 @@ impl Mat3 {
         }
     }
 
+    /// Creates a 3x3 matrix from three row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec3, row1: Vec3, row2: Vec3) -> Self {
+        let [m00, m01, m02] = row0.to_array();
+        let [m10, m11, m12] = row1.to_array();
+        let [m20, m21, m22] = row2.to_array();
+        Self::new(m00, m10, m20, m01, m11, m21, m02, m12, m22)
+    }
+
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -152,6 +166,28 @@ impl Mat3 {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
         ]
+    }
+
+    /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 9]) -> Self {
+        Self::new(m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8])
+    }
+
+    /// Creates a `[f32; 9]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 9] {
+        let m = self.to_cols_array();
+        [m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]]
     }
 
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -428,6 +464,25 @@ impl Mat3 {
         slice[8] = self.z_axis.z;
     }
 
+    /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 9 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(
+            slice[0], slice[3], slice[6], slice[1], slice[4], slice[7], slice[2], slice[5],
+            slice[8],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -471,6 +526,37 @@ impl Mat3 {
             0 => Vec3::new(self.x_axis.x, self.y_axis.x, self.z_axis.x),
             1 => Vec3::new(self.x_axis.y, self.y_axis.y, self.z_axis.y),
             2 => Vec3::new(self.x_axis.z, self.y_axis.z, self.z_axis.z),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 3 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 2.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec3) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -104,7 +104,7 @@ impl Mat3 {
 
     /// Creates a 3x3 matrix from three row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -170,7 +170,7 @@ impl Mat3 {
 
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -181,7 +181,7 @@ impl Mat3 {
 
     /// Creates a `[f32; 9]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -467,7 +467,7 @@ impl Mat3 {
     /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -532,7 +532,7 @@ impl Mat3 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 3 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/neon/mat2.rs
+++ b/src/f32/neon/mat2.rs
@@ -74,6 +74,19 @@ impl Mat2 {
         }
     }
 
+    /// Creates a 2x2 matrix from two row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec2, row1: Vec2) -> Self {
+        let [m00, m01] = row0.to_array();
+        let [m10, m11] = row1.to_array();
+        Self::new(m00, m10, m01, m11)
+    }
+
     /// Creates a 2x2 matrix from a `[f32; 4]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -106,6 +119,28 @@ impl Mat2 {
     #[must_use]
     pub const fn to_cols_array_2d(&self) -> [[f32; 2]; 2] {
         unsafe { *(self as *const Self as *const [[f32; 2]; 2]) }
+    }
+
+    /// Creates a 2x2 matrix from a `[f32; 4]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 4]) -> Self {
+        Self::new(m[0], m[2], m[1], m[3])
+    }
+
+    /// Creates a `[f32; 4]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 4] {
+        let m = self.to_cols_array();
+        [m[0], m[2], m[1], m[3]]
     }
 
     /// Creates a 2x2 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -217,6 +252,22 @@ impl Mat2 {
         slice[3] = self.y_axis.y;
     }
 
+    /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 4 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(slice[0], slice[2], slice[1], slice[3])
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -257,6 +308,30 @@ impl Mat2 {
         match index {
             0 => Vec2::new(self.x_axis.x, self.y_axis.x),
             1 => Vec2::new(self.x_axis.y, self.y_axis.y),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 2 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 1.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec2) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/neon/mat2.rs
+++ b/src/f32/neon/mat2.rs
@@ -76,7 +76,7 @@ impl Mat2 {
 
     /// Creates a 2x2 matrix from two row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -123,7 +123,7 @@ impl Mat2 {
 
     /// Creates a 2x2 matrix from a `[f32; 4]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -134,7 +134,7 @@ impl Mat2 {
 
     /// Creates a `[f32; 4]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -255,7 +255,7 @@ impl Mat2 {
     /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -314,7 +314,7 @@ impl Mat2 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 2 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/neon/mat3a.rs
+++ b/src/f32/neon/mat3a.rs
@@ -106,7 +106,7 @@ impl Mat3A {
 
     /// Creates a 3x3 matrix from three row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -169,7 +169,7 @@ impl Mat3A {
 
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -180,7 +180,7 @@ impl Mat3A {
 
     /// Creates a `[f32; 9]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -534,7 +534,7 @@ impl Mat3A {
     /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -599,7 +599,7 @@ impl Mat3A {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 3 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/neon/mat3a.rs
+++ b/src/f32/neon/mat3a.rs
@@ -104,6 +104,20 @@ impl Mat3A {
         }
     }
 
+    /// Creates a 3x3 matrix from three row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec3A, row1: Vec3A, row2: Vec3A) -> Self {
+        let [m00, m01, m02] = row0.to_array();
+        let [m10, m11, m12] = row1.to_array();
+        let [m20, m21, m22] = row2.to_array();
+        Self::new(m00, m10, m20, m01, m11, m21, m02, m12, m22)
+    }
+
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -151,6 +165,28 @@ impl Mat3A {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
         ]
+    }
+
+    /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 9]) -> Self {
+        Self::new(m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8])
+    }
+
+    /// Creates a `[f32; 9]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 9] {
+        let m = self.to_cols_array();
+        [m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]]
     }
 
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -495,6 +531,25 @@ impl Mat3A {
         slice[8] = self.z_axis.z;
     }
 
+    /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 9 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(
+            slice[0], slice[3], slice[6], slice[1], slice[4], slice[7], slice[2], slice[5],
+            slice[8],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -538,6 +593,37 @@ impl Mat3A {
             0 => Vec3A::new(self.x_axis.x, self.y_axis.x, self.z_axis.x),
             1 => Vec3A::new(self.x_axis.y, self.y_axis.y, self.z_axis.y),
             2 => Vec3A::new(self.x_axis.z, self.y_axis.z, self.z_axis.z),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 3 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 2.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec3A) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -106,6 +106,23 @@ impl Mat4 {
         }
     }
 
+    /// Creates a 4x4 matrix from four row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec4, row1: Vec4, row2: Vec4, row3: Vec4) -> Self {
+        let [m00, m01, m02, m03] = row0.to_array();
+        let [m10, m11, m12, m13] = row1.to_array();
+        let [m20, m21, m22, m23] = row2.to_array();
+        let [m30, m31, m32, m33] = row3.to_array();
+        Self::new(
+            m00, m10, m20, m30, m01, m11, m21, m31, m02, m12, m22, m32, m03, m13, m23, m33,
+        )
+    }
+
     /// Creates a 4x4 matrix from a `[f32; 16]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -158,6 +175,34 @@ impl Mat4 {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
             self.w_axis.to_array(),
+        ]
+    }
+
+    /// Creates a 4x4 matrix from a `[f32; 16]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 16]) -> Self {
+        Self::new(
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
+        )
+    }
+
+    /// Creates a `[f32; 16]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 16] {
+        let m = self.to_cols_array();
+        [
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
         ]
     }
 
@@ -532,6 +577,25 @@ impl Mat4 {
         slice[15] = self.w_axis.w;
     }
 
+    /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 16 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(
+            slice[0], slice[4], slice[8], slice[12], slice[1], slice[5], slice[9], slice[13],
+            slice[2], slice[6], slice[10], slice[14], slice[3], slice[7], slice[11], slice[15],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -578,6 +642,46 @@ impl Mat4 {
             1 => Vec4::new(self.x_axis.y, self.y_axis.y, self.z_axis.y, self.w_axis.y),
             2 => Vec4::new(self.x_axis.z, self.y_axis.z, self.z_axis.z, self.w_axis.z),
             3 => Vec4::new(self.x_axis.w, self.y_axis.w, self.z_axis.w, self.w_axis.w),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 4 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 3.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec4) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+                self.w_axis.x = row.w;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+                self.w_axis.y = row.w;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+                self.w_axis.z = row.w;
+            }
+            3 => {
+                self.x_axis.w = row.x;
+                self.y_axis.w = row.y;
+                self.z_axis.w = row.z;
+                self.w_axis.w = row.w;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -108,7 +108,7 @@ impl Mat4 {
 
     /// Creates a 4x4 matrix from four row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -180,7 +180,7 @@ impl Mat4 {
 
     /// Creates a 4x4 matrix from a `[f32; 16]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -194,7 +194,7 @@ impl Mat4 {
 
     /// Creates a `[f32; 16]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -580,7 +580,7 @@ impl Mat4 {
     /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -648,7 +648,7 @@ impl Mat4 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 4 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/scalar/mat2.rs
+++ b/src/f32/scalar/mat2.rs
@@ -60,6 +60,19 @@ impl Mat2 {
         Self { x_axis, y_axis }
     }
 
+    /// Creates a 2x2 matrix from two row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec2, row1: Vec2) -> Self {
+        let [m00, m01] = row0.to_array();
+        let [m10, m11] = row1.to_array();
+        Self::new(m00, m10, m01, m11)
+    }
+
     /// Creates a 2x2 matrix from a `[f32; 4]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -92,6 +105,28 @@ impl Mat2 {
     #[must_use]
     pub const fn to_cols_array_2d(&self) -> [[f32; 2]; 2] {
         [self.x_axis.to_array(), self.y_axis.to_array()]
+    }
+
+    /// Creates a 2x2 matrix from a `[f32; 4]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 4]) -> Self {
+        Self::new(m[0], m[2], m[1], m[3])
+    }
+
+    /// Creates a `[f32; 4]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 4] {
+        let m = self.to_cols_array();
+        [m[0], m[2], m[1], m[3]]
     }
 
     /// Creates a 2x2 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -203,6 +238,22 @@ impl Mat2 {
         slice[3] = self.y_axis.y;
     }
 
+    /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 4 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(slice[0], slice[2], slice[1], slice[3])
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -243,6 +294,30 @@ impl Mat2 {
         match index {
             0 => Vec2::new(self.x_axis.x, self.y_axis.x),
             1 => Vec2::new(self.x_axis.y, self.y_axis.y),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 2 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 1.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec2) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/scalar/mat2.rs
+++ b/src/f32/scalar/mat2.rs
@@ -62,7 +62,7 @@ impl Mat2 {
 
     /// Creates a 2x2 matrix from two row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -109,7 +109,7 @@ impl Mat2 {
 
     /// Creates a 2x2 matrix from a `[f32; 4]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -120,7 +120,7 @@ impl Mat2 {
 
     /// Creates a `[f32; 4]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -241,7 +241,7 @@ impl Mat2 {
     /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -300,7 +300,7 @@ impl Mat2 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 2 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -102,6 +102,20 @@ impl Mat3A {
         }
     }
 
+    /// Creates a 3x3 matrix from three row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec3A, row1: Vec3A, row2: Vec3A) -> Self {
+        let [m00, m01, m02] = row0.to_array();
+        let [m10, m11, m12] = row1.to_array();
+        let [m20, m21, m22] = row2.to_array();
+        Self::new(m00, m10, m20, m01, m11, m21, m02, m12, m22)
+    }
+
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -152,6 +166,28 @@ impl Mat3A {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
         ]
+    }
+
+    /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 9]) -> Self {
+        Self::new(m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8])
+    }
+
+    /// Creates a `[f32; 9]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 9] {
+        let m = self.to_cols_array();
+        [m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]]
     }
 
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -496,6 +532,25 @@ impl Mat3A {
         slice[8] = self.z_axis.z;
     }
 
+    /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 9 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(
+            slice[0], slice[3], slice[6], slice[1], slice[4], slice[7], slice[2], slice[5],
+            slice[8],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -539,6 +594,37 @@ impl Mat3A {
             0 => Vec3A::new(self.x_axis.x, self.y_axis.x, self.z_axis.x),
             1 => Vec3A::new(self.x_axis.y, self.y_axis.y, self.z_axis.y),
             2 => Vec3A::new(self.x_axis.z, self.y_axis.z, self.z_axis.z),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 3 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 2.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec3A) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -104,7 +104,7 @@ impl Mat3A {
 
     /// Creates a 3x3 matrix from three row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -170,7 +170,7 @@ impl Mat3A {
 
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -181,7 +181,7 @@ impl Mat3A {
 
     /// Creates a `[f32; 9]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -535,7 +535,7 @@ impl Mat3A {
     /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -600,7 +600,7 @@ impl Mat3A {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 3 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -106,7 +106,7 @@ impl Mat4 {
 
     /// Creates a 4x4 matrix from four row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -187,7 +187,7 @@ impl Mat4 {
 
     /// Creates a 4x4 matrix from a `[f32; 16]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -201,7 +201,7 @@ impl Mat4 {
 
     /// Creates a `[f32; 16]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -586,7 +586,7 @@ impl Mat4 {
     /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -654,7 +654,7 @@ impl Mat4 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 4 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -104,6 +104,23 @@ impl Mat4 {
         }
     }
 
+    /// Creates a 4x4 matrix from four row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec4, row1: Vec4, row2: Vec4, row3: Vec4) -> Self {
+        let [m00, m01, m02, m03] = row0.to_array();
+        let [m10, m11, m12, m13] = row1.to_array();
+        let [m20, m21, m22, m23] = row2.to_array();
+        let [m30, m31, m32, m33] = row3.to_array();
+        Self::new(
+            m00, m10, m20, m30, m01, m11, m21, m31, m02, m12, m22, m32, m03, m13, m23, m33,
+        )
+    }
+
     /// Creates a 4x4 matrix from a `[f32; 16]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -165,6 +182,34 @@ impl Mat4 {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
             self.w_axis.to_array(),
+        ]
+    }
+
+    /// Creates a 4x4 matrix from a `[f32; 16]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 16]) -> Self {
+        Self::new(
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
+        )
+    }
+
+    /// Creates a `[f32; 16]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 16] {
+        let m = self.to_cols_array();
+        [
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
         ]
     }
 
@@ -538,6 +583,25 @@ impl Mat4 {
         slice[15] = self.w_axis.w;
     }
 
+    /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 16 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(
+            slice[0], slice[4], slice[8], slice[12], slice[1], slice[5], slice[9], slice[13],
+            slice[2], slice[6], slice[10], slice[14], slice[3], slice[7], slice[11], slice[15],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -584,6 +648,46 @@ impl Mat4 {
             1 => Vec4::new(self.x_axis.y, self.y_axis.y, self.z_axis.y, self.w_axis.y),
             2 => Vec4::new(self.x_axis.z, self.y_axis.z, self.z_axis.z, self.w_axis.z),
             3 => Vec4::new(self.x_axis.w, self.y_axis.w, self.z_axis.w, self.w_axis.w),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 4 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 3.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec4) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+                self.w_axis.x = row.w;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+                self.w_axis.y = row.w;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+                self.w_axis.z = row.w;
+            }
+            3 => {
+                self.x_axis.w = row.x;
+                self.y_axis.w = row.y;
+                self.z_axis.w = row.z;
+                self.w_axis.w = row.w;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/sse2/mat2.rs
+++ b/src/f32/sse2/mat2.rs
@@ -77,6 +77,19 @@ impl Mat2 {
         }
     }
 
+    /// Creates a 2x2 matrix from two row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec2, row1: Vec2) -> Self {
+        let [m00, m01] = row0.to_array();
+        let [m10, m11] = row1.to_array();
+        Self::new(m00, m10, m01, m11)
+    }
+
     /// Creates a 2x2 matrix from a `[f32; 4]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -109,6 +122,28 @@ impl Mat2 {
     #[must_use]
     pub const fn to_cols_array_2d(&self) -> [[f32; 2]; 2] {
         unsafe { *(self as *const Self as *const [[f32; 2]; 2]) }
+    }
+
+    /// Creates a 2x2 matrix from a `[f32; 4]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 4]) -> Self {
+        Self::new(m[0], m[2], m[1], m[3])
+    }
+
+    /// Creates a `[f32; 4]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 4] {
+        let m = self.to_cols_array();
+        [m[0], m[2], m[1], m[3]]
     }
 
     /// Creates a 2x2 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -220,6 +255,22 @@ impl Mat2 {
         slice[3] = self.y_axis.y;
     }
 
+    /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 4 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(slice[0], slice[2], slice[1], slice[3])
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -260,6 +311,30 @@ impl Mat2 {
         match index {
             0 => Vec2::new(self.x_axis.x, self.y_axis.x),
             1 => Vec2::new(self.x_axis.y, self.y_axis.y),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 2 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 1.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec2) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/sse2/mat2.rs
+++ b/src/f32/sse2/mat2.rs
@@ -79,7 +79,7 @@ impl Mat2 {
 
     /// Creates a 2x2 matrix from two row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -126,7 +126,7 @@ impl Mat2 {
 
     /// Creates a 2x2 matrix from a `[f32; 4]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -137,7 +137,7 @@ impl Mat2 {
 
     /// Creates a `[f32; 4]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -258,7 +258,7 @@ impl Mat2 {
     /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -317,7 +317,7 @@ impl Mat2 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 2 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -107,6 +107,20 @@ impl Mat3A {
         }
     }
 
+    /// Creates a 3x3 matrix from three row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec3A, row1: Vec3A, row2: Vec3A) -> Self {
+        let [m00, m01, m02] = row0.to_array();
+        let [m10, m11, m12] = row1.to_array();
+        let [m20, m21, m22] = row2.to_array();
+        Self::new(m00, m10, m20, m01, m11, m21, m02, m12, m22)
+    }
+
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -154,6 +168,28 @@ impl Mat3A {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
         ]
+    }
+
+    /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 9]) -> Self {
+        Self::new(m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8])
+    }
+
+    /// Creates a `[f32; 9]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 9] {
+        let m = self.to_cols_array();
+        [m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]]
     }
 
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -498,6 +534,25 @@ impl Mat3A {
         slice[8] = self.z_axis.z;
     }
 
+    /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 9 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(
+            slice[0], slice[3], slice[6], slice[1], slice[4], slice[7], slice[2], slice[5],
+            slice[8],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -541,6 +596,37 @@ impl Mat3A {
             0 => Vec3A::new(self.x_axis.x, self.y_axis.x, self.z_axis.x),
             1 => Vec3A::new(self.x_axis.y, self.y_axis.y, self.z_axis.y),
             2 => Vec3A::new(self.x_axis.z, self.y_axis.z, self.z_axis.z),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 3 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 2.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec3A) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -109,7 +109,7 @@ impl Mat3A {
 
     /// Creates a 3x3 matrix from three row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -172,7 +172,7 @@ impl Mat3A {
 
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -183,7 +183,7 @@ impl Mat3A {
 
     /// Creates a `[f32; 9]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -537,7 +537,7 @@ impl Mat3A {
     /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -602,7 +602,7 @@ impl Mat3A {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 3 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -109,6 +109,23 @@ impl Mat4 {
         }
     }
 
+    /// Creates a 4x4 matrix from four row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec4, row1: Vec4, row2: Vec4, row3: Vec4) -> Self {
+        let [m00, m01, m02, m03] = row0.to_array();
+        let [m10, m11, m12, m13] = row1.to_array();
+        let [m20, m21, m22, m23] = row2.to_array();
+        let [m30, m31, m32, m33] = row3.to_array();
+        Self::new(
+            m00, m10, m20, m30, m01, m11, m21, m31, m02, m12, m22, m32, m03, m13, m23, m33,
+        )
+    }
+
     /// Creates a 4x4 matrix from a `[f32; 16]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -161,6 +178,34 @@ impl Mat4 {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
             self.w_axis.to_array(),
+        ]
+    }
+
+    /// Creates a 4x4 matrix from a `[f32; 16]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 16]) -> Self {
+        Self::new(
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
+        )
+    }
+
+    /// Creates a `[f32; 16]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 16] {
+        let m = self.to_cols_array();
+        [
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
         ]
     }
 
@@ -535,6 +580,25 @@ impl Mat4 {
         slice[15] = self.w_axis.w;
     }
 
+    /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 16 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(
+            slice[0], slice[4], slice[8], slice[12], slice[1], slice[5], slice[9], slice[13],
+            slice[2], slice[6], slice[10], slice[14], slice[3], slice[7], slice[11], slice[15],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -581,6 +645,46 @@ impl Mat4 {
             1 => Vec4::new(self.x_axis.y, self.y_axis.y, self.z_axis.y, self.w_axis.y),
             2 => Vec4::new(self.x_axis.z, self.y_axis.z, self.z_axis.z, self.w_axis.z),
             3 => Vec4::new(self.x_axis.w, self.y_axis.w, self.z_axis.w, self.w_axis.w),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 4 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 3.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec4) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+                self.w_axis.x = row.w;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+                self.w_axis.y = row.w;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+                self.w_axis.z = row.w;
+            }
+            3 => {
+                self.x_axis.w = row.x;
+                self.y_axis.w = row.y;
+                self.z_axis.w = row.z;
+                self.w_axis.w = row.w;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -111,7 +111,7 @@ impl Mat4 {
 
     /// Creates a 4x4 matrix from four row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -183,7 +183,7 @@ impl Mat4 {
 
     /// Creates a 4x4 matrix from a `[f32; 16]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -197,7 +197,7 @@ impl Mat4 {
 
     /// Creates a `[f32; 16]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -583,7 +583,7 @@ impl Mat4 {
     /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -651,7 +651,7 @@ impl Mat4 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 4 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/wasm/mat2.rs
+++ b/src/f32/wasm/mat2.rs
@@ -61,6 +61,19 @@ impl Mat2 {
         Self(f32x4(x_axis.x, x_axis.y, y_axis.x, y_axis.y))
     }
 
+    /// Creates a 2x2 matrix from two row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec2, row1: Vec2) -> Self {
+        let [m00, m01] = row0.to_array();
+        let [m10, m11] = row1.to_array();
+        Self::new(m00, m10, m01, m11)
+    }
+
     /// Creates a 2x2 matrix from a `[f32; 4]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -93,6 +106,28 @@ impl Mat2 {
     #[must_use]
     pub const fn to_cols_array_2d(&self) -> [[f32; 2]; 2] {
         unsafe { *(self as *const Self as *const [[f32; 2]; 2]) }
+    }
+
+    /// Creates a 2x2 matrix from a `[f32; 4]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 4]) -> Self {
+        Self::new(m[0], m[2], m[1], m[3])
+    }
+
+    /// Creates a `[f32; 4]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 4] {
+        let m = self.to_cols_array();
+        [m[0], m[2], m[1], m[3]]
     }
 
     /// Creates a 2x2 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -204,6 +239,22 @@ impl Mat2 {
         slice[3] = self.y_axis.y;
     }
 
+    /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 4 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(slice[0], slice[2], slice[1], slice[3])
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -244,6 +295,30 @@ impl Mat2 {
         match index {
             0 => Vec2::new(self.x_axis.x, self.y_axis.x),
             1 => Vec2::new(self.x_axis.y, self.y_axis.y),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 2 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 1.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec2) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/wasm/mat2.rs
+++ b/src/f32/wasm/mat2.rs
@@ -63,7 +63,7 @@ impl Mat2 {
 
     /// Creates a 2x2 matrix from two row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -110,7 +110,7 @@ impl Mat2 {
 
     /// Creates a 2x2 matrix from a `[f32; 4]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -121,7 +121,7 @@ impl Mat2 {
 
     /// Creates a `[f32; 4]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -242,7 +242,7 @@ impl Mat2 {
     /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -301,7 +301,7 @@ impl Mat2 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 2 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/wasm/mat3a.rs
+++ b/src/f32/wasm/mat3a.rs
@@ -107,6 +107,20 @@ impl Mat3A {
         }
     }
 
+    /// Creates a 3x3 matrix from three row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec3A, row1: Vec3A, row2: Vec3A) -> Self {
+        let [m00, m01, m02] = row0.to_array();
+        let [m10, m11, m12] = row1.to_array();
+        let [m20, m21, m22] = row2.to_array();
+        Self::new(m00, m10, m20, m01, m11, m21, m02, m12, m22)
+    }
+
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -154,6 +168,28 @@ impl Mat3A {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
         ]
+    }
+
+    /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 9]) -> Self {
+        Self::new(m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8])
+    }
+
+    /// Creates a `[f32; 9]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 9] {
+        let m = self.to_cols_array();
+        [m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]]
     }
 
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -498,6 +534,25 @@ impl Mat3A {
         slice[8] = self.z_axis.z;
     }
 
+    /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 9 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(
+            slice[0], slice[3], slice[6], slice[1], slice[4], slice[7], slice[2], slice[5],
+            slice[8],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -541,6 +596,37 @@ impl Mat3A {
             0 => Vec3A::new(self.x_axis.x, self.y_axis.x, self.z_axis.x),
             1 => Vec3A::new(self.x_axis.y, self.y_axis.y, self.z_axis.y),
             2 => Vec3A::new(self.x_axis.z, self.y_axis.z, self.z_axis.z),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 3 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 2.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec3A) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/wasm/mat3a.rs
+++ b/src/f32/wasm/mat3a.rs
@@ -109,7 +109,7 @@ impl Mat3A {
 
     /// Creates a 3x3 matrix from three row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -172,7 +172,7 @@ impl Mat3A {
 
     /// Creates a 3x3 matrix from a `[f32; 9]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -183,7 +183,7 @@ impl Mat3A {
 
     /// Creates a `[f32; 9]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -537,7 +537,7 @@ impl Mat3A {
     /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -602,7 +602,7 @@ impl Mat3A {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 3 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f32/wasm/mat4.rs
+++ b/src/f32/wasm/mat4.rs
@@ -109,6 +109,23 @@ impl Mat4 {
         }
     }
 
+    /// Creates a 4x4 matrix from four row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: Vec4, row1: Vec4, row2: Vec4, row3: Vec4) -> Self {
+        let [m00, m01, m02, m03] = row0.to_array();
+        let [m10, m11, m12, m13] = row1.to_array();
+        let [m20, m21, m22, m23] = row2.to_array();
+        let [m30, m31, m32, m33] = row3.to_array();
+        Self::new(
+            m00, m10, m20, m30, m01, m11, m21, m31, m02, m12, m22, m32, m03, m13, m23, m33,
+        )
+    }
+
     /// Creates a 4x4 matrix from a `[f32; 16]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -161,6 +178,34 @@ impl Mat4 {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
             self.w_axis.to_array(),
+        ]
+    }
+
+    /// Creates a 4x4 matrix from a `[f32; 16]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f32; 16]) -> Self {
+        Self::new(
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
+        )
+    }
+
+    /// Creates a `[f32; 16]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f32; 16] {
+        let m = self.to_cols_array();
+        [
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
         ]
     }
 
@@ -535,6 +580,25 @@ impl Mat4 {
         slice[15] = self.w_axis.w;
     }
 
+    /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 16 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f32]) -> Self {
+        Self::new(
+            slice[0], slice[4], slice[8], slice[12], slice[1], slice[5], slice[9], slice[13],
+            slice[2], slice[6], slice[10], slice[14], slice[3], slice[7], slice[11], slice[15],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -581,6 +645,46 @@ impl Mat4 {
             1 => Vec4::new(self.x_axis.y, self.y_axis.y, self.z_axis.y, self.w_axis.y),
             2 => Vec4::new(self.x_axis.z, self.y_axis.z, self.z_axis.z, self.w_axis.z),
             3 => Vec4::new(self.x_axis.w, self.y_axis.w, self.z_axis.w, self.w_axis.w),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 4 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 3.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: Vec4) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+                self.w_axis.x = row.w;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+                self.w_axis.y = row.w;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+                self.w_axis.z = row.w;
+            }
+            3 => {
+                self.x_axis.w = row.x;
+                self.y_axis.w = row.y;
+                self.z_axis.w = row.z;
+                self.w_axis.w = row.w;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f32/wasm/mat4.rs
+++ b/src/f32/wasm/mat4.rs
@@ -111,7 +111,7 @@ impl Mat4 {
 
     /// Creates a 4x4 matrix from four row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -183,7 +183,7 @@ impl Mat4 {
 
     /// Creates a 4x4 matrix from a `[f32; 16]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -197,7 +197,7 @@ impl Mat4 {
 
     /// Creates a `[f32; 16]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -583,7 +583,7 @@ impl Mat4 {
     /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -651,7 +651,7 @@ impl Mat4 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 4 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f64/dmat2.rs
+++ b/src/f64/dmat2.rs
@@ -58,7 +58,7 @@ impl DMat2 {
 
     /// Creates a 2x2 matrix from two row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -105,7 +105,7 @@ impl DMat2 {
 
     /// Creates a 2x2 matrix from a `[f64; 4]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -116,7 +116,7 @@ impl DMat2 {
 
     /// Creates a `[f64; 4]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -207,7 +207,7 @@ impl DMat2 {
     /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -266,7 +266,7 @@ impl DMat2 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 2 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f64/dmat2.rs
+++ b/src/f64/dmat2.rs
@@ -56,6 +56,19 @@ impl DMat2 {
         Self { x_axis, y_axis }
     }
 
+    /// Creates a 2x2 matrix from two row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: DVec2, row1: DVec2) -> Self {
+        let [m00, m01] = row0.to_array();
+        let [m10, m11] = row1.to_array();
+        Self::new(m00, m10, m01, m11)
+    }
+
     /// Creates a 2x2 matrix from a `[f64; 4]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -88,6 +101,28 @@ impl DMat2 {
     #[must_use]
     pub const fn to_cols_array_2d(&self) -> [[f64; 2]; 2] {
         [self.x_axis.to_array(), self.y_axis.to_array()]
+    }
+
+    /// Creates a 2x2 matrix from a `[f64; 4]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f64; 4]) -> Self {
+        Self::new(m[0], m[2], m[1], m[3])
+    }
+
+    /// Creates a `[f64; 4]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f64; 4] {
+        let m = self.to_cols_array();
+        [m[0], m[2], m[1], m[3]]
     }
 
     /// Creates a 2x2 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -169,6 +204,22 @@ impl DMat2 {
         slice[3] = self.y_axis.y;
     }
 
+    /// Creates a 2x2 matrix from the first 4 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 4 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f64]) -> Self {
+        Self::new(slice[0], slice[2], slice[1], slice[3])
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -209,6 +260,30 @@ impl DMat2 {
         match index {
             0 => DVec2::new(self.x_axis.x, self.y_axis.x),
             1 => DVec2::new(self.x_axis.y, self.y_axis.y),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 2 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 1.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: DVec2) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f64/dmat3.rs
+++ b/src/f64/dmat3.rs
@@ -99,6 +99,20 @@ impl DMat3 {
         }
     }
 
+    /// Creates a 3x3 matrix from three row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: DVec3, row1: DVec3, row2: DVec3) -> Self {
+        let [m00, m01, m02] = row0.to_array();
+        let [m10, m11, m12] = row1.to_array();
+        let [m20, m21, m22] = row2.to_array();
+        Self::new(m00, m10, m20, m01, m11, m21, m02, m12, m22)
+    }
+
     /// Creates a 3x3 matrix from a `[f64; 9]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -149,6 +163,28 @@ impl DMat3 {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
         ]
+    }
+
+    /// Creates a 3x3 matrix from a `[f64; 9]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f64; 9]) -> Self {
+        Self::new(m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8])
+    }
+
+    /// Creates a `[f64; 9]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f64; 9] {
+        let m = self.to_cols_array();
+        [m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8]]
     }
 
     /// Creates a 3x3 matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -429,6 +465,25 @@ impl DMat3 {
         slice[8] = self.z_axis.z;
     }
 
+    /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 9 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f64]) -> Self {
+        Self::new(
+            slice[0], slice[3], slice[6], slice[1], slice[4], slice[7], slice[2], slice[5],
+            slice[8],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -472,6 +527,37 @@ impl DMat3 {
             0 => DVec3::new(self.x_axis.x, self.y_axis.x, self.z_axis.x),
             1 => DVec3::new(self.x_axis.y, self.y_axis.y, self.z_axis.y),
             2 => DVec3::new(self.x_axis.z, self.y_axis.z, self.z_axis.z),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 3 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 2.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: DVec3) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/src/f64/dmat3.rs
+++ b/src/f64/dmat3.rs
@@ -101,7 +101,7 @@ impl DMat3 {
 
     /// Creates a 3x3 matrix from three row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -167,7 +167,7 @@ impl DMat3 {
 
     /// Creates a 3x3 matrix from a `[f64; 9]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -178,7 +178,7 @@ impl DMat3 {
 
     /// Creates a `[f64; 9]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -468,7 +468,7 @@ impl DMat3 {
     /// Creates a 3x3 matrix from the first 9 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -533,7 +533,7 @@ impl DMat3 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 3 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -103,7 +103,7 @@ impl DMat4 {
 
     /// Creates a 4x4 matrix from four row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -184,7 +184,7 @@ impl DMat4 {
 
     /// Creates a 4x4 matrix from a `[f64; 16]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -198,7 +198,7 @@ impl DMat4 {
 
     /// Creates a `[f64; 16]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -571,7 +571,7 @@ impl DMat4 {
     /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -639,7 +639,7 @@ impl DMat4 {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all 4 columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -101,6 +101,23 @@ impl DMat4 {
         }
     }
 
+    /// Creates a 4x4 matrix from four row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(row0: DVec4, row1: DVec4, row2: DVec4, row3: DVec4) -> Self {
+        let [m00, m01, m02, m03] = row0.to_array();
+        let [m10, m11, m12, m13] = row1.to_array();
+        let [m20, m21, m22, m23] = row2.to_array();
+        let [m30, m31, m32, m33] = row3.to_array();
+        Self::new(
+            m00, m10, m20, m30, m01, m11, m21, m31, m02, m12, m22, m32, m03, m13, m23, m33,
+        )
+    }
+
     /// Creates a 4x4 matrix from a `[f64; 16]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -162,6 +179,34 @@ impl DMat4 {
             self.y_axis.to_array(),
             self.z_axis.to_array(),
             self.w_axis.to_array(),
+        ]
+    }
+
+    /// Creates a 4x4 matrix from a `[f64; 16]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[f64; 16]) -> Self {
+        Self::new(
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
+        )
+    }
+
+    /// Creates a `[f64; 16]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [f64; 16] {
+        let m = self.to_cols_array();
+        [
+            m[0], m[4], m[8], m[12], m[1], m[5], m[9], m[13], m[2], m[6], m[10], m[14], m[3], m[7],
+            m[11], m[15],
         ]
     }
 
@@ -523,6 +568,25 @@ impl DMat4 {
         slice[15] = self.w_axis.w;
     }
 
+    /// Creates a 4x4 matrix from the first 16 values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than 16 elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[f64]) -> Self {
+        Self::new(
+            slice[0], slice[4], slice[8], slice[12], slice[1], slice[5], slice[9], slice[13],
+            slice[2], slice[6], slice[10], slice[14], slice[3], slice[7], slice[11], slice[15],
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -569,6 +633,46 @@ impl DMat4 {
             1 => DVec4::new(self.x_axis.y, self.y_axis.y, self.z_axis.y, self.w_axis.y),
             2 => DVec4::new(self.x_axis.z, self.y_axis.z, self.z_axis.z, self.w_axis.z),
             3 => DVec4::new(self.x_axis.w, self.y_axis.w, self.z_axis.w, self.w_axis.w),
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all 4 columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than 3.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: DVec4) {
+        match index {
+            0 => {
+                self.x_axis.x = row.x;
+                self.y_axis.x = row.y;
+                self.z_axis.x = row.z;
+                self.w_axis.x = row.w;
+            }
+            1 => {
+                self.x_axis.y = row.x;
+                self.y_axis.y = row.y;
+                self.z_axis.y = row.z;
+                self.w_axis.y = row.w;
+            }
+            2 => {
+                self.x_axis.z = row.x;
+                self.y_axis.z = row.y;
+                self.z_axis.z = row.z;
+                self.w_axis.z = row.w;
+            }
+            3 => {
+                self.x_axis.w = row.x;
+                self.y_axis.w = row.y;
+                self.z_axis.w = row.z;
+                self.w_axis.w = row.w;
+            }
             _ => panic!("index out of bounds"),
         }
     }

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -297,7 +297,7 @@ impl {{ self_t }} {
 
     /// Creates a {{ nxn }} matrix from {{ dimension_in_full }} row vectors.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
     /// laid out as columns.
     #[inline(always)]
@@ -395,7 +395,7 @@ impl {{ self_t }} {
 
     /// Creates a {{ nxn }} matrix from a `[{{ scalar_t }}; {{ size }}]` array stored in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
     /// in column major order.
     #[inline]
@@ -412,7 +412,7 @@ impl {{ self_t }} {
 
     /// Creates a `[{{ scalar_t }}; {{ size }}]` array storing data in row major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// Note matrices are stored in column major order, so this transposes the data
     /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
     #[inline]
     #[must_use]
@@ -1066,7 +1066,7 @@ impl {{ self_t }} {
     /// Creates a {{ nxn }} matrix from the first {{ size }} values in `slice`, stored in row
     /// major order.
     ///
-    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// Note matrices are stored in column major order, so the data given here is
     /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
     /// in column major order.
     ///
@@ -1138,7 +1138,7 @@ impl {{ self_t }} {
 
     /// Sets the matrix row for the given `index`.
     ///
-    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// Note matrices are stored in column major order, so a row is spread across
     /// all {{ dim }} columns and writing one touches every column. Prefer
     /// [`Self::col_mut`] when you can work with columns instead.
     ///

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -295,6 +295,30 @@ impl {{ self_t }} {
         {% endif %}
     }
 
+    /// Creates a {{ nxn }} matrix from {{ dimension_in_full }} row vectors.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols`] when the data is already
+    /// laid out as columns.
+    #[inline(always)]
+    #[must_use]
+    pub const fn from_rows(
+        {% for i in range(end = dim) %}
+            row{{ i }}: {{ col_t }},
+        {% endfor %}
+    ) -> Self {
+        {% for i in range(end = dim) %}
+            let [{% for j in range(end = dim) %}m{{ i }}{{ j }}, {% endfor %}] = row{{ i }}.to_array();
+        {%- endfor %}
+        Self::new(
+            {% for i in range(end = dim) %}
+                {%- for j in range(end = dim) %}
+                    m{{ j }}{{ i }},
+                {%- endfor %}
+            {%- endfor %}
+        )
+    }
+
     /// Creates a {{ nxn }} matrix from a `[{{ scalar_t }}; {{ size }}]` array stored in column major order.
     /// If your data is stored in row major you will need to `transpose` the returned
     /// matrix.
@@ -367,6 +391,40 @@ impl {{ self_t }} {
                 {%- endfor %}
             ]
         {% endif %}
+    }
+
+    /// Creates a {{ nxn }} matrix from a `[{{ scalar_t }}; {{ size }}]` array stored in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_array`] when the data is already
+    /// in column major order.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_array(m: &[{{ scalar_t }}; {{ size }}]) -> Self {
+        Self::new(
+            {% for i in range(end = dim) %}
+                {%- for j in range(end = dim) %}
+                    m[{{ j * dim + i }}],
+                {%- endfor %}
+            {%- endfor %}
+        )
+    }
+
+    /// Creates a `[{{ scalar_t }}; {{ size }}]` array storing data in row major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so this transposes the data
+    /// on the way out. Prefer [`Self::to_cols_array`] when column major data will do.
+    #[inline]
+    #[must_use]
+    pub const fn to_rows_array(&self) -> [{{ scalar_t }}; {{ size }}] {
+        let m = self.to_cols_array();
+        [
+            {% for i in range(end = dim) %}
+                {%- for j in range(end = dim) %}
+                    m[{{ j * dim + i }}],
+                {%- endfor %}
+            {%- endfor %}
+        ]
     }
 
     /// Creates a {{ nxn }} matrix with its diagonal set to `diagonal` and all other entries set to 0.
@@ -1005,6 +1063,28 @@ impl {{ self_t }} {
         {%- endfor %}
     }
 
+    /// Creates a {{ nxn }} matrix from the first {{ size }} values in `slice`, stored in row
+    /// major order.
+    ///
+    /// Note that `glam` stores matrices in column major order, so the data given here is
+    /// transposed on the way in. Prefer [`Self::from_cols_slice`] when the slice is already
+    /// in column major order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `slice` is less than {{ size }} elements long.
+    #[inline]
+    #[must_use]
+    pub const fn from_rows_slice(slice: &[{{ scalar_t }}]) -> Self {
+        Self::new(
+            {% for i in range(end = dim) %}
+                {%- for j in range(end = dim) %}
+                    slice[{{ j * dim + i }}],
+                {%- endfor %}
+            {%- endfor %}
+        )
+    }
+
     /// Returns the matrix column for the given `index`.
     ///
     /// # Panics
@@ -1051,6 +1131,29 @@ impl {{ self_t }} {
                         self.{{ axis }}.{{ components[i] }},
                     {%- endfor %}
                 ),
+            {%- endfor %}
+            _ => panic!("index out of bounds"),
+        }
+    }
+
+    /// Sets the matrix row for the given `index`.
+    ///
+    /// Note that `glam` stores matrices in column major order, so a row is spread across
+    /// all {{ dim }} columns and writing one touches every column. Prefer
+    /// [`Self::col_mut`] when you can work with columns instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `index` is greater than {{ dim - 1 }}.
+    #[inline]
+    pub fn set_row(&mut self, index: usize, row: {{ col_t }}) {
+        match index {
+            {% for i in range(end=dim) %}
+                {{ i }} => {
+                    {% for j in range(end=dim) %}
+                        self.{{ axes[j] }}.{{ components[i] }} = row.{{ components[j] }};
+                    {%- endfor %}
+                }
             {%- endfor %}
             _ => panic!("index out of bounds"),
         }

--- a/tests/mat2.rs
+++ b/tests/mat2.rs
@@ -64,6 +64,46 @@ macro_rules! impl_mat2_tests {
             should_panic!({ $mat2::ZERO.row(2) });
         });
 
+        glam_test!(test_mat2_rows, {
+            // ARRAY1X4 is column major, so the same matrix in row major order is:
+            const ROW_MAJOR: [$t; 4] = [1.0, 3.0, 2.0, 4.0];
+
+            let m = $mat2::from_cols_array(&ARRAY1X4);
+
+            assert_eq!(ROW_MAJOR, m.to_rows_array());
+            assert_eq!(m, $mat2::from_rows_array(&ROW_MAJOR));
+            assert_eq!(m, $mat2::from_rows_slice(&ROW_MAJOR));
+            assert_eq!(m, $mat2::from_rows(m.row(0), m.row(1)));
+
+            // rows are just the columns of the transpose
+            assert_eq!(m.to_rows_array(), m.transpose().to_cols_array());
+            assert_eq!(
+                $mat2::from_rows_array(&ARRAY1X4),
+                $mat2::from_cols_array(&ARRAY1X4).transpose()
+            );
+
+            let mut m2 = $mat2::ZERO;
+            m2.set_row(0, m.row(0));
+            m2.set_row(1, m.row(1));
+            assert_eq!(m, m2);
+
+            // these are all const
+            const M0: $mat2 = $mat2::from_rows($newvec2(1.0, 3.0), $newvec2(2.0, 4.0));
+            const M1: $mat2 = $mat2::from_rows_array(&ROW_MAJOR);
+            const M2: $mat2 = $mat2::from_rows_slice(&ROW_MAJOR);
+            const A: [$t; 4] = M0.to_rows_array();
+            assert_eq!(ARRAY1X4, M0.to_cols_array());
+            assert_eq!(ARRAY1X4, M1.to_cols_array());
+            assert_eq!(ARRAY1X4, M2.to_cols_array());
+            assert_eq!(ROW_MAJOR, A);
+
+            should_panic!({
+                let mut m = $mat2::ZERO;
+                m.set_row(2, $vec2::ZERO);
+            });
+            should_panic!({ $mat2::from_rows_slice(&[0.0; 3]) });
+        });
+
         glam_test!(test_mat2_from_axes, {
             let a = $mat2::from_cols_array_2d(&ARRAY2X2);
             assert_eq!(ARRAY2X2, a.to_cols_array_2d());

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -89,6 +89,51 @@ macro_rules! impl_mat3_tests {
             should_panic!({ $mat3::ZERO.row(3) });
         });
 
+        glam_test!(test_mat3_rows, {
+            // ARRAY1X9 is column major, so the same matrix in row major order is:
+            const ROW_MAJOR: [$t; 9] = [1.0, 4.0, 7.0, 2.0, 5.0, 8.0, 3.0, 6.0, 9.0];
+
+            let m = $mat3::from_cols_array(&ARRAY1X9);
+
+            assert_eq!(ROW_MAJOR, m.to_rows_array());
+            assert_eq!(m, $mat3::from_rows_array(&ROW_MAJOR));
+            assert_eq!(m, $mat3::from_rows_slice(&ROW_MAJOR));
+            assert_eq!(m, $mat3::from_rows(m.row(0), m.row(1), m.row(2)));
+
+            // rows are just the columns of the transpose
+            assert_eq!(m.to_rows_array(), m.transpose().to_cols_array());
+            assert_eq!(
+                $mat3::from_rows_array(&ARRAY1X9),
+                $mat3::from_cols_array(&ARRAY1X9).transpose()
+            );
+
+            let mut m2 = $mat3::ZERO;
+            m2.set_row(0, m.row(0));
+            m2.set_row(1, m.row(1));
+            m2.set_row(2, m.row(2));
+            assert_eq!(m, m2);
+
+            // these are all const
+            const M0: $mat3 = $mat3::from_rows(
+                $newvec3(1.0, 4.0, 7.0),
+                $newvec3(2.0, 5.0, 8.0),
+                $newvec3(3.0, 6.0, 9.0),
+            );
+            const M1: $mat3 = $mat3::from_rows_array(&ROW_MAJOR);
+            const M2: $mat3 = $mat3::from_rows_slice(&ROW_MAJOR);
+            const A: [$t; 9] = M0.to_rows_array();
+            assert_eq!(ARRAY1X9, M0.to_cols_array());
+            assert_eq!(ARRAY1X9, M1.to_cols_array());
+            assert_eq!(ARRAY1X9, M2.to_cols_array());
+            assert_eq!(ROW_MAJOR, A);
+
+            should_panic!({
+                let mut m = $mat3::ZERO;
+                m.set_row(3, $newvec3(0.0, 0.0, 0.0));
+            });
+            should_panic!({ $mat3::from_rows_slice(&[0.0; 8]) });
+        });
+
         glam_test!(test_mat3_from_axes, {
             let a = $mat3::from_cols_array_2d(&[[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]]);
             assert_eq!(ARRAY3X3, a.to_cols_array_2d());

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -109,6 +109,58 @@ macro_rules! impl_mat4_tests {
             should_panic!({ $mat4::ZERO.row(4) });
         });
 
+        glam_test!(test_mat4_rows, {
+            // ARRAY1X16 is column major, so the same matrix in row major order is:
+            const ROW_MAJOR: [$t; 16] = [
+                1.0, 5.0, 9.0, 13.0, //
+                2.0, 6.0, 10.0, 14.0, //
+                3.0, 7.0, 11.0, 15.0, //
+                4.0, 8.0, 12.0, 16.0, //
+            ];
+
+            let m = $mat4::from_cols_array(&ARRAY1X16);
+
+            assert_eq!(ROW_MAJOR, m.to_rows_array());
+            assert_eq!(m, $mat4::from_rows_array(&ROW_MAJOR));
+            assert_eq!(m, $mat4::from_rows_slice(&ROW_MAJOR));
+            assert_eq!(m, $mat4::from_rows(m.row(0), m.row(1), m.row(2), m.row(3)));
+
+            // rows are just the columns of the transpose
+            assert_eq!(m.to_rows_array(), m.transpose().to_cols_array());
+            assert_eq!(
+                $mat4::from_rows_array(&ARRAY1X16),
+                $mat4::from_cols_array(&ARRAY1X16).transpose()
+            );
+
+            let mut m2 = $mat4::ZERO;
+            m2.set_row(0, m.row(0));
+            m2.set_row(1, m.row(1));
+            m2.set_row(2, m.row(2));
+            m2.set_row(3, m.row(3));
+            assert_eq!(m, m2);
+
+            // these are all const
+            const M0: $mat4 = $mat4::from_rows(
+                $newvec4(1.0, 5.0, 9.0, 13.0),
+                $newvec4(2.0, 6.0, 10.0, 14.0),
+                $newvec4(3.0, 7.0, 11.0, 15.0),
+                $newvec4(4.0, 8.0, 12.0, 16.0),
+            );
+            const M1: $mat4 = $mat4::from_rows_array(&ROW_MAJOR);
+            const M2: $mat4 = $mat4::from_rows_slice(&ROW_MAJOR);
+            const A: [$t; 16] = M0.to_rows_array();
+            assert_eq!(ARRAY1X16, M0.to_cols_array());
+            assert_eq!(ARRAY1X16, M1.to_cols_array());
+            assert_eq!(ARRAY1X16, M2.to_cols_array());
+            assert_eq!(ROW_MAJOR, A);
+
+            should_panic!({
+                let mut m = $mat4::ZERO;
+                m.set_row(4, $vec4::ZERO);
+            });
+            should_panic!({ $mat4::from_rows_slice(&[0.0; 15]) });
+        });
+
         glam_test!(test_mat4_from_axes, {
             let a = $mat4::from_cols_array_2d(&[
                 [1.0, 2.0, 3.0, 4.0],


### PR DESCRIPTION
# Objective

- Fixes #639.
- The matrix types have `row()` for reading, but no way to build a matrix from rows or write one back. Row major is what you usually get out of file formats and other math libraries, so everyone ends up writing the same transpose glue themselves.

Adds the functions from the issue to `Mat2`, `Mat3`, `Mat3A`, `Mat4` and the `DMat` equivalents:

- `from_rows`
- `from_rows_array`
- `from_rows_slice`
- `to_rows_array`
- `set_row`

## Solution

You mentioned in the issue you were fine with these as long as they carry a doc comment reminding people glam stores columns and that rows cost more, so each one says that and links to the column equivalent to use instead when you don't need rows.

On the overhead itself, it turned out to be cheaper than expected. The array and slice constructors are just an index permutation into the existing `Self::new`, and `to_rows_array` permutes `to_cols_array`, so none of them actually call `transpose` and all four stay `const` like their column counterparts. `set_row` writes straight into the columns, so it's the only one that can't be const.

I left out `from_rows_array_2d` and `to_rows_array_2d` since they weren't in the issue, happy to add them if you want the mirror to be complete.

## Code generation

Yes. Everything is in `templates/mat.rs.tera` and the generator was run, which is where the 19 generated matrix files in the diff come from.

## Testing and linting

Added a `test_matN_rows` test to `tests/mat2.rs`, `tests/mat3.rs` and `tests/mat4.rs`, so it runs for every type variant including `Mat3A` and the `DMat` ones. They cover:

- the row major array round trip through `from_rows_array` / `to_rows_array` / `from_rows_slice`
- that `to_rows_array()` agrees with `transpose().to_cols_array()`
- `from_rows` rebuilding a matrix from its own `row()` values
- `set_row` round tripping with `row()`
- the const paths, so constness is actually exercised and not just declared
- out of bounds panics for `set_row` and a too short slice

- `cargo run -p ci` passes
- `cargo run -p ci -- msrv` passes, so the new const fns are fine on 1.68.2
- checked scalar, neon, sse2, wasm simd128 and core-simd all build, including the `Mat2` SIMD case that goes through `Deref` rather than real fields