### PR TITLE
perf(mat4): specialize affine determinant in SRT decomposition

### DIFF
--- a/benches/mat4.rs
+++ b/benches/mat4.rs
@@ -3,7 +3,7 @@
 mod macros;
 mod support;
 
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion, Throughput};
 use glam::Mat4;
 use std::ops::Mul;
 use support::*;
@@ -90,6 +90,25 @@ bench_from_ypr!(
     ty => Mat4
 );
 
+pub fn mat4_to_srt(c: &mut Criterion) {
+    let mut rng = PCG32::default();
+    let mut group = c.benchmark_group("mat4 to srt");
+    for size in [1, 256] {
+        let inputs: Vec<_> = (0..size).map(|_| random_srt_mat4(&mut rng)).collect();
+        let mut outputs = vec![Mat4::IDENTITY.to_scale_rotation_translation(); size];
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_function(size.to_string(), |b| {
+            b.iter(|| {
+                for (input, output) in core::hint::black_box(&inputs).iter().zip(&mut outputs) {
+                    *output = input.to_scale_rotation_translation();
+                }
+                core::hint::black_box(&outputs);
+            });
+        });
+    }
+    group.finish();
+}
+
 pub fn mat4_from_srt(c: &mut Criterion) {
     use glam::{Quat, Vec3};
     const SIZE: usize = 1 << 13;
@@ -123,6 +142,7 @@ criterion_group!(
     benches,
     mat4_determinant,
     mat4_from_srt,
+    mat4_to_srt,
     mat4_from_ypr,
     mat4_inverse,
     mat4_mul_mat4,

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -237,7 +237,12 @@ impl Mat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
-        let det = self.determinant();
+        // The determinant of an affine matrix is the determinant of its linear part.
+        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
+        let det = self
+            .x_axis
+            .xyz()
+            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
         glam_assert!(det != 0.0);
 
         let scale = Vec3::new(

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -237,13 +237,15 @@ impl Mat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
+        // The full matrix can be singular even when its linear part is not.
+        glam_assert!(self.determinant() != 0.0);
+
         // The determinant of an affine matrix is the determinant of its linear part.
         // Expand along the first column, like `determinant()`, to preserve underflow behavior.
         let det = self
             .x_axis
             .xyz()
             .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
-        glam_assert!(det != 0.0);
 
         let scale = Vec3::new(
             self.x_axis.length() * math::signum(det),

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -244,13 +244,15 @@ impl Mat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
+        // The full matrix can be singular even when its linear part is not.
+        glam_assert!(self.determinant() != 0.0);
+
         // The determinant of an affine matrix is the determinant of its linear part.
         // Expand along the first column, like `determinant()`, to preserve underflow behavior.
         let det = self
             .x_axis
             .xyz()
             .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
-        glam_assert!(det != 0.0);
 
         let scale = Vec3::new(
             self.x_axis.length() * math::signum(det),

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -244,7 +244,12 @@ impl Mat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
-        let det = self.determinant();
+        // The determinant of an affine matrix is the determinant of its linear part.
+        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
+        let det = self
+            .x_axis
+            .xyz()
+            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
         glam_assert!(det != 0.0);
 
         let scale = Vec3::new(

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -250,13 +250,15 @@ impl Mat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
+        // The full matrix can be singular even when its linear part is not.
+        glam_assert!(self.determinant() != 0.0);
+
         // The determinant of an affine matrix is the determinant of its linear part.
         // Expand along the first column, like `determinant()`, to preserve underflow behavior.
         let det = self
             .x_axis
             .xyz()
             .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
-        glam_assert!(det != 0.0);
 
         let scale = Vec3::new(
             self.x_axis.length() * math::signum(det),

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -250,7 +250,12 @@ impl Mat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
-        let det = self.determinant();
+        // The determinant of an affine matrix is the determinant of its linear part.
+        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
+        let det = self
+            .x_axis
+            .xyz()
+            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
         glam_assert!(det != 0.0);
 
         let scale = Vec3::new(

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -247,7 +247,12 @@ impl Mat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
-        let det = self.determinant();
+        // The determinant of an affine matrix is the determinant of its linear part.
+        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
+        let det = self
+            .x_axis
+            .xyz()
+            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
         glam_assert!(det != 0.0);
 
         let scale = Vec3::new(

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -247,13 +247,15 @@ impl Mat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
+        // The full matrix can be singular even when its linear part is not.
+        glam_assert!(self.determinant() != 0.0);
+
         // The determinant of an affine matrix is the determinant of its linear part.
         // Expand along the first column, like `determinant()`, to preserve underflow behavior.
         let det = self
             .x_axis
             .xyz()
             .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
-        glam_assert!(det != 0.0);
 
         let scale = Vec3::new(
             self.x_axis.length() * math::signum(det),

--- a/src/f32/wasm/mat4.rs
+++ b/src/f32/wasm/mat4.rs
@@ -247,7 +247,12 @@ impl Mat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
-        let det = self.determinant();
+        // The determinant of an affine matrix is the determinant of its linear part.
+        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
+        let det = self
+            .x_axis
+            .xyz()
+            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
         glam_assert!(det != 0.0);
 
         let scale = Vec3::new(

--- a/src/f32/wasm/mat4.rs
+++ b/src/f32/wasm/mat4.rs
@@ -247,13 +247,15 @@ impl Mat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
+        // The full matrix can be singular even when its linear part is not.
+        glam_assert!(self.determinant() != 0.0);
+
         // The determinant of an affine matrix is the determinant of its linear part.
         // Expand along the first column, like `determinant()`, to preserve underflow behavior.
         let det = self
             .x_axis
             .xyz()
             .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
-        glam_assert!(det != 0.0);
 
         let scale = Vec3::new(
             self.x_axis.length() * math::signum(det),

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -251,7 +251,12 @@ impl DMat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (DVec3, DQuat, DVec3) {
-        let det = self.determinant();
+        // The determinant of an affine matrix is the determinant of its linear part.
+        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
+        let det = self
+            .x_axis
+            .xyz()
+            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
         glam_assert!(det != 0.0);
 
         let scale = DVec3::new(

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -251,13 +251,15 @@ impl DMat4 {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (DVec3, DQuat, DVec3) {
+        // The full matrix can be singular even when its linear part is not.
+        glam_assert!(self.determinant() != 0.0);
+
         // The determinant of an affine matrix is the determinant of its linear part.
         // Expand along the first column, like `determinant()`, to preserve underflow behavior.
         let det = self
             .x_axis
             .xyz()
             .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
-        glam_assert!(det != 0.0);
 
         let scale = DVec3::new(
             self.x_axis.length() * math::signum(det),

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -725,10 +725,12 @@ impl {{ self_t }} {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> ({{ vec3_t }}, {{ quat_t }}, {{ vec3_t }}) {
+        // The full matrix can be singular even when its linear part is not.
+        glam_assert!(self.determinant() != 0.0);
+
         // The determinant of an affine matrix is the determinant of its linear part.
         // Expand along the first column, like `determinant()`, to preserve underflow behavior.
         let det = self.x_axis.xyz().dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
-        glam_assert!(det != 0.0);
 
         let scale = {{ vec3_t }}::new(
             self.x_axis.length() * math::signum(det),

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -725,7 +725,9 @@ impl {{ self_t }} {
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> ({{ vec3_t }}, {{ quat_t }}, {{ vec3_t }}) {
-        let det = self.determinant();
+        // The determinant of an affine matrix is the determinant of its linear part.
+        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
+        let det = self.x_axis.xyz().dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
         glam_assert!(det != 0.0);
 
         let scale = {{ vec3_t }}::new(

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -381,6 +381,79 @@ macro_rules! impl_mat4_tests {
             should_glam_assert!({ $mat4::ZERO.inverse() });
         });
 
+        glam_test!(test_mat4_decompose_reflections, {
+            for i in 0..32 {
+                let rotation = $quat::from_euler(
+                    glam::EulerRot::XYZ,
+                    (i as $t - 16.0) * 0.13,
+                    (i as $t - 7.0) * 0.29,
+                    (i as $t - 23.0) * 0.37,
+                );
+                for signs in 0..8 {
+                    for magnitude in [1.0e-9, 1.0, 1.0e9] {
+                        let scale = $vec3::new(
+                            if signs & 1 == 0 { magnitude } else { -magnitude },
+                            if signs & 2 == 0 { 2.0 } else { -2.0 },
+                            if signs & 4 == 0 { 1.0 / magnitude } else { -1.0 / magnitude },
+                        );
+                        let translation = $vec3::new(-0.0, i as $t, -1.0e10);
+                        let matrix = $mat4::from_scale_rotation_translation(scale, rotation, translation);
+                        let (s, r, t) = matrix.to_scale_rotation_translation();
+                        assert_eq!(s.x.signum(), matrix.determinant().signum());
+                        assert_eq!(s.x.signum(), (scale.x * scale.y * scale.z).signum());
+                        assert!(s.y > 0.0 && s.z > 0.0);
+                        assert!(r.is_normalized());
+                        assert_eq!(t.to_array().map($t::to_bits), translation.to_array().map($t::to_bits));
+                        let rebuilt = $mat4::from_scale_rotation_translation(s, r, t);
+                        for column in 0..3 {
+                            let tolerance = 32.0 * $t::EPSILON * scale[column].abs();
+                            assert!(rebuilt.col(column).abs_diff_eq(matrix.col(column), tolerance));
+                        }
+                    }
+                }
+            }
+        });
+
+        glam_test!(test_mat4_decompose_small_determinant, {
+            let small = $t::from_bits(1).cbrt();
+            let scale = $vec3::splat(small);
+            let mut checked = 0;
+            for i in 0..64 {
+                let rotation = $quat::from_euler(
+                    glam::EulerRot::XYZ,
+                    i as $t * 0.13,
+                    i as $t * 0.29,
+                    i as $t * 0.37,
+                );
+                let matrix = $mat4::from_scale_rotation_translation(scale, rotation, $vec3::ZERO);
+                // Check inputs accepted by the full 4x4 determinant, even near underflow.
+                if matrix.determinant() != 0.0 {
+                    let (s, r, t) = matrix.to_scale_rotation_translation();
+                    assert!(s.abs_diff_eq(scale, 32.0 * $t::EPSILON * small));
+                    assert!(r.is_normalized());
+                    assert_eq!(t, $vec3::ZERO);
+                    checked += 1;
+                }
+            }
+            assert!(checked > 0);
+        });
+
+        #[cfg(all(
+            feature = "std",
+            panic = "unwind",
+            any(feature = "glam-assert", feature = "debug-glam-assert")
+        ))]
+        glam_test!(test_mat4_decompose_singular, {
+            for column in 0..3 {
+                let mut matrix = $mat4::IDENTITY;
+                *matrix.col_mut(column) = $vec4::ZERO;
+                should_glam_assert!({ matrix.to_scale_rotation_translation() });
+            }
+            let mut matrix = $mat4::IDENTITY;
+            matrix.y_axis = matrix.x_axis;
+            should_glam_assert!({ matrix.to_scale_rotation_translation() });
+        });
+
         glam_test!(test_mat4_decompose, {
             // identity
             let (out_scale, out_rotation, out_translation) =

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -444,7 +444,8 @@ macro_rules! impl_mat4_tests {
             any(feature = "glam-assert", feature = "debug-glam-assert")
         ))]
         glam_test!(test_mat4_decompose_singular, {
-            for column in 0..3 {
+            // A zero fourth column makes the full matrix singular even when its linear part is not.
+            for column in 0..4 {
                 let mut matrix = $mat4::IDENTITY;
                 *matrix.col_mut(column) = $vec4::ZERO;
                 should_glam_assert!({ matrix.to_scale_rotation_translation() });


### PR DESCRIPTION
Following #824, could we also skip the full 4x4 determinant when decomposing an affine matrix?

## Solution

This uses the 3x3 linear part instead, keeping the existing expansion order to avoid changing behavior near underflow. Templates, generated code, tests, and benchmarks are included.

## Benchmarks

On my Xeon E5-2696 v4:

| Measurement | Before | After | Change |
|---|---:|---:|---:|
| 256-matrix batch | 4.879 µs | 3.705 µs | -24.1% |
| Throughput | 52.47 M/s | 69.10 M/s | +31.7% |
| Cycles/matrix | 62.608 | 49.313 | -21.2% |
| Instructions/matrix | 148.200 | 119.634 | -19.3% |
| Allocations | 0 | 0 | Unchanged |

Timing: Criterion on Windows. Counters: five alternating, core-pinned runs under WSL.

## Testing and linting

- Three million bit-for-bit comparisons passed.
- All nine feature-test configurations passed.
- Glam-specific Clippy, formatting, and generated-matrix checks passed.
- Existing Windows workspace-check issues remain.

🤖 AI disclosure: I used Codex with GPT-6 Astra at xhigh reasoning effort to help identify the optimization and construct the benchmark. I have reviewed and understand the resulting implementation.