### PR TITLE
chore: Remove unnecessary `use core::f32`

### DIFF
--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -4,7 +4,7 @@ use crate::{coresimd::*, f32::math, BVec3, BVec3A, FloatExt, Quat, Vec2, Vec3, V
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 use core::simd::{cmp::SimdPartialEq, cmp::SimdPartialOrd, num::SimdFloat, *};
 use std::simd::StdFloat;

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -4,7 +4,7 @@ use crate::{coresimd::*, f32::math, BVec4, BVec4A, Vec2, Vec3, Vec3A};
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 use core::simd::{cmp::SimdPartialEq, cmp::SimdPartialOrd, num::SimdFloat, *};
 use std::simd::StdFloat;

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -4,7 +4,7 @@ use crate::{f32::math, neon::*, BVec3, BVec3A, FloatExt, Quat, Vec2, Vec3, Vec4}
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 use core::arch::aarch64::*;
 

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -4,7 +4,7 @@ use crate::{f32::math, neon::*, BVec4, BVec4A, Vec2, Vec3, Vec3A};
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 use core::arch::aarch64::*;
 

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -4,7 +4,7 @@ use crate::{f32::math, BVec3, BVec3A, FloatExt, Quat, Vec2, Vec3, Vec4};
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -9,7 +9,7 @@ use crate::{f32::math, BVec4, Vec2, Vec3, Vec3A};
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -4,7 +4,7 @@ use crate::{f32::math, sse2::*, BVec3, BVec3A, FloatExt, Quat, Vec2, Vec3, Vec4}
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -4,7 +4,7 @@ use crate::{f32::math, sse2::*, BVec4, BVec4A, Vec2, Vec3, Vec3A};
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(target_arch = "x86")]
 use core::arch::x86::*;

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -4,7 +4,7 @@ use crate::{f32::math, BVec2, Vec3};
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -4,7 +4,7 @@ use crate::{f32::math, BVec3, BVec3A, FloatExt, Quat, Vec2, Vec3A, Vec4};
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/f32/wasm/vec3a.rs
+++ b/src/f32/wasm/vec3a.rs
@@ -4,7 +4,7 @@ use crate::{f32::math, wasm::*, BVec3, BVec3A, FloatExt, Quat, Vec2, Vec3, Vec4}
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(target_arch = "wasm32")]
 use core::arch::wasm32::*;

