### PR TITLE
feat: add float_eq support behind an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ encase = { version = "0.12", optional = true, default-features = false }
 zerocopy = { version = "0.8", optional = true, default-features = false, features = ["simd"] }
 zerocopy-derive = { version = "0.8", optional = true, default-features = false }
 arbitrary = { version = "1.4.2", default-features = false, optional = true }
+float_eq = { version = "1.0.1", default-features = false, optional = true }
 
 [dev-dependencies]
 # rand_xoshiro is required for tests if rand is enabled

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ glam = { default-features = false, features = ["nostd-libm"] }
 * [`arbitrary`] - `arbitrary` trait implementations for `glam` types.
 * [`bytemuck`] - for casting into slices of bytes
 * [`encase`] - `encase` trait implementations for `glam` types.
+* [`float_eq`] - traits and macros for comparing float types using various tolerances.
 * [`libm`] - uses `libm` math functions instead of `std`
 * [`mint`] - for interoperating with other 3D math libraries
 * [`rand`] - implementations of `Distribution` trait for all `glam` types.
@@ -174,6 +175,7 @@ glam = { default-features = false, features = ["nostd-libm"] }
 [`bytecheck`]: https://github.com/rkyv/bytecheck
 [`bytemuck`]: https://docs.rs/bytemuck
 [`encase`]: https://github.com/teoxoy/encase
+[`float_eq`]: https://docs.rs/float_eq
 [`libm`]: https://github.com/rust-lang/libm
 [`mint`]: https://github.com/kvark/mint
 [`rand`]: https://github.com/rust-random/rand

--- a/src/features.rs
+++ b/src/features.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "approx")]
 pub mod impl_approx;
 
+#[cfg(feature = "float_eq")]
+pub mod impl_float_eq;
+
 #[cfg(feature = "bytemuck")]
 pub mod impl_bytemuck;
 

