### PR TITLE
ci(bench): remove committed baselines before update.

### DIFF
--- a/.github/workflows/bench-update.yml
+++ b/.github/workflows/bench-update.yml
@@ -30,6 +30,10 @@ jobs:
       - run: rustup default ${{ env.BENCH_TOOLCHAIN }}
       - name: Install valgrind
         run: sudo apt-get update && sudo apt-get install -y valgrind
+      - name: Remove committed baselines
+        run: |
+          find benches/gungraun-baselines -type f -name '*.base@*' -delete
+          find benches/gungraun-baselines -type d -empty -delete
       - run: cargo run --release -p ci -- bench --save
       - name: Keep only baseline files
         run: |
@@ -47,6 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      - name: Remove committed baselines
+        run: |
+          find benches/gungraun-baselines -type f -name '*.base@*' -delete
+          find benches/gungraun-baselines -type d -empty -delete
       - uses: actions/download-artifact@v8
         with:
           pattern: baselines-*


### PR DESCRIPTION
Remove generated baselines before save and artifact step so committed baselines are not in the artifact and also remove them before downloading artifacts from each runner so old baselines get removed.
