### PR TITLE
perf(quat): avoid acos in is_near_identity

### DIFF
--- a/benches/gungraun.rs
+++ b/benches/gungraun.rs
@@ -416,6 +416,12 @@ fn quat_inverse(q: Quat) -> Quat {
 }
 
 #[library_benchmark]
+#[bench::args(quat())]
+fn quat_is_near_identity(q: Quat) -> bool {
+    black_box(q.is_near_identity())
+}
+
+#[library_benchmark]
 #[bench::positive_dot(quat(), quat_rot_x_180(), bb_f32())]
 #[bench::negative_dot(quat(), quat_rot_x_240(), bb_f32())]
 fn quat_lerp(q1: Quat, q2: Quat, t: f32) -> Quat {
@@ -671,6 +677,7 @@ library_benchmark_group!(
         quat_from_axis_angle,
         quat_from_euler,
         quat_inverse,
+        quat_is_near_identity,
         quat_lerp,
         quat_mul_quat,
         quat_mul_vec3,

--- a/benches/quat.rs
+++ b/benches/quat.rs
@@ -45,6 +45,13 @@ bench_binop!(
     from => random_quat
 );
 
+bench_unop!(
+    quat_is_near_identity,
+    "quat is_near_identity",
+    op => is_near_identity,
+    from => random_quat
+);
+
 bench_trinop!(
     quat_lerp,
     "quat lerp",
@@ -69,6 +76,7 @@ criterion_group!(
     benches,
     quat_conjugate,
     quat_dot,
+    quat_is_near_identity,
     quat_lerp,
     quat_slerp,
     quat_mul_quat,

--- a/src/f32/coresimd/quat.rs
+++ b/src/f32/coresimd/quat.rs
@@ -620,29 +620,16 @@ impl Quat {
         Vec4::from(self).is_normalized()
     }
 
+    /// Returns `true` if `self` represents a rotation near the identity.
     #[inline]
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        // Because of floating point precision, we cannot represent very small rotations.
-        // The closest f32 to 1.0 that is not 1.0 itself yields:
-        // 0.99999994.acos() * 2.0  = 0.000690533954 rad
-        //
-        // An error threshold of 1.e-6 is used by default.
-        // (1.0 - 1.e-6).acos() * 2.0 = 0.00284714461 rad
-        // (1.0 - 1.e-7).acos() * 2.0 = 0.00097656250 rad
-        //
-        // We don't really care about the angle value itself, only if it's close to 0.
-        // This will happen whenever quat.w is close to 1.0.
-        // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
-        // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
-        // the shortest path.
-        //
-        // For f64 we're using a threshhold of
-        // (1.0 - 1e-14).acos() * 2.0
-        const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
-        let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < THRESHOLD_ANGLE
+        // The shortest rotation angle is `2 * acos(abs(w))`. Since `acos` is monotonically
+        // decreasing, comparing `abs(w)` to the cosine threshold avoids calculating the angle.
+        // Equivalent to an angular threshold of `(1.0 - 1e-6).acos() * 2.0`.
+        const THRESHOLD: f32 = 1.0 - 1e-6;
+        math::abs(self.w) > THRESHOLD
     }
 
     /// Returns the angle (in radians) for the minimal rotation between two quaternions

--- a/src/f32/neon/quat.rs
+++ b/src/f32/neon/quat.rs
@@ -632,29 +632,16 @@ impl Quat {
         Vec4::from(self).is_normalized()
     }
 
+    /// Returns `true` if `self` represents a rotation near the identity.
     #[inline]
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        // Because of floating point precision, we cannot represent very small rotations.
-        // The closest f32 to 1.0 that is not 1.0 itself yields:
-        // 0.99999994.acos() * 2.0  = 0.000690533954 rad
-        //
-        // An error threshold of 1.e-6 is used by default.
-        // (1.0 - 1.e-6).acos() * 2.0 = 0.00284714461 rad
-        // (1.0 - 1.e-7).acos() * 2.0 = 0.00097656250 rad
-        //
-        // We don't really care about the angle value itself, only if it's close to 0.
-        // This will happen whenever quat.w is close to 1.0.
-        // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
-        // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
-        // the shortest path.
-        //
-        // For f64 we're using a threshhold of
-        // (1.0 - 1e-14).acos() * 2.0
-        const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
-        let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < THRESHOLD_ANGLE
+        // The shortest rotation angle is `2 * acos(abs(w))`. Since `acos` is monotonically
+        // decreasing, comparing `abs(w)` to the cosine threshold avoids calculating the angle.
+        // Equivalent to an angular threshold of `(1.0 - 1e-6).acos() * 2.0`.
+        const THRESHOLD: f32 = 1.0 - 1e-6;
+        math::abs(self.w) > THRESHOLD
     }
 
     /// Returns the angle (in radians) for the minimal rotation between two quaternions

--- a/src/f32/scalar/quat.rs
+++ b/src/f32/scalar/quat.rs
@@ -634,29 +634,16 @@ impl Quat {
         Vec4::from(self).is_normalized()
     }
 
+    /// Returns `true` if `self` represents a rotation near the identity.
     #[inline]
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        // Because of floating point precision, we cannot represent very small rotations.
-        // The closest f32 to 1.0 that is not 1.0 itself yields:
-        // 0.99999994.acos() * 2.0  = 0.000690533954 rad
-        //
-        // An error threshold of 1.e-6 is used by default.
-        // (1.0 - 1.e-6).acos() * 2.0 = 0.00284714461 rad
-        // (1.0 - 1.e-7).acos() * 2.0 = 0.00097656250 rad
-        //
-        // We don't really care about the angle value itself, only if it's close to 0.
-        // This will happen whenever quat.w is close to 1.0.
-        // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
-        // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
-        // the shortest path.
-        //
-        // For f64 we're using a threshhold of
-        // (1.0 - 1e-14).acos() * 2.0
-        const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
-        let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < THRESHOLD_ANGLE
+        // The shortest rotation angle is `2 * acos(abs(w))`. Since `acos` is monotonically
+        // decreasing, comparing `abs(w)` to the cosine threshold avoids calculating the angle.
+        // Equivalent to an angular threshold of `(1.0 - 1e-6).acos() * 2.0`.
+        const THRESHOLD: f32 = 1.0 - 1e-6;
+        math::abs(self.w) > THRESHOLD
     }
 
     /// Returns the angle (in radians) for the minimal rotation between two quaternions

--- a/src/f32/sse2/quat.rs
+++ b/src/f32/sse2/quat.rs
@@ -635,29 +635,16 @@ impl Quat {
         Vec4::from(self).is_normalized()
     }
 
+    /// Returns `true` if `self` represents a rotation near the identity.
     #[inline]
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        // Because of floating point precision, we cannot represent very small rotations.
-        // The closest f32 to 1.0 that is not 1.0 itself yields:
-        // 0.99999994.acos() * 2.0  = 0.000690533954 rad
-        //
-        // An error threshold of 1.e-6 is used by default.
-        // (1.0 - 1.e-6).acos() * 2.0 = 0.00284714461 rad
-        // (1.0 - 1.e-7).acos() * 2.0 = 0.00097656250 rad
-        //
-        // We don't really care about the angle value itself, only if it's close to 0.
-        // This will happen whenever quat.w is close to 1.0.
-        // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
-        // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
-        // the shortest path.
-        //
-        // For f64 we're using a threshhold of
-        // (1.0 - 1e-14).acos() * 2.0
-        const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
-        let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < THRESHOLD_ANGLE
+        // The shortest rotation angle is `2 * acos(abs(w))`. Since `acos` is monotonically
+        // decreasing, comparing `abs(w)` to the cosine threshold avoids calculating the angle.
+        // Equivalent to an angular threshold of `(1.0 - 1e-6).acos() * 2.0`.
+        const THRESHOLD: f32 = 1.0 - 1e-6;
+        math::abs(self.w) > THRESHOLD
     }
 
     /// Returns the angle (in radians) for the minimal rotation between two quaternions