--- a/src/features/impl_float_eq.rs
+++ b/src/features/impl_float_eq.rs
@@ -1,0 +1,273 @@
+use crate::{Affine2, Affine3, Affine3A, Mat2, Mat3, Mat3A, Mat4, Quat, Vec2, Vec3, Vec3A, Vec4};
+#[cfg(feature = "f64")]
+use crate::{DAffine2, DAffine3, DMat2, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4};
+use float_eq::{
+    AssertFloatEq, AssertFloatEqAll, DebugUlpsDiff, FloatEq, FloatEqAll, FloatEqDebugUlpsDiff,
+    FloatEqUlpsTol, UlpsTol,
+};
+
+// Every glam type here can be viewed as a fixed size array of primitives, and
+// `float_eq` already implements all of its traits for `[T; N]`. So each impl
+// just borrows the values as an array (via `to_array` or `to_cols_array`) and
+// defers to that. The tolerance and debug types are the array's, which keeps
+// the per-field comparisons lining up with the components of the type.
+macro_rules! impl_float_eq {
+    ($prim:ident, $type:ty, $n:literal, $to_array:ident) => {
+        impl FloatEqUlpsTol for $type {
+            type UlpsTol = <[$prim; $n] as FloatEqUlpsTol>::UlpsTol;
+        }
+
+        impl FloatEqDebugUlpsDiff for $type {
+            type DebugUlpsDiff = <[$prim; $n] as FloatEqDebugUlpsDiff>::DebugUlpsDiff;
+        }
+
+        impl FloatEq for $type {
+            type Tol = <[$prim; $n] as FloatEq>::Tol;
+
+            fn eq_abs(&self, other: &Self, tol: &Self::Tol) -> bool {
+                self.$to_array().eq_abs(&other.$to_array(), tol)
+            }
+
+            fn eq_rmax(&self, other: &Self, tol: &Self::Tol) -> bool {
+                self.$to_array().eq_rmax(&other.$to_array(), tol)
+            }
+
+            fn eq_rmin(&self, other: &Self, tol: &Self::Tol) -> bool {
+                self.$to_array().eq_rmin(&other.$to_array(), tol)
+            }
+
+            fn eq_r1st(&self, other: &Self, tol: &Self::Tol) -> bool {
+                self.$to_array().eq_r1st(&other.$to_array(), tol)
+            }
+
+            fn eq_r2nd(&self, other: &Self, tol: &Self::Tol) -> bool {
+                self.$to_array().eq_r2nd(&other.$to_array(), tol)
+            }
+
+            fn eq_ulps(&self, other: &Self, tol: &UlpsTol<Self::Tol>) -> bool {
+                self.$to_array().eq_ulps(&other.$to_array(), tol)
+            }
+        }
+
+        impl FloatEqAll for $type {
+            type AllTol = <[$prim; $n] as FloatEqAll>::AllTol;
+
+            fn eq_abs_all(&self, other: &Self, tol: &Self::AllTol) -> bool {
+                self.$to_array().eq_abs_all(&other.$to_array(), tol)
+            }
+
+            fn eq_rmax_all(&self, other: &Self, tol: &Self::AllTol) -> bool {
+                self.$to_array().eq_rmax_all(&other.$to_array(), tol)
+            }
+
+            fn eq_rmin_all(&self, other: &Self, tol: &Self::AllTol) -> bool {
+                self.$to_array().eq_rmin_all(&other.$to_array(), tol)
+            }
+
+            fn eq_r1st_all(&self, other: &Self, tol: &Self::AllTol) -> bool {
+                self.$to_array().eq_r1st_all(&other.$to_array(), tol)
+            }
+
+            fn eq_r2nd_all(&self, other: &Self, tol: &Self::AllTol) -> bool {
+                self.$to_array().eq_r2nd_all(&other.$to_array(), tol)
+            }
+
+            fn eq_ulps_all(&self, other: &Self, tol: &UlpsTol<Self::AllTol>) -> bool {
+                self.$to_array().eq_ulps_all(&other.$to_array(), tol)
+            }
+        }
+
+        impl AssertFloatEq for $type {
+            type DebugAbsDiff = <[$prim; $n] as AssertFloatEq>::DebugAbsDiff;
+            type DebugTol = <[$prim; $n] as AssertFloatEq>::DebugTol;
+
+            fn debug_abs_diff(&self, other: &Self) -> Self::DebugAbsDiff {
+                self.$to_array().debug_abs_diff(&other.$to_array())
+            }
+
+            fn debug_ulps_diff(&self, other: &Self) -> DebugUlpsDiff<Self::DebugAbsDiff> {
+                self.$to_array().debug_ulps_diff(&other.$to_array())
+            }
+
+            fn debug_abs_tol(&self, other: &Self, tol: &Self::Tol) -> Self::DebugTol {
+                self.$to_array().debug_abs_tol(&other.$to_array(), tol)
+            }
+
+            fn debug_rmax_tol(&self, other: &Self, tol: &Self::Tol) -> Self::DebugTol {
+                self.$to_array().debug_rmax_tol(&other.$to_array(), tol)
+            }
+
+            fn debug_rmin_tol(&self, other: &Self, tol: &Self::Tol) -> Self::DebugTol {
+                self.$to_array().debug_rmin_tol(&other.$to_array(), tol)
+            }
+
+            fn debug_r1st_tol(&self, other: &Self, tol: &Self::Tol) -> Self::DebugTol {
+                self.$to_array().debug_r1st_tol(&other.$to_array(), tol)
+            }
+
+            fn debug_r2nd_tol(&self, other: &Self, tol: &Self::Tol) -> Self::DebugTol {
+                self.$to_array().debug_r2nd_tol(&other.$to_array(), tol)
+            }
+
+            fn debug_ulps_tol(
+                &self,
+                other: &Self,
+                tol: &UlpsTol<Self::Tol>,
+            ) -> UlpsTol<Self::DebugTol> {
+                self.$to_array().debug_ulps_tol(&other.$to_array(), tol)
+            }
+        }
+
+        impl AssertFloatEqAll for $type {
+            type AllDebugTol = <[$prim; $n] as AssertFloatEqAll>::AllDebugTol;
+
+            fn debug_abs_all_tol(&self, other: &Self, tol: &Self::AllTol) -> Self::AllDebugTol {
+                self.$to_array().debug_abs_all_tol(&other.$to_array(), tol)
+            }
+
+            fn debug_rmax_all_tol(&self, other: &Self, tol: &Self::AllTol) -> Self::AllDebugTol {
+                self.$to_array().debug_rmax_all_tol(&other.$to_array(), tol)
+            }
+
+            fn debug_rmin_all_tol(&self, other: &Self, tol: &Self::AllTol) -> Self::AllDebugTol {
+                self.$to_array().debug_rmin_all_tol(&other.$to_array(), tol)
+            }
+
+            fn debug_r1st_all_tol(&self, other: &Self, tol: &Self::AllTol) -> Self::AllDebugTol {
+                self.$to_array().debug_r1st_all_tol(&other.$to_array(), tol)
+            }
+
+            fn debug_r2nd_all_tol(&self, other: &Self, tol: &Self::AllTol) -> Self::AllDebugTol {
+                self.$to_array().debug_r2nd_all_tol(&other.$to_array(), tol)
+            }
+
+            fn debug_ulps_all_tol(
+                &self,
+                other: &Self,
+                tol: &UlpsTol<Self::AllTol>,
+            ) -> UlpsTol<Self::AllDebugTol> {
+                self.$to_array().debug_ulps_all_tol(&other.$to_array(), tol)
+            }
+        }
+    };
+}
+
+impl_float_eq!(f32, Vec2, 2, to_array);
+impl_float_eq!(f32, Vec3, 3, to_array);
+impl_float_eq!(f32, Vec3A, 3, to_array);
+impl_float_eq!(f32, Vec4, 4, to_array);
+impl_float_eq!(f32, Quat, 4, to_array);
+impl_float_eq!(f32, Mat2, 4, to_cols_array);
+impl_float_eq!(f32, Mat3, 9, to_cols_array);
+impl_float_eq!(f32, Mat3A, 9, to_cols_array);
+impl_float_eq!(f32, Mat4, 16, to_cols_array);
+impl_float_eq!(f32, Affine2, 6, to_cols_array);
+impl_float_eq!(f32, Affine3, 12, to_cols_array);
+impl_float_eq!(f32, Affine3A, 12, to_cols_array);
+
+#[cfg(feature = "f64")]
+impl_float_eq!(f64, DVec2, 2, to_array);
+#[cfg(feature = "f64")]
+impl_float_eq!(f64, DVec3, 3, to_array);
+#[cfg(feature = "f64")]
+impl_float_eq!(f64, DVec4, 4, to_array);
+#[cfg(feature = "f64")]
+impl_float_eq!(f64, DQuat, 4, to_array);
+#[cfg(feature = "f64")]
+impl_float_eq!(f64, DMat2, 4, to_cols_array);
+#[cfg(feature = "f64")]
+impl_float_eq!(f64, DMat3, 9, to_cols_array);
+#[cfg(feature = "f64")]
+impl_float_eq!(f64, DMat4, 16, to_cols_array);
+#[cfg(feature = "f64")]
+impl_float_eq!(f64, DAffine2, 6, to_cols_array);
+#[cfg(feature = "f64")]
+impl_float_eq!(f64, DAffine3, 12, to_cols_array);
+
+#[cfg(test)]
+mod test {
+    use crate::*;
+    use float_eq::{assert_float_eq, assert_float_ne};
+
+    // Perturbs a value by scaling it, which nudges every component by the same
+    // number of ulps away from the original.
+    macro_rules! impl_float_eq_test {
+        ($prim:ident, $type:ident, $ones:expr) => {{
+            let ones: $type = $ones;
+            let eps = $prim::EPSILON;
+            let near = ones * (1.0 + 2.0 * eps);
+            let far = ones * (1.0 + 64.0 * eps);
+
+            assert_float_eq!(ones, ones, abs_all <= 0.0);
+            assert_float_eq!(ones, ones, ulps_all <= 0);
+
+            assert_float_eq!(ones, near, abs_all <= 4.0 * eps);
+            assert_float_eq!(ones, near, rmax_all <= 4.0 * eps);
+            assert_float_eq!(ones, near, ulps_all <= 4);
+
+            assert_float_ne!(ones, far, abs_all <= 4.0 * eps);
+            assert_float_ne!(ones, far, rmax_all <= 4.0 * eps);
+            assert_float_ne!(ones, far, ulps_all <= 4);
+        }};
+        ($prim:ident, $type:ident) => {
+            impl_float_eq_test!($prim, $type, $type::ONE)
+        };
+    }
+
+    // Affine types don't multiply by a scalar, so build the perturbed values
+    // from their column arrays instead.
+    macro_rules! impl_affine_float_eq_test {
+        ($prim:ident, $type:ident, $n:literal) => {{
+            let eps = $prim::EPSILON;
+            let ones = <$type>::from_cols_array(&[1.0; $n]);
+            let mut near_cols: [$prim; $n] = [1.0; $n];
+            near_cols.iter_mut().for_each(|x| *x += 2.0 * eps);
+            let near = <$type>::from_cols_array(&near_cols);
+            let mut far_cols: [$prim; $n] = [1.0; $n];
+            far_cols.iter_mut().for_each(|x| *x += 64.0 * eps);
+            let far = <$type>::from_cols_array(&far_cols);
+
+            assert_float_eq!(ones, ones, abs_all <= 0.0);
+            assert_float_eq!(ones, near, abs_all <= 4.0 * eps);
+            assert_float_eq!(ones, near, ulps_all <= 4);
+            assert_float_ne!(ones, far, abs_all <= 4.0 * eps);
+            assert_float_ne!(ones, far, ulps_all <= 4);
+        }};
+    }
+
+    #[test]
+    fn test_float_eq_f32() {
+        const ONES: [f32; 16] = [1.0; 16];
+
+        impl_float_eq_test!(f32, Vec2);
+        impl_float_eq_test!(f32, Vec3);
+        impl_float_eq_test!(f32, Vec3A);
+        impl_float_eq_test!(f32, Vec4);
+        impl_float_eq_test!(f32, Quat, Quat::from_slice(&ONES));
+        impl_float_eq_test!(f32, Mat2, Mat2::from_cols_slice(&ONES));
+        impl_float_eq_test!(f32, Mat3, Mat3::from_cols_slice(&ONES));
+        impl_float_eq_test!(f32, Mat3A, Mat3A::from_cols_slice(&ONES));
+        impl_float_eq_test!(f32, Mat4, Mat4::from_cols_slice(&ONES));
+
+        impl_affine_float_eq_test!(f32, Affine2, 6);
+        impl_affine_float_eq_test!(f32, Affine3, 12);
+        impl_affine_float_eq_test!(f32, Affine3A, 12);
+    }
+
+    #[cfg(feature = "f64")]
+    #[test]
+    fn test_float_eq_f64() {
+        const ONES: [f64; 16] = [1.0; 16];
+
+        impl_float_eq_test!(f64, DVec2);
+        impl_float_eq_test!(f64, DVec3);
+        impl_float_eq_test!(f64, DVec4);
+        impl_float_eq_test!(f64, DQuat, DQuat::from_slice(&ONES));
+        impl_float_eq_test!(f64, DMat2, DMat2::from_cols_slice(&ONES));
+        impl_float_eq_test!(f64, DMat3, DMat3::from_cols_slice(&ONES));
+        impl_float_eq_test!(f64, DMat4, DMat4::from_cols_slice(&ONES));
+
+        impl_affine_float_eq_test!(f64, DAffine2, 6);
+        impl_affine_float_eq_test!(f64, DAffine3, 12);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -276,6 +276,7 @@ and benchmarks.
 * `arbitrary` - implementations of `Arbitrary` trait for all `glam` types.
 * `bytemuck` - for casting into slices of bytes
 * `encase` - `encase` trait implementations for `glam` types.
+* `float_eq` - traits and macros for comparing float types using various tolerances.
 * `libm` - uses `libm` math functions instead of `std`
 * `mint` - for interoperating with other 3D math libraries
 * `rand` - implementations of `Distribution` trait for all `glam` types.

--- a/tools/ci/src/features.rs
+++ b/tools/ci/src/features.rs
@@ -1,6 +1,6 @@
 macro_rules! deps {
     () => {
-        "arbitrary approx bytemuck encase mint rand rkyv bytecheck serde speedy zerocopy debug-glam-assert"
+        "arbitrary approx bytemuck encase float_eq mint rand rkyv bytecheck serde speedy zerocopy debug-glam-assert"
     };
 }
 
@@ -24,7 +24,7 @@ pub(crate) const ALL_FEATURES: &str = deps!();
 
 // core-simd profile features (no zerocopy as it doesn't compile with core-simd)
 pub(crate) const CORE_SIMD_FEATURES: &str =
-    "core-simd arbitrary approx bytemuck encase mint rand rkyv bytecheck serde speedy debug-glam-assert";
+    "core-simd arbitrary approx bytemuck encase float_eq mint rand rkyv bytecheck serde speedy debug-glam-assert";
 
 pub fn resolve_sets(index: Option<usize>) -> &'static [&'static str] {
     match index {


### PR DESCRIPTION
# Objective

- Add optional `float_eq` support for the glam types, matching the existing `approx` feature.
- Closes #470.

Each type forwards to its component array (`to_array` / `to_cols_array`) and defers to the `[T; N]` impls in `float_eq`, so the per-field tolerances and debug output line up with the components. I wired it into the ci feature lists next to approx and added a test covering the abs, relative and ulps comparisons for every type.