--- a/src/f32/wasm/vec4.rs
+++ b/src/f32/wasm/vec4.rs
@@ -4,7 +4,7 @@ use crate::{f32::math, wasm::*, BVec4, BVec4A, Vec2, Vec3, Vec3A};
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(target_arch = "wasm32")]
 use core::arch::wasm32::*;

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -12,7 +12,7 @@ use crate::UVec2;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -12,7 +12,7 @@ use crate::UVec3;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -14,7 +14,7 @@ use crate::UVec4;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i16/i16vec2.rs
+++ b/src/i16/i16vec2.rs
@@ -31,7 +31,7 @@ use crate::USizeVec2;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i16/i16vec3.rs
+++ b/src/i16/i16vec3.rs
@@ -31,7 +31,7 @@ use crate::USizeVec3;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i16/i16vec4.rs
+++ b/src/i16/i16vec4.rs
@@ -33,7 +33,7 @@ use crate::USizeVec4;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i32/ivec2.rs
+++ b/src/i32/ivec2.rs
@@ -31,7 +31,7 @@ use crate::USizeVec2;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i32/ivec3.rs
+++ b/src/i32/ivec3.rs
@@ -31,7 +31,7 @@ use crate::USizeVec3;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i32/ivec4.rs
+++ b/src/i32/ivec4.rs
@@ -33,7 +33,7 @@ use crate::USizeVec4;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i64/i64vec2.rs
+++ b/src/i64/i64vec2.rs
@@ -31,7 +31,7 @@ use crate::USizeVec2;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i64/i64vec3.rs
+++ b/src/i64/i64vec3.rs
@@ -31,7 +31,7 @@ use crate::USizeVec3;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i64/i64vec4.rs
+++ b/src/i64/i64vec4.rs
@@ -33,7 +33,7 @@ use crate::USizeVec4;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i8/i8vec2.rs
+++ b/src/i8/i8vec2.rs
@@ -31,7 +31,7 @@ use crate::USizeVec2;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i8/i8vec3.rs
+++ b/src/i8/i8vec3.rs
@@ -31,7 +31,7 @@ use crate::USizeVec3;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/i8/i8vec4.rs
+++ b/src/i8/i8vec4.rs
@@ -33,7 +33,7 @@ use crate::USizeVec4;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/isize/isizevec2.rs
+++ b/src/isize/isizevec2.rs
@@ -31,7 +31,7 @@ use crate::I64Vec2;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/isize/isizevec3.rs
+++ b/src/isize/isizevec3.rs
@@ -31,7 +31,7 @@ use crate::I64Vec3;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/isize/isizevec4.rs
+++ b/src/isize/isizevec4.rs
@@ -33,7 +33,7 @@ use crate::I64Vec4;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u16/u16vec2.rs
+++ b/src/u16/u16vec2.rs
@@ -31,7 +31,7 @@ use crate::USizeVec2;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u16/u16vec3.rs
+++ b/src/u16/u16vec3.rs
@@ -31,7 +31,7 @@ use crate::USizeVec3;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u16/u16vec4.rs
+++ b/src/u16/u16vec4.rs
@@ -33,7 +33,7 @@ use crate::USizeVec4;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u32/uvec2.rs
+++ b/src/u32/uvec2.rs
@@ -31,7 +31,7 @@ use crate::USizeVec2;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u32/uvec3.rs
+++ b/src/u32/uvec3.rs
@@ -31,7 +31,7 @@ use crate::USizeVec3;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u32/uvec4.rs
+++ b/src/u32/uvec4.rs
@@ -33,7 +33,7 @@ use crate::USizeVec4;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u64/u64vec2.rs
+++ b/src/u64/u64vec2.rs
@@ -31,7 +31,7 @@ use crate::USizeVec2;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u64/u64vec3.rs
+++ b/src/u64/u64vec3.rs
@@ -31,7 +31,7 @@ use crate::USizeVec3;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u64/u64vec4.rs
+++ b/src/u64/u64vec4.rs
@@ -33,7 +33,7 @@ use crate::USizeVec4;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u8/u8vec2.rs
+++ b/src/u8/u8vec2.rs
@@ -31,7 +31,7 @@ use crate::USizeVec2;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u8/u8vec3.rs
+++ b/src/u8/u8vec3.rs
@@ -31,7 +31,7 @@ use crate::USizeVec3;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/u8/u8vec4.rs
+++ b/src/u8/u8vec4.rs
@@ -33,7 +33,7 @@ use crate::USizeVec4;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/usize/usizevec2.rs
+++ b/src/usize/usizevec2.rs
@@ -31,7 +31,7 @@ use crate::ISizeVec2;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/usize/usizevec3.rs
+++ b/src/usize/usizevec3.rs
@@ -31,7 +31,7 @@ use crate::ISizeVec3;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/src/usize/usizevec4.rs
+++ b/src/usize/usizevec4.rs
@@ -33,7 +33,7 @@ use crate::ISizeVec4;
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 #[cfg(feature = "zerocopy")]
 use zerocopy_derive::*;

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -259,7 +259,7 @@
 
 use core::fmt;
 use core::iter::{Product, Sum};
-use core::{f32, ops::*};
+use core::ops::*;
 
 {% if is_sse2 %}
 #[cfg(target_arch = "x86")]


### PR DESCRIPTION
This was causing deprecation warnings from `f32::MIN` resolving to `core::f32::MIN` which is deprecated.
