### PR TITLE
perf: Use m128_sin in Vec3A::slerp

### DIFF
--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -1339,7 +1339,6 @@ impl Vec3A {
             // Angle between the vectors [0, +π]
             let theta = math::acos_approx(dot);
             // Sine of the angle between vectors [0, 1]
-
             let x = 1.0 - s;
             let y = s;
             let z = 1.0;

--- a/src/f32/sse2/vec3a.rs
+++ b/src/f32/sse2/vec3a.rs
@@ -1339,9 +1339,20 @@ impl Vec3A {
             // Angle between the vectors [0, +π]
             let theta = math::acos_approx(dot);
             // Sine of the angle between vectors [0, 1]
-            let sin_theta = math::sin(theta);
-            let t1 = math::sin(theta * (1.0 - s));
-            let t2 = math::sin(theta * s);
+
+            let x = 1.0 - s;
+            let y = s;
+            let z = 1.0;
+
+            let (sin_theta, t1, t2) = unsafe {
+                let tmp = _mm_mul_ps(_mm_set_ps1(theta), _mm_set_ps(0.0, z, y, x));
+                let tmp = m128_sin(tmp);
+                (
+                    _mm_cvtss_f32(_mm_shuffle_ps(tmp, tmp, 0b10_10_10_10)), // sin(theta)
+                    _mm_cvtss_f32(_mm_shuffle_ps(tmp, tmp, 0b00_00_00_00)), // sin(theta * (1.0 - s))
+                    _mm_cvtss_f32(_mm_shuffle_ps(tmp, tmp, 0b01_01_01_01)), // sin(theta * s)
+                )
+            };
 
             // Interpolate vector lengths
             let result_length = self_length.lerp(rhs_length, s);

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -2692,9 +2692,25 @@ impl {{ self_t }} {
             // Angle between the vectors [0, +π]
             let theta = math::acos_approx(dot);
             // Sine of the angle between vectors [0, 1]
+            {% if is_sse2 %}
+            let x = 1.0 - s;
+            let y = s;
+            let z = 1.0;
+
+            let (sin_theta, t1, t2) = unsafe {
+                let tmp = _mm_mul_ps(_mm_set_ps1(theta), _mm_set_ps(0.0, z, y, x));
+                let tmp = m128_sin(tmp);
+                (
+                    _mm_cvtss_f32(_mm_shuffle_ps(tmp, tmp, 0b10_10_10_10)), // sin(theta)
+                    _mm_cvtss_f32(_mm_shuffle_ps(tmp, tmp, 0b00_00_00_00)), // sin(theta * (1.0 - s))
+                    _mm_cvtss_f32(_mm_shuffle_ps(tmp, tmp, 0b01_01_01_01)), // sin(theta * s)
+                )
+            };
+            {% else %}
             let sin_theta = math::sin(theta);
             let t1 = math::sin(theta * (1.0 - s));
             let t2 = math::sin(theta * s);
+            {% endif %}
         
             // Interpolate vector lengths
             let result_length = self_length.lerp(rhs_length, s);

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -2692,7 +2692,7 @@ impl {{ self_t }} {
             // Angle between the vectors [0, +π]
             let theta = math::acos_approx(dot);
             // Sine of the angle between vectors [0, 1]
-            {% if is_sse2 %}
+            {%- if is_sse2 %}
             let x = 1.0 - s;
             let y = s;
             let z = 1.0;
@@ -2706,7 +2706,7 @@ impl {{ self_t }} {
                     _mm_cvtss_f32(_mm_shuffle_ps(tmp, tmp, 0b01_01_01_01)), // sin(theta * s)
                 )
             };
-            {% else %}
+            {%- else %}
             let sin_theta = math::sin(theta);
             let t1 = math::sin(theta * (1.0 - s));
             let t2 = math::sin(theta * s);

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -1653,22 +1653,24 @@ macro_rules! impl_vec3_float_tests {
             );
             assert_approx_eq!(
                 v0.angle_between(v0.slerp(v1, 0.5)) * 2.0,
-                v0.angle_between(v1)
+                v0.angle_between(v1),
+                1e-5
             );
             assert_approx_eq!(
                 $vec3::new(5.0, 0.0, 0.0).slerp($vec3::new(0.0, 5.0, 0.0), 0.5),
-                $vec3::new(5.0, 5.0, 0.0) * std::$t::consts::FRAC_1_SQRT_2
+                $vec3::new(5.0, 5.0, 0.0) * std::$t::consts::FRAC_1_SQRT_2,
+                1e-5
             );
         });
         glam_test!(test_slerp_extrapolate, {
             let v0 = $vec3::Y;
             let v1 = $vec3::X;
             // Normalized
-            assert_approx_eq!(v0.slerp(v1, -1.0), $vec3::NEG_X, 2e-7);
-            assert_approx_eq!(v0.slerp(v1, 2.0), $vec3::NEG_Y, 2e-7);
+            assert_approx_eq!(v0.slerp(v1, -1.0), $vec3::NEG_X, 1e-6);
+            assert_approx_eq!(v0.slerp(v1, 2.0), $vec3::NEG_Y, 1e-6);
             // Scaled
-            assert_approx_eq!(v0.slerp(v1 * 1.5, -1.0), $vec3::NEG_X * 0.5);
-            assert_approx_eq!(v0.slerp(v1 * 1.5, 2.0), $vec3::NEG_Y * 2.0, 4e-7);
+            assert_approx_eq!(v0.slerp(v1 * 1.5, -1.0), $vec3::NEG_X * 0.5, 1e-6);
+            assert_approx_eq!(v0.slerp(v1 * 1.5, 2.0), $vec3::NEG_Y * 2.0, 1e-6);
         });
         glam_test!(test_slerp_parallel, {
             // Same direction


### PR DESCRIPTION
# Objective

- Use the m128_sin simd sin approx in Vec3A::slerp
- It's currently used in Quat::slerp, the vector version is similar.
