### PR TITLE
Add float move_towards methods

### DIFF
--- a/src/f32/float.rs
+++ b/src/f32/float.rs
@@ -37,4 +37,14 @@ impl FloatExt for f32 {
     fn saturate(self) -> Self {
         self.clamp(0.0, 1.0)
     }
+
+    #[inline]
+    fn move_towards(self, rhs: Self, d: Self) -> Self {
+        let a = rhs - self;
+        if a.abs() <= d {
+            rhs
+        } else {
+            self + a.signum() * d
+        }
+    }
 }

--- a/src/f64/float.rs
+++ b/src/f64/float.rs
@@ -37,4 +37,14 @@ impl FloatExt for f64 {
     fn saturate(self) -> Self {
         self.clamp(0.0, 1.0)
     }
+
+    #[inline]
+    fn move_towards(self, rhs: Self, d: Self) -> Self {
+        let a = rhs - self;
+        if a.abs() <= d {
+            rhs
+        } else {
+            self + a.signum() * d
+        }
+    }
 }

--- a/src/float.rs
+++ b/src/float.rs
@@ -45,4 +45,12 @@ pub trait FloatExt {
     /// Returns `self` clamped within the range `[0.0, 1.0]`
     #[must_use]
     fn saturate(self) -> Self;
+
+    /// Moves `self` towards `rhs` by at most the distance `d`.
+    ///
+    /// When `d` is `0.0`, the result will be equal to `self`. When `d` is greater than or
+    /// equal to the distance between `self` and `rhs`, the result will be equal to `rhs`.
+    /// Will not go past `rhs`.
+    #[must_use]
+    fn move_towards(self, rhs: Self, d: Self) -> Self;
 }

--- a/templates/float.rs.tera
+++ b/templates/float.rs.tera
@@ -37,4 +37,14 @@ impl FloatExt for {{ scalar_t }} {
     fn saturate(self) -> Self {
         self.clamp(0.0, 1.0)
     }
+
+    #[inline]
+    fn move_towards(self, rhs: Self, d: Self) -> Self {
+        let a = rhs - self;
+        if a.abs() <= d {
+            rhs
+        } else {
+            self + a.signum() * d
+        }
+    }
 }

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -39,6 +39,16 @@ macro_rules! impl_float_tests {
             assert_approx_eq!((-2000000.123).fract_gl(), 0.877, 0.002);
             assert_approx_eq!(1000000.123.fract_gl(), 0.123, 0.002);
         });
+
+        glam_test!(test_move_towards, {
+            assert_eq!($t::move_towards(-1., 1., 0.), -1.);
+            assert_eq!($t::move_towards(-1., 1., 1.), 0.);
+            assert_eq!($t::move_towards(-1., 1., 2.), 1.);
+            assert_eq!($t::move_towards(-1., 1., 3.), 1.);
+            assert_eq!($t::move_towards(1., -1., 1.), 0.);
+            assert_eq!($t::move_towards(1., -1., 3.), -1.);
+            assert_eq!($t::move_towards(1., 1., 1.), 1.);
+        });
     };
 }
 


### PR DESCRIPTION
# Objective

Glam implements move_towards for Vec2 Vec3 Vec4 but not for Floats

## Solution

Added very simple implementation of move_towards for Float, with tests