--- a/src/f32/wasm/quat.rs
+++ b/src/f32/wasm/quat.rs
@@ -630,29 +630,16 @@ impl Quat {
         Vec4::from(self).is_normalized()
     }
 
+    /// Returns `true` if `self` represents a rotation near the identity.
     #[inline]
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        // Because of floating point precision, we cannot represent very small rotations.
-        // The closest f32 to 1.0 that is not 1.0 itself yields:
-        // 0.99999994.acos() * 2.0  = 0.000690533954 rad
-        //
-        // An error threshold of 1.e-6 is used by default.
-        // (1.0 - 1.e-6).acos() * 2.0 = 0.00284714461 rad
-        // (1.0 - 1.e-7).acos() * 2.0 = 0.00097656250 rad
-        //
-        // We don't really care about the angle value itself, only if it's close to 0.
-        // This will happen whenever quat.w is close to 1.0.
-        // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
-        // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
-        // the shortest path.
-        //
-        // For f64 we're using a threshhold of
-        // (1.0 - 1e-14).acos() * 2.0
-        const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
-        let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < THRESHOLD_ANGLE
+        // The shortest rotation angle is `2 * acos(abs(w))`. Since `acos` is monotonically
+        // decreasing, comparing `abs(w)` to the cosine threshold avoids calculating the angle.
+        // Equivalent to an angular threshold of `(1.0 - 1e-6).acos() * 2.0`.
+        const THRESHOLD: f32 = 1.0 - 1e-6;
+        math::abs(self.w) > THRESHOLD
     }
 
     /// Returns the angle (in radians) for the minimal rotation between two quaternions

