### PR TITLE
chore: Updated contributing docs

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,36 @@
+Using AI (i.e., LLMs) as tools for contributing to glam is allowed. A high bar
+is held for all contributions to this project. Moreover, the project maintainers
+remain responsible for any code that is published as part of a release.
+Contributors are expected to be responsible for any code they publish.
+
+**AI should not be used to generate comments when communicating with
+maintainers**. Comments are expected to be written by humans. Comments that are
+believed to be written by AI may be hidden without notice.
+
+If you are opening an issue, you should be able to describe the problem in your
+own words.
+
+If you are opening a pull request, you are expected to be able to explain the
+proposed changes in your own words. This includes the pull request body and
+responses to questions. **Do not copy responses from the AI when replying to
+questions from maintainers.**
+
+This project requires a human in the loop who understands the work produced by
+AI. **Autonomous agents are not allowed to be used for contributing to this
+project**. Pull requests that appear in violation of this will be closed,
+perhaps without notice.
+
+If you wish to include context from an interaction with AI in your comments, it
+must be in a quote block (e.g., using `>`) and disclosed as such. It must be
+accompanied by human commentary explaining the relevance and implications of
+the context. Do not share long snippets.
+
+AI is useful when communicating as a non-native English speaker. If you are
+using AI to edit your comments for this purpose, please take the time to ensure
+it reflects your own voice and ideas. If using AI for translation, we recommend
+writing in your native language and including the AI translation in a quote
+block.
+
+This policy was adapted from [ripgrep's AI policy].
+
+[uv's AI policy]: https://github.com/BurntSushi/ripgrep/blob/4857d6fa67db69a95cd4b6f2adda5d807d4d0119/AI_POLICY.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,11 @@ The short guide to contributing is [start a discussion] on GitHub.  Pull
 requests are welcome for bug fixes, documentation improvements and
 optimizations. For anything else it would be best to discuss it first.
 
+## Use of AI
+
+All use of AI in contributions must follow the [AI Policy]. Contributions not
+following the AI Policy will be closed.
+
 ## Questions
 
 If you have a question about the usage of this library please [ask a question]
@@ -34,32 +39,6 @@ If you feel some functionality could be optimized please [open an issue] on
 GitHub or submit a pull request. Any optimization pull request should include a
 benchmark if there isn't one already, so I can confirm the performance
 improvement.
-
-## Instruction count baselines
-
-The gungraun benchmarks in `benches/gungraun.rs` run under valgrind and count
-executed instructions. Install valgrind first (e.g. `sudo apt-get install
-valgrind` on Ubuntu or `sudo dnf install valgrind` on Fedora); the
-`gungraun-runner` binary is installed automatically by the ci tool.
-
-- Check for regressions: `cargo run --release -p ci -- bench`
-- Update baselines after an intentional change: `cargo run --release -p ci -- bench --save`
-
-The results are compared against baselines committed in
-`benches/gungraun-baselines`, tracked per backend: `sse2` and `scalar_math`
-on x86_64 Linux and `neon` on aarch64 Linux. Other hosts are skipped because
-valgrind doesn't run on macOS, and counts are only comparable for the
-toolchain and target triple they were generated with. CI fails pull requests
-on any instruction-count regression; the `Update gungraun baselines` workflow
-regenerates all backends (including `neon`, which needs an ARM runner) and
-opens a pull request. When bumping the pinned `BENCH_TOOLCHAIN` in
-`.github/workflows/bench.yml`, rerun that workflow in the same pull request.
-
-Counts are also only reproducible for an identical dependency resolution, so
-the benchmarks pin their own lockfile at `benches/gungraun-baselines/Cargo.lock`
-instead of using the repository's untracked `Cargo.lock` (which is backed up
-and restored around the run). Bumping the `gungraun` dev-dependency and
-rerunning `--save` updates the lockfile together with the baselines.
 
 ## Documentation
 
@@ -139,3 +118,4 @@ Also run `cargo fmt` on any new hand-written files and `cargo clippy` on any new
 [Tera v2]: https://keats.github.io/tera/
 [Conventional Commits]: https://www.conventionalcommits.org/
 [changelog]: CHANGELOG.md
+[AI Policy]: AI_POLICY.md


### PR DESCRIPTION
Add a policy for machines.

Remove gungraun section. Baselines should be updated from CI for consistency but perhaps the docs should explain how to use it instead.
