### PR TITLE
ci: cap wasm-bindgen-test below 0.3.78 for MSRV compatibility

### DIFF
--- a/tools/ci/src/commands/msrv.rs
+++ b/tools/ci/src/commands/msrv.rs
@@ -20,6 +20,8 @@ impl Prepare for Msrv {
         let a = |features: &str| {
             toolchain::cargo(sh, tc)
                 .arg("check")
+                .arg("--manifest-path")
+                .arg("tools/msrv/Cargo.toml")
                 .arg("--features")
                 .arg(features)
         };
@@ -39,6 +41,8 @@ impl Prepare for Msrv {
                 name: "msrv check: libm scalar-math (no-default-features)".into(),
                 command: toolchain::cargo(sh, tc)
                     .arg("check")
+                    .arg("--manifest-path")
+                    .arg("tools/msrv/Cargo.toml")
                     .arg("--no-default-features")
                     .arg("--features")
                     .arg(format!(

--- a/tools/msrv/Cargo.toml
+++ b/tools/msrv/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "glam-msrv"
+description = "Checks glam compiles with the MSRV toolchain from an external consumer"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+# Standalone workspace: this crate must not join the parent workspace, whose
+# shared lockfile resolves glam's dev-dependencies with the MSRV toolchain.
+[workspace]
+
+# Deliberately NOT a workspace member: checking glam from a consumer project
+# only resolves glam's library dependencies. Dev-dependencies (e.g. the wasm
+# test stack) do not participate, so their latest releases cannot break the
+# MSRV check the way they could when the shared workspace lock was resolved
+# with the MSRV cargo.
+
+[dependencies]
+glam = { path = "../..", default-features = false }
+
+[features]
+# Mirrors glam's default features (std math backend); checks 1-2 in
+# tools/ci/src/commands/msrv.rs use this. Check 3 passes
+# --no-default-features and enables libm instead, like the original check.
+default = ["glam/std"]
+all-types = ["glam/all-types"]
+arbitrary = ["glam/arbitrary"]
+approx = ["glam/approx"]
+mint = ["glam/mint"]
+speedy = ["glam/speedy"]
+debug-glam-assert = ["glam/debug-glam-assert"]
+scalar-math = ["glam/scalar-math"]
+libm = ["glam/libm"]

--- a/tools/msrv/src/lib.rs
+++ b/tools/msrv/src/lib.rs
@@ -1,0 +1,1 @@
+// The MSRV check only needs to compile glam with the target feature set.


### PR DESCRIPTION
Fixes the failing **Check MSRV** CI job (broken since 2026-09-05).

## Why it broke

`cargo check` was run on the **workspace itself** with the MSRV toolchain (rustup 1.68.2). That resolves the shared workspace lockfile, which includes glam's dev-dependencies — including the wasm-bindgen-test/js-sys test stack. Those float to latest on crates.io:

- `wasm-bindgen-test 0.3.78` pins `js-sys =0.3.105`
- js-sys 0.3.105's `std` feature references `futures-util/std`, but `futures-core-03-stream` uses `dep:futures-util`, which suppresses the implicit `futures-util` feature — unresolvable by cargo 1.68.2 (fixed in cargo 1.71.0, rust-lang/cargo#12130)

So a **test-only dev-dependency** broke the MSRV promise. Cap attempts failed because the lock is shared across the whole workspace, and any pin that constrains the wasm stack affects the wasm32 job too.

## The fix

Check MSRV from a **standalone consumer package** (`tools/msrv`, its own workspace + lockfile): a path dependency on glam that forwards the checked features (`all-types`, `scalar-math`, `libm`, etc.). Consumers never resolve a dependency's dev-dependencies, so the wasm test stack cannot affect the MSRV check again — and no version caps are needed anywhere.

`tools/ci/src/commands/msrv.rs` now runs the three variants (default features, scalar-math, libm no-default-features) with `--manifest-path tools/msrv/Cargo.toml`.