--- a/src/f64/dquat.rs
+++ b/src/f64/dquat.rs
@@ -616,29 +616,16 @@ impl DQuat {
         DVec4::from(self).is_normalized()
     }
 
+    /// Returns `true` if `self` represents a rotation near the identity.
     #[inline]
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        // Because of floating point precision, we cannot represent very small rotations.
-        // The closest f32 to 1.0 that is not 1.0 itself yields:
-        // 0.99999994.acos() * 2.0  = 0.000690533954 rad
-        //
-        // An error threshold of 1.e-6 is used by default.
-        // (1.0 - 1.e-6).acos() * 2.0 = 0.00284714461 rad
-        // (1.0 - 1.e-7).acos() * 2.0 = 0.00097656250 rad
-        //
-        // We don't really care about the angle value itself, only if it's close to 0.
-        // This will happen whenever quat.w is close to 1.0.
-        // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
-        // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
-        // the shortest path.
-        //
-        // For f64 we're using a threshhold of
-        // (1.0 - 1e-14).acos() * 2.0
-        const THRESHOLD_ANGLE: f64 = 2.827_296_549_232_347_4e-7;
-        let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < THRESHOLD_ANGLE
+        // The shortest rotation angle is `2 * acos(abs(w))`. Since `acos` is monotonically
+        // decreasing, comparing `abs(w)` to the cosine threshold avoids calculating the angle.
+        // Equivalent to an angular threshold of `(1.0 - 1e-14).acos() * 2.0`.
+        const THRESHOLD: f64 = 1.0 - 1e-14;
+        math::abs(self.w) > THRESHOLD
     }
 
     /// Returns the angle (in radians) for the minimal rotation between two quaternions

--- a/templates/quat.rs.tera
+++ b/templates/quat.rs.tera
@@ -768,33 +768,21 @@ impl {{ self_t }} {
         {{ vec4_t }}::from(self).is_normalized()
     }
 
+    /// Returns `true` if `self` represents a rotation near the identity.
     #[inline]
     #[must_use]
     pub fn is_near_identity(self) -> bool {
         // Based on https://github.com/nfrechette/rtm `rtm::quat_near_identity`
-        // Because of floating point precision, we cannot represent very small rotations.
-        // The closest f32 to 1.0 that is not 1.0 itself yields:
-        // 0.99999994.acos() * 2.0  = 0.000690533954 rad
-        //
-        // An error threshold of 1.e-6 is used by default.
-        // (1.0 - 1.e-6).acos() * 2.0 = 0.00284714461 rad
-        // (1.0 - 1.e-7).acos() * 2.0 = 0.00097656250 rad
-        //
-        // We don't really care about the angle value itself, only if it's close to 0.
-        // This will happen whenever quat.w is close to 1.0.
-        // If the quat.w is close to -1.0, the angle will be near 2*PI which is close to
-        // a negative 0 rotation. By forcing quat.w to be positive, we'll end up with
-        // the shortest path.
-        //
-        // For f64 we're using a threshhold of
-        // (1.0 - 1e-14).acos() * 2.0
+        // The shortest rotation angle is `2 * acos(abs(w))`. Since `acos` is monotonically
+        // decreasing, comparing `abs(w)` to the cosine threshold avoids calculating the angle.
         {%- if scalar_t == 'f32' %}
-            const THRESHOLD_ANGLE: f32 = 0.002_847_144_6;
+            // Equivalent to an angular threshold of `(1.0 - 1e-6).acos() * 2.0`.
+            const THRESHOLD: f32 = 1.0 - 1e-6;
         {%- elif scalar_t == 'f64' %}
-            const THRESHOLD_ANGLE: f64 = 2.827_296_549_232_347_4e-7;
+            // Equivalent to an angular threshold of `(1.0 - 1e-14).acos() * 2.0`.
+            const THRESHOLD: f64 = 1.0 - 1e-14;
         {%- endif %}
-        let positive_w_angle = math::acos_approx(math::abs(self.w)) * 2.0;
-        positive_w_angle < THRESHOLD_ANGLE
+        math::abs(self.w) > THRESHOLD
     }
 
     /// Returns the angle (in radians) for the minimal rotation between two quaternions

