### PR TITLE
ci: Run bench-update when PR merged if labeled.

### DIFF
--- a/.github/workflows/bench-update.yml
+++ b/.github/workflows/bench-update.yml
@@ -1,21 +1,17 @@
 name: Update bench baselines
 
-# Saves instruction-count baselines from this repo's code into the shared
+# Saves instruction-count baselines from this repo into the shared
 # bitshifter/glam-bench-baselines repo, which the Bench workflow compares
 # against.
 #
 # Triggers:
-# - workflow_dispatch: manual run on main, whenever wanted.
-# - pull_request_target (closed): automatic run when a PR labeled
-#   `bench-update` is merged to main. `pull_request_target` is used (rather
-#   than `pull_request`) so the secret used to push the baselines is available
-#   even for PRs from forks. The workflow runs from main's copy of this file
-#   and only the merged commit (merge_commit_sha, which is already on main) is
-#   checked out, never the PR head, so this has the same trust level as a
-#   manual run on main.
-#
-# Only maintainers can apply the `bench-update` label on this repo, so the
-# automatic trigger is opt-in per PR and cannot be invoked by PR authors.
+# - workflow_dispatch: manual run on main.
+# - pull_request_target (closed): merged PR labeled `bench-update`. Used
+#   instead of `pull_request` so the baselines push secret works for fork
+#   PRs. Only the merged commit (merge_commit_sha, already on main) is ever
+#   checked out, never the PR head, so it has the same trust level as a manual
+#   run on main. Only maintainers can apply the label, so PR authors can't
+#   trigger this.
 on:
   workflow_dispatch:
   pull_request_target:
@@ -36,11 +32,9 @@ permissions:
 jobs:
   save:
     name: save (${{ matrix.os }})
-    # Baselines are saved from this repo's code and committed to the shared
-    # bitshifter/glam-bench-baselines repo, which the Bench workflow compares
-    # against. Only allow saving from main's code: either a manual dispatch on
-    # main, or a merged PR labeled `bench-update` whose base is main (the
-    # checked-out merge_commit_sha is then on main).
+    # Only save from main's code: a manual dispatch on main, or a merged PR
+    # labeled `bench-update` (base main; the checked-out merge_commit_sha is
+    # then on main).
     if: |
       (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'pull_request_target' && github.event.action == 'closed' &&
@@ -59,9 +53,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: true
-          # workflow_dispatch: HEAD of main (github.sha). pull_request_target:
-          # the squash-merge commit, i.e. what actually landed on main; the PR
-          # head (github.sha on PR events) must never be checked out.
+          # workflow_dispatch: HEAD of main; pull_request_target: the merged
+          # commit on main. Never the PR head (github.sha on PR events).
           ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/bench-update.yml
+++ b/.github/workflows/bench-update.yml
@@ -1,6 +1,26 @@
 name: Update bench baselines
+
+# Saves instruction-count baselines from this repo's code into the shared
+# bitshifter/glam-bench-baselines repo, which the Bench workflow compares
+# against.
+#
+# Triggers:
+# - workflow_dispatch: manual run on main, whenever wanted.
+# - pull_request_target (closed): automatic run when a PR labeled
+#   `bench-update` is merged to main. `pull_request_target` is used (rather
+#   than `pull_request`) so the secret used to push the baselines is available
+#   even for PRs from forks. The workflow runs from main's copy of this file
+#   and only the merged commit (merge_commit_sha, which is already on main) is
+#   checked out, never the PR head, so this has the same trust level as a
+#   manual run on main.
+#
+# Only maintainers can apply the `bench-update` label on this repo, so the
+# automatic trigger is opt-in per PR and cannot be invoked by PR authors.
 on:
   workflow_dispatch:
+  pull_request_target:
+    branches: [main]
+    types: [closed]
 
 concurrency:
   group: ${{ github.workflow }}
@@ -9,14 +29,23 @@ env:
   # Keep in sync with BENCH_TOOLCHAIN in bench.yml.
   BENCH_TOOLCHAIN: 1.98.0
 
+permissions:
+  contents: read # checkout; pushes to the baselines repo use the PAT below
+  actions: write # upload artifacts (save job), not otherwise used
+
 jobs:
   save:
     name: save (${{ matrix.os }})
     # Baselines are saved from this repo's code and committed to the shared
     # bitshifter/glam-bench-baselines repo, which the Bench workflow compares
-    # against. Saving from any ref other than main would overwrite the shared
-    # baselines with non-main instruction counts, so only allow main for now.
-    if: github.ref == 'refs/heads/main'
+    # against. Only allow saving from main's code: either a manual dispatch on
+    # main, or a merged PR labeled `bench-update` whose base is main (the
+    # checked-out merge_commit_sha is then on main).
+    if: |
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request_target' && github.event.action == 'closed' &&
+       github.event.pull_request.merged && github.event.pull_request.base.ref == 'main' &&
+       contains(github.event.pull_request.labels.*.name, 'bench-update'))
     strategy:
       fail-fast: false
       matrix:
@@ -30,6 +59,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           submodules: true
+          # workflow_dispatch: HEAD of main (github.sha). pull_request_target:
+          # the squash-merge commit, i.e. what actually landed on main; the PR
+          # head (github.sha on PR events) must never be checked out.
+          ref: ${{ github.event.pull_request.merge_commit_sha || github.sha }}
       - uses: actions/checkout@v7
         with:
           repository: bitshifter/glam-bench-baselines
@@ -86,5 +119,5 @@ jobs:
             echo "no baseline changes"
             exit 0
           fi
-          git commit -m "chore: update bench baselines from glam-rs@${{ github.sha }}"
+          git commit -m "chore: update bench baselines from glam-rs@${{ github.event.pull_request.merge_commit_sha || github.sha }}"
           git push

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,8 +15,42 @@ env:
   BENCH_TOOLCHAIN: 1.98.0
 
 jobs:
+  # When a PR labeled `bench-update` is merged, the Update bench baselines
+  # workflow rewrites the shared baselines from the merged commit. Skip the
+  # push-to-main compare for that commit: running both at once would race on
+  # the baselines repo, and comparing against freshly saved baselines is
+  # pointless. PRs during review (pull_request events) always compare, label
+  # or not.
+  skip-update:
+    name: Skip if baselines were updated for this commit
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    outputs:
+      baselines-updated: ${{ steps.check.outputs.updated }}
+    permissions:
+      pull-requests: read # list the merged PR for this commit, read its labels
+    steps:
+      - id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # For a squash-merged PR this endpoint returns the merged PR (and
+          # thus its labels) for the single commit that landed on main.
+          labels="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls" \
+            --jq '[.[].labels[].name] | unique | join(",")' || true)"
+          if grep -q 'bench-update' <<<"$labels"; then
+            echo "updated=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "updated=false" >> "$GITHUB_OUTPUT"
+          fi
+
   gungraun:
     name: gungraun (${{ matrix.os }})
+    needs: skip-update
+    # Compare unless this push is the merge of a `bench-update`-labeled PR
+    # (i.e. the gate job found an update). Runs when the gate job itself was
+    # skipped: pull_request events and manual runs still compare.
+    if: ${{ !(needs.skip-update.result == 'success' && needs.skip-update.outputs.baselines-updated == 'true') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -15,27 +15,27 @@ env:
   BENCH_TOOLCHAIN: 1.98.0
 
 jobs:
-  # When a PR labeled `bench-update` is merged, the Update bench baselines
-  # workflow rewrites the shared baselines from the merged commit. Skip the
-  # push-to-main compare for that commit: running both at once would race on
-  # the baselines repo, and comparing against freshly saved baselines is
-  # pointless. PRs during review (pull_request events) always compare, label
-  # or not.
+  # Skip the push-to-main compare when a `bench-update`-labeled PR was
+  # merged: the update workflow rewrites the baselines for that commit, so
+  # comparing against them is pointless and would race. Other events always
+  # compare. Runs on every event (no job `if`) so gungraun never depends on a
+  # skipped job.
   skip-update:
     name: Skip if baselines were updated for this commit
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     outputs:
       baselines-updated: ${{ steps.check.outputs.updated }}
     permissions:
-      pull-requests: read # list the merged PR for this commit, read its labels
+      pull-requests: read # find the merged PR for this commit and its labels
     steps:
-      - id: check
+      - name: Check for merged bench-update PR
+        id: check
+        # Only pushes to main can be merges.
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # For a squash-merged PR this endpoint returns the merged PR (and
-          # thus its labels) for the single commit that landed on main.
+          # A squash-merged PR is returned for its single commit on main.
           labels="$(gh api "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls" \
             --jq '[.[].labels[].name] | unique | join(",")' || true)"
           if grep -q 'bench-update' <<<"$labels"; then
@@ -43,14 +43,15 @@ jobs:
           else
             echo "updated=false" >> "$GITHUB_OUTPUT"
           fi
+        # Fail-open: a broken check still compares instead of silently
+        # skipping.
+        continue-on-error: true
 
   gungraun:
     name: gungraun (${{ matrix.os }})
     needs: skip-update
-    # Compare unless this push is the merge of a `bench-update`-labeled PR
-    # (i.e. the gate job found an update). Runs when the gate job itself was
-    # skipped: pull_request events and manual runs still compare.
-    if: ${{ !(needs.skip-update.result == 'success' && needs.skip-update.outputs.baselines-updated == 'true') }}
+    # Compare unless a `bench-update`-merged PR was found for this commit.
+    if: needs.skip-update.outputs.baselines-updated != 'true'
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
bench-update workflow runs on bench-update label on PR merge. bench workflow will not run if bench-update is running.
