### PR TITLE
ci: fix summary md merge collision

### DIFF
--- a/.github/workflows/bench-update.yml
+++ b/.github/workflows/bench-update.yml
@@ -33,6 +33,7 @@ jobs:
       - name: Remove baselines saved by other runners
         run: |
           find benches/gungraun-baselines -type f -name '*.base@*' -delete
+          rm -f benches/gungraun-baselines/x86_64.md benches/gungraun-baselines/aarch64.md
           find benches/gungraun-baselines -type d -empty -delete
       - uses: Swatinem/rust-cache@v2
       - run: rustup update --no-self-update ${{ env.BENCH_TOOLCHAIN }}


### PR DESCRIPTION
Each bench-update runner was uploading both arch summary files, so `merge-multiple` could let a stale `x86_64.md`/`aarch64.md` overwrite the freshly generated one. Each runner now deletes both summary files before saving, leaving only its own arch's file in its artifact.