### PR TITLE
feat: add smoothstep methods

### DIFF
--- a/src/f32/coresimd/vec3a.rs
+++ b/src/f32/coresimd/vec3a.rs
@@ -801,6 +801,19 @@ impl Vec3A {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f32/coresimd/vec4.rs
+++ b/src/f32/coresimd/vec4.rs
@@ -782,6 +782,19 @@ impl Vec4 {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f32/float.rs
+++ b/src/f32/float.rs
@@ -14,6 +14,12 @@ impl FloatExt for f32 {
     }
 
     #[inline]
+    fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        let t = ((self - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+        t * t * (3.0 - 2.0 * t)
+    }
+
+    #[inline]
     fn remap(self, in_start: Self, in_end: Self, out_start: Self, out_end: Self) -> Self {
         let t = Self::inverse_lerp(in_start, in_end, self);
         Self::lerp(out_start, out_end, t)

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -850,6 +850,19 @@ impl Vec3A {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -818,6 +818,19 @@ impl Vec4 {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f32/scalar/vec3a.rs
+++ b/src/f32/scalar/vec3a.rs
@@ -840,6 +840,19 @@ impl Vec3A {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f32/scalar/vec4.rs
+++ b/src/f32/scalar/vec4.rs
@@ -883,6 +883,19 @@ impl Vec4 {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -854,6 +854,19 @@ impl Vec3A {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f32/sse2/vec4.rs
+++ b/src/f32/sse2/vec4.rs
@@ -831,6 +831,19 @@ impl Vec4 {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f32/vec2.rs
+++ b/src/f32/vec2.rs
@@ -719,6 +719,19 @@ impl Vec2 {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f32/vec3.rs
+++ b/src/f32/vec3.rs
@@ -829,6 +829,19 @@ impl Vec3 {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f32/wasm/vec3a.rs
+++ b/src/f32/wasm/vec3a.rs
@@ -820,6 +820,19 @@ impl Vec3A {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f32/wasm/vec4.rs
+++ b/src/f32/wasm/vec4.rs
@@ -801,6 +801,19 @@ impl Vec4 {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f64/dvec2.rs
+++ b/src/f64/dvec2.rs
@@ -727,6 +727,19 @@ impl DVec2 {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f64/dvec3.rs
+++ b/src/f64/dvec3.rs
@@ -830,6 +830,19 @@ impl DVec3 {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f64/dvec4.rs
+++ b/src/f64/dvec4.rs
@@ -884,6 +884,19 @@ impl DVec4 {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/src/f64/float.rs
+++ b/src/f64/float.rs
@@ -14,6 +14,12 @@ impl FloatExt for f64 {
     }
 
     #[inline]
+    fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        let t = ((self - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+        t * t * (3.0 - 2.0 * t)
+    }
+
+    #[inline]
     fn remap(self, in_start: Self, in_end: Self, out_start: Self, out_end: Self) -> Self {
         let t = Self::inverse_lerp(in_start, in_end, self);
         Self::lerp(out_start, out_end, t)

--- a/src/float.rs
+++ b/src/float.rs
@@ -17,6 +17,13 @@ pub trait FloatExt {
     /// `a` and `b` must not be equal, otherwise the result will be either infinite or `NAN`.
     fn inverse_lerp(a: Self, b: Self, v: Self) -> Self;
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if `edge0` is greater than or equal to `edge1`.
+    #[must_use]
+    fn smoothstep(self, edge0: Self, edge1: Self) -> Self;
+
     /// Remap `self` from the input range to the output range.
     ///
     /// When `self` is equal to `in_start` this returns `out_start`.

--- a/templates/float.rs.tera
+++ b/templates/float.rs.tera
@@ -14,6 +14,12 @@ impl FloatExt for {{ scalar_t }} {
     }
 
     #[inline]
+    fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        let t = ((self - edge0) / (edge1 - edge0)).clamp(0.0, 1.0);
+        t * t * (3.0 - 2.0 * t)
+    }
+
+    #[inline]
     fn remap(self, in_start: Self, in_end: Self, out_start: Self, out_end: Self) -> Self {
         let t = Self::inverse_lerp(in_start, in_end, self);
         Self::lerp(out_start, out_end, t)

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -2114,6 +2114,19 @@ impl {{ self_t }} {
         Self::select(rhs.cmplt(self), Self::ZERO, Self::ONE)
     }
 
+    /// Performs Hermite interpolation between `0.0` and `1.0` using `x` normalized to `[edge0, edge1]`.
+    ///
+    /// This is equivalent to `t * t * (3.0 - 2.0 * t)`, where `t` is clamped to `[0.0, 1.0]`.
+    /// Results are undefined if any element of `edge0` is greater than or equal to the corresponding
+    /// element of `edge1`.
+    #[inline]
+    #[must_use]
+    pub fn smoothstep(self, edge0: Self, edge1: Self) -> Self {
+        glam_assert!(edge0.cmplt(edge1).all());
+        let t = ((self - edge0) / (edge1 - edge0)).saturate();
+        t * t * (Self::splat(3.0) - Self::splat(2.0) * t)
+    }
+
     /// Returns a vector containing all elements of `self` clamped to the range of `[0, 1]`.
     #[inline]
     #[must_use]

--- a/tests/float.rs
+++ b/tests/float.rs
@@ -24,6 +24,14 @@ macro_rules! impl_float_tests {
             assert!($t::inverse_lerp(a, a, 1.).is_infinite());
         });
 
+        glam_test!(test_smoothstep, {
+            assert_eq!((-1. as $t).smoothstep(0., 1.), 0.);
+            assert_eq!((0. as $t).smoothstep(0., 1.), 0.);
+            assert_eq!((0.5 as $t).smoothstep(0., 1.), 0.5);
+            assert_eq!((1. as $t).smoothstep(0., 1.), 1.);
+            assert_eq!((2. as $t).smoothstep(0., 1.), 1.);
+        });
+
         glam_test!(test_remap, {
             assert_eq!($t::remap(0., 0., 2., 0., 20.), 0.);
             assert_eq!($t::remap(1., 0., 2., 0., 20.), 10.);

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -1599,6 +1599,17 @@ macro_rules! impl_vec2_float_tests {
             );
         });
 
+        glam_test!(test_smoothstep, {
+            let t = $vec2::new(0.0, 0.75);
+            assert_approx_eq!(
+                $vec2::new(-2.0, 2.0).smoothstep($vec2::splat(-1.0), $vec2::splat(3.0)),
+                t * t * ($vec2::splat(3.0) - $vec2::splat(2.0) * t),
+                1e-5
+            );
+            should_glam_assert!({ $vec2::ZERO.smoothstep($vec2::ZERO, $vec2::X) });
+            should_glam_assert!({ $vec2::ZERO.smoothstep($vec2::ONE, $vec2::ZERO) });
+        });
+
         glam_test!(test_saturate, {
             use glam::FloatExt;
             assert_approx_eq!(

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -1900,6 +1900,17 @@ macro_rules! impl_vec3_float_tests {
             );
         });
 
+        glam_test!(test_smoothstep, {
+            let t = $vec3::new(0.0, 0.25, 1.0);
+            assert_approx_eq!(
+                $vec3::new(-2.0, 0.0, 4.0).smoothstep($vec3::splat(-1.0), $vec3::splat(3.0)),
+                t * t * ($vec3::splat(3.0) - $vec3::splat(2.0) * t),
+                1e-5
+            );
+            should_glam_assert!({ $vec3::ZERO.smoothstep($vec3::ZERO, $vec3::X) });
+            should_glam_assert!({ $vec3::ZERO.smoothstep($vec3::ONE, $vec3::ZERO) });
+        });
+
         glam_test!(test_saturate, {
             use glam::FloatExt;
             assert_approx_eq!(

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1990,6 +1990,17 @@ macro_rules! impl_vec4_float_tests {
             );
         });
 
+        glam_test!(test_smoothstep, {
+            let t = $vec4::new(0.0, 0.25, 0.75, 1.0);
+            assert_approx_eq!(
+                $vec4::new(-2.0, 0.0, 2.0, 4.0).smoothstep($vec4::splat(-1.0), $vec4::splat(3.0)),
+                t * t * ($vec4::splat(3.0) - $vec4::splat(2.0) * t),
+                1e-5
+            );
+            should_glam_assert!({ $vec4::ZERO.smoothstep($vec4::ZERO, $vec4::X) });
+            should_glam_assert!({ $vec4::ZERO.smoothstep($vec4::ONE, $vec4::ZERO) });
+        });
+
         glam_test!(test_saturate, {
             use glam::FloatExt;
             assert_approx_eq!(


### PR DESCRIPTION
# Objective

Smoothstep is a common standardised function available in shaders, but not currently available in glam unlike map_toward lerp inverse_lerp etc.

## Solution

Adds smoothstep methods to floats and vecs, it uses (x, edge0, edge1) signature which differs from opengl but fits with the rust standards better I think. as you might do x.smoothstep(edge0, edge1) and it doesn't really read correctly to do edge0.smoothstep(edge1, x)