--- a/tests/quat.rs
+++ b/tests/quat.rs
@@ -885,6 +885,26 @@ mod quat {
         );
     });
 
+    glam_test!(test_is_near_identity_threshold, {
+        let threshold_w = 0.999_999_f32;
+        let inside_w = f32::from_bits(threshold_w.to_bits() + 1);
+        let threshold = quat(
+            (1.0 - threshold_w * threshold_w).sqrt(),
+            0.0,
+            0.0,
+            threshold_w,
+        );
+        let inside = quat((1.0 - inside_w * inside_w).sqrt(), 0.0, 0.0, inside_w);
+
+        assert!(threshold.is_normalized());
+        assert!(inside.is_normalized());
+        assert!(!threshold.is_near_identity());
+        assert!(inside.is_near_identity());
+        assert!(!(-threshold).is_near_identity());
+        assert!((-inside).is_near_identity());
+        assert!(!Quat::NAN.is_near_identity());
+    });
+
     impl_quat_tests!(f32, quat, Mat3, Mat4, Quat, Vec2, Vec3, Vec4);
 }
 
@@ -898,6 +918,26 @@ mod dquat {
         use std::mem;
         assert_eq!(32, mem::size_of::<DQuat>());
         assert_eq!(mem::align_of::<f64>(), mem::align_of::<DQuat>());
+    });
+
+    glam_test!(test_is_near_identity_threshold, {
+        let threshold_w = 0.999_999_999_999_99_f64;
+        let inside_w = f64::from_bits(threshold_w.to_bits() + 1);
+        let threshold = dquat(
+            (1.0 - threshold_w * threshold_w).sqrt(),
+            0.0,
+            0.0,
+            threshold_w,
+        );
+        let inside = dquat((1.0 - inside_w * inside_w).sqrt(), 0.0, 0.0, inside_w);
+
+        assert!(threshold.is_normalized());
+        assert!(inside.is_normalized());
+        assert!(!threshold.is_near_identity());
+        assert!(inside.is_near_identity());
+        assert!(!(-threshold).is_near_identity());
+        assert!((-inside).is_near_identity());
+        assert!(!DQuat::NAN.is_near_identity());
     });
 
     impl_quat_tests!(f64, dquat, DMat3, DMat4, DQuat, DVec2, DVec3, DVec4);


### PR DESCRIPTION
Glam has been a big help while optimizing [DeadSync](https://github.com/pnn64/deadsync), my Rust rewrite of StepMania/ITGmania, so I went looking for small wins I could potentially contribute upstream.

Is there a reason why we don't compare `abs(w)` directly here instead?

Feel free to close this if it has been tried previously or if there is a reason to retain the angle calculation.

`Quat::is_near_identity` currently calculates:

```rust
2.0 * acos(abs(w)) < threshold_angle
```

Because `acos` is monotonically decreasing, this can instead be expressed as a direct comparison against the corresponding cosine threshold.

## Solution

Replace the approximate `acos` calculation with:

```rust
abs(w) > threshold
```

The existing f32 and f64 tolerances are retained. Boundary tests cover:

- The exact threshold
- The next representable value inside the threshold
- Both quaternion signs
- NaN inputs

## Benchmarks

On my machine:

| Metric | Before | After | Change |
|---|---:|---:|---:|
| Criterion time | 7.8916 ns | 2.4259 ns | -69.84% |
| Callgrind instructions | 38 | 7 | -81.6% |
| DHAT allocations | 0 | 0 | No change |

## Code generation

The quaternion template was modified and the generated f32 SIMD/scalar and f64 implementations were regenerated.

## Testing and linting

- Quaternion tests: 83 passed
- All feature-test configurations passed
- Documentation and no-std checks passed
- Rust 1.68.2 MSRV checks passed
- Patch-scoped clippy passed with warnings denied
- Quaternion code-generation check passed

🤖 AI disclosure: I used Codex with GPT-5.6 Sol at xhigh reasoning effort to help identify the optimization and construct the benchmark. I have reviewed and understand the resulting implementation.