### PR TITLE
perf: Rewrote sclar-math impl of Mat3A::mul_vec3a to stop LLVM being stupid.

### DIFF
--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -772,10 +772,11 @@ impl Mat3A {
     #[inline]
     #[must_use]
     pub fn mul_vec3a(&self, rhs: Vec3A) -> Vec3A {
-        let mut res = self.x_axis.mul(rhs.xxx());
-        res = res.add(self.y_axis.mul(rhs.yyy()));
-        res = res.add(self.z_axis.mul(rhs.zzz()));
-        res
+        Vec3A::new(
+            self.x_axis.x * rhs.x + self.y_axis.x * rhs.y + self.z_axis.x * rhs.z,
+            self.x_axis.y * rhs.x + self.y_axis.y * rhs.y + self.z_axis.y * rhs.z,
+            self.x_axis.z * rhs.x + self.y_axis.z * rhs.y + self.z_axis.z * rhs.z,
+        )
     }
 
     /// Transforms a 3D vector by the transpose of `self`.

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -2480,10 +2480,23 @@ impl {{ self_t }} {
     #[inline]
     #[must_use]
     pub fn mul_vec3a(&self, rhs: Vec3A) -> Vec3A {
+        {% if is_scalar %}
+        {#
+            Written as explicit row-dot products rather than swizzles: the scalar Vec3A has an
+            initialized padding lane which drives LLVM's vectorizer into shuffle-heavy code,
+            regressing scalar-math benches on x86_64 by ~20 instructions.
+        #}
+        Vec3A::new(
+            self.x_axis.x * rhs.x + self.y_axis.x * rhs.y + self.z_axis.x * rhs.z,
+            self.x_axis.y * rhs.x + self.y_axis.y * rhs.y + self.z_axis.y * rhs.z,
+            self.x_axis.z * rhs.x + self.y_axis.z * rhs.y + self.z_axis.z * rhs.z,
+        )
+        {% else %}
         let mut res = self.x_axis.mul(rhs.xxx());
         res = res.add(self.y_axis.mul(rhs.yyy()));
         res = res.add(self.z_axis.mul(rhs.zzz()));
         res
+        {% endif %}
     }
 {% endif %}
 


### PR DESCRIPTION
There were some perf regressions from adding padding to Vec3A due to the LLVM optimizer doing unoptimal things, this work around mitigates the largest regression.

