### PR TITLE
perf: further optimisations to to_scale_rotation_translation

### DIFF
--- a/benches/gungraun.rs
+++ b/benches/gungraun.rs
@@ -46,6 +46,16 @@ fn mat4() -> Mat4 {
     ]))
 }
 
+// A non-singular affine matrix
+#[inline]
+fn mat4_srt() -> Mat4 {
+    black_box(Mat4::from_scale_rotation_translation(
+        vec3(),
+        quat_rot_x_240(),
+        vec3(),
+    ))
+}
+
 // The `*_invertible` and `*_singular` matrices are used by the `inverse`,
 // `try_inverse` and `inverse_or_zero` benchmarks. `IDENTITY` exercises the
 // success paths, `ZERO` exercises the failure paths.
@@ -374,6 +384,12 @@ fn mat4_from_scale_rotation_translation(s: Vec3, r: Quat, t: Vec3) -> Mat4 {
 }
 
 #[library_benchmark]
+#[bench::args(mat4_srt())]
+fn mat4_to_scale_rotation_translation(m: Mat4) -> (Vec3, Quat, Vec3) {
+    black_box(m.to_scale_rotation_translation())
+}
+
+#[library_benchmark]
 #[bench::args(mat4(), vec3())]
 fn mat4_transform_point3(m: Mat4, v: Vec3) -> Vec3 {
     black_box(m.transform_point3(v))
@@ -664,6 +680,7 @@ library_benchmark_group!(
         mat4_mul_mat4,
         mat4_mul_vec4,
         mat4_mul_transpose_vec4,
+        mat4_to_scale_rotation_translation,
         mat4_transform_point3,
         mat4_transform_vector3,
         mat4_transpose,

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -46,6 +46,10 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// 2D inputs as 3D vectors with an implicit `z` value of `1` for points and `0` for
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
+///
+/// SIMD vector types are used for storage on supported platforms.
+///
+/// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[repr(C)]

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -38,6 +38,10 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// multiply 3D inputs as 4D vectors with an implicit `w` value of `1` for points and `0`
 /// for vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
+///
+/// SIMD vector types are used for storage on supported platforms.
+///
+/// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[repr(C)]
@@ -231,37 +235,35 @@ impl Mat4 {
     /// expected to be a 3D affine transformation matrix otherwise the output will be invalid.
     ///
     /// # Panics
-    ///
-    /// Will panic if the determinant of `self` is zero or if the resulting scale vector
-    /// contains any zero elements when `glam_assert` is enabled.
+    /// Will panic if `self` is not a valid affine transformation matrix, if the determinant of the
+    /// 3x3 linear part (the rotation and scale part of the transform) is zero, when `glam_assert`
+    /// is enabled.
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
-        // The full matrix can be singular even when its linear part is not.
-        glam_assert!(self.determinant() != 0.0);
+        glam_assert!(self.row(3).abs_diff_eq(Vec4::W, 1e-6));
 
-        // The determinant of an affine matrix is the determinant of its linear part.
-        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
-        let det = self
-            .x_axis
-            .xyz()
-            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
+        let r = Mat3A::from_mat4(*self);
+
+        let det = r.determinant();
+
+        glam_assert!(det != 0.0);
 
         let scale = Vec3::new(
-            self.x_axis.length() * math::signum(det),
-            self.y_axis.length(),
-            self.z_axis.length(),
+            r.x_axis.length() * math::signum(det),
+            r.y_axis.length(),
+            r.z_axis.length(),
         );
 
         glam_assert!(scale.cmpne(Vec3::ZERO).all());
 
         let inv_scale = scale.recip();
 
-        let rotation = Quat::from_rotation_axes(
-            self.x_axis.mul(inv_scale.x).xyz(),
-            self.y_axis.mul(inv_scale.y).xyz(),
-            self.z_axis.mul(inv_scale.z).xyz(),
-        );
+        let rotation = Quat::from_mat3a(&Mat3A::from_cols(
+            r.x_axis.mul(inv_scale.x),
+            r.y_axis.mul(inv_scale.y),
+            r.z_axis.mul(inv_scale.z),
+        ));
 
         let translation = self.w_axis.xyz();
 

--- a/src/f32/neon/mat3a.rs
+++ b/src/f32/neon/mat3a.rs
@@ -49,6 +49,10 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// 2D inputs as 3D vectors with an implicit `z` value of `1` for points and `0` for
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
+///
+/// SIMD vector types are used for storage on supported platforms.
+///
+/// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -41,6 +41,10 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// multiply 3D inputs as 4D vectors with an implicit `w` value of `1` for points and `0`
 /// for vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
+///
+/// SIMD vector types are used for storage on supported platforms.
+///
+/// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(
@@ -238,37 +242,35 @@ impl Mat4 {
     /// expected to be a 3D affine transformation matrix otherwise the output will be invalid.
     ///
     /// # Panics
-    ///
-    /// Will panic if the determinant of `self` is zero or if the resulting scale vector
-    /// contains any zero elements when `glam_assert` is enabled.
+    /// Will panic if `self` is not a valid affine transformation matrix, if the determinant of the
+    /// 3x3 linear part (the rotation and scale part of the transform) is zero, when `glam_assert`
+    /// is enabled.
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
-        // The full matrix can be singular even when its linear part is not.
-        glam_assert!(self.determinant() != 0.0);
+        glam_assert!(self.row(3).abs_diff_eq(Vec4::W, 1e-6));
 
-        // The determinant of an affine matrix is the determinant of its linear part.
-        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
-        let det = self
-            .x_axis
-            .xyz()
-            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
+        let r = Mat3A::from_mat4(*self);
+
+        let det = r.determinant();
+
+        glam_assert!(det != 0.0);
 
         let scale = Vec3::new(
-            self.x_axis.length() * math::signum(det),
-            self.y_axis.length(),
-            self.z_axis.length(),
+            r.x_axis.length() * math::signum(det),
+            r.y_axis.length(),
+            r.z_axis.length(),
         );
 
         glam_assert!(scale.cmpne(Vec3::ZERO).all());
 
         let inv_scale = scale.recip();
 
-        let rotation = Quat::from_rotation_axes(
-            self.x_axis.mul(inv_scale.x).xyz(),
-            self.y_axis.mul(inv_scale.y).xyz(),
-            self.z_axis.mul(inv_scale.z).xyz(),
-        );
+        let rotation = Quat::from_mat3a(&Mat3A::from_cols(
+            r.x_axis.mul(inv_scale.x),
+            r.y_axis.mul(inv_scale.y),
+            r.z_axis.mul(inv_scale.z),
+        ));
 
         let translation = self.w_axis.xyz();
 

--- a/src/f32/scalar/mat4.rs
+++ b/src/f32/scalar/mat4.rs
@@ -244,26 +244,24 @@ impl Mat4 {
     /// expected to be a 3D affine transformation matrix otherwise the output will be invalid.
     ///
     /// # Panics
-    ///
-    /// Will panic if the determinant of `self` is zero or if the resulting scale vector
-    /// contains any zero elements when `glam_assert` is enabled.
+    /// Will panic if `self` is not a valid affine transformation matrix, if the determinant of the
+    /// 3x3 linear part (the rotation and scale part of the transform) is zero, when `glam_assert`
+    /// is enabled.
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
-        // The full matrix can be singular even when its linear part is not.
-        glam_assert!(self.determinant() != 0.0);
+        glam_assert!(self.row(3).abs_diff_eq(Vec4::W, 1e-6));
 
-        // The determinant of an affine matrix is the determinant of its linear part.
-        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
-        let det = self
-            .x_axis
-            .xyz()
-            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
+        let r = Mat3::from_mat4(*self);
+
+        let det = r.determinant();
+
+        glam_assert!(det != 0.0);
 
         let scale = Vec3::new(
-            self.x_axis.length() * math::signum(det),
-            self.y_axis.length(),
-            self.z_axis.length(),
+            r.x_axis.length() * math::signum(det),
+            r.y_axis.length(),
+            r.z_axis.length(),
         );
 
         glam_assert!(scale.cmpne(Vec3::ZERO).all());
@@ -271,9 +269,9 @@ impl Mat4 {
         let inv_scale = scale.recip();
 
         let rotation = Quat::from_rotation_axes(
-            self.x_axis.mul(inv_scale.x).xyz(),
-            self.y_axis.mul(inv_scale.y).xyz(),
-            self.z_axis.mul(inv_scale.z).xyz(),
+            r.x_axis.mul(inv_scale.x),
+            r.y_axis.mul(inv_scale.y),
+            r.z_axis.mul(inv_scale.z),
         );
 
         let translation = self.w_axis.xyz();

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -52,6 +52,10 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// 2D inputs as 3D vectors with an implicit `z` value of `1` for points and `0` for
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
+///
+/// SIMD vector types are used for storage on supported platforms.
+///
+/// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -44,6 +44,10 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// multiply 3D inputs as 4D vectors with an implicit `w` value of `1` for points and `0`
 /// for vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
+///
+/// SIMD vector types are used for storage on supported platforms.
+///
+/// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(
@@ -241,37 +245,35 @@ impl Mat4 {
     /// expected to be a 3D affine transformation matrix otherwise the output will be invalid.
     ///
     /// # Panics
-    ///
-    /// Will panic if the determinant of `self` is zero or if the resulting scale vector
-    /// contains any zero elements when `glam_assert` is enabled.
+    /// Will panic if `self` is not a valid affine transformation matrix, if the determinant of the
+    /// 3x3 linear part (the rotation and scale part of the transform) is zero, when `glam_assert`
+    /// is enabled.
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
-        // The full matrix can be singular even when its linear part is not.
-        glam_assert!(self.determinant() != 0.0);
+        glam_assert!(self.row(3).abs_diff_eq(Vec4::W, 1e-6));
 
-        // The determinant of an affine matrix is the determinant of its linear part.
-        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
-        let det = self
-            .x_axis
-            .xyz()
-            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
+        let r = Mat3A::from_mat4(*self);
+
+        let det = r.determinant();
+
+        glam_assert!(det != 0.0);
 
         let scale = Vec3::new(
-            self.x_axis.length() * math::signum(det),
-            self.y_axis.length(),
-            self.z_axis.length(),
+            r.x_axis.length() * math::signum(det),
+            r.y_axis.length(),
+            r.z_axis.length(),
         );
 
         glam_assert!(scale.cmpne(Vec3::ZERO).all());
 
         let inv_scale = scale.recip();
 
-        let rotation = Quat::from_rotation_axes(
-            self.x_axis.mul(inv_scale.x).xyz(),
-            self.y_axis.mul(inv_scale.y).xyz(),
-            self.z_axis.mul(inv_scale.z).xyz(),
-        );
+        let rotation = Quat::from_mat3a(&Mat3A::from_cols(
+            r.x_axis.mul(inv_scale.x),
+            r.y_axis.mul(inv_scale.y),
+            r.z_axis.mul(inv_scale.z),
+        ));
 
         let translation = self.w_axis.xyz();
 

--- a/src/f32/wasm/mat3a.rs
+++ b/src/f32/wasm/mat3a.rs
@@ -52,6 +52,10 @@ pub const fn mat3a(x_axis: Vec3A, y_axis: Vec3A, z_axis: Vec3A) -> Mat3A {
 /// 2D inputs as 3D vectors with an implicit `z` value of `1` for points and `0` for
 /// vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
+///
+/// SIMD vector types are used for storage on supported platforms.
+///
+/// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(

--- a/src/f32/wasm/mat4.rs
+++ b/src/f32/wasm/mat4.rs
@@ -44,6 +44,10 @@ pub const fn mat4(x_axis: Vec4, y_axis: Vec4, z_axis: Vec4, w_axis: Vec4) -> Mat
 /// multiply 3D inputs as 4D vectors with an implicit `w` value of `1` for points and `0`
 /// for vectors respectively. These methods assume that `Self` contains a valid affine
 /// transform.
+///
+/// SIMD vector types are used for storage on supported platforms.
+///
+/// This type is 16 byte aligned.
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bytemuck", derive(bytemuck::Pod, bytemuck::Zeroable))]
 #[cfg_attr(
@@ -241,37 +245,35 @@ impl Mat4 {
     /// expected to be a 3D affine transformation matrix otherwise the output will be invalid.
     ///
     /// # Panics
-    ///
-    /// Will panic if the determinant of `self` is zero or if the resulting scale vector
-    /// contains any zero elements when `glam_assert` is enabled.
+    /// Will panic if `self` is not a valid affine transformation matrix, if the determinant of the
+    /// 3x3 linear part (the rotation and scale part of the transform) is zero, when `glam_assert`
+    /// is enabled.
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (Vec3, Quat, Vec3) {
-        // The full matrix can be singular even when its linear part is not.
-        glam_assert!(self.determinant() != 0.0);
+        glam_assert!(self.row(3).abs_diff_eq(Vec4::W, 1e-6));
 
-        // The determinant of an affine matrix is the determinant of its linear part.
-        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
-        let det = self
-            .x_axis
-            .xyz()
-            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
+        let r = Mat3A::from_mat4(*self);
+
+        let det = r.determinant();
+
+        glam_assert!(det != 0.0);
 
         let scale = Vec3::new(
-            self.x_axis.length() * math::signum(det),
-            self.y_axis.length(),
-            self.z_axis.length(),
+            r.x_axis.length() * math::signum(det),
+            r.y_axis.length(),
+            r.z_axis.length(),
         );
 
         glam_assert!(scale.cmpne(Vec3::ZERO).all());
 
         let inv_scale = scale.recip();
 
-        let rotation = Quat::from_rotation_axes(
-            self.x_axis.mul(inv_scale.x).xyz(),
-            self.y_axis.mul(inv_scale.y).xyz(),
-            self.z_axis.mul(inv_scale.z).xyz(),
-        );
+        let rotation = Quat::from_mat3a(&Mat3A::from_cols(
+            r.x_axis.mul(inv_scale.x),
+            r.y_axis.mul(inv_scale.y),
+            r.z_axis.mul(inv_scale.z),
+        ));
 
         let translation = self.w_axis.xyz();
 

--- a/src/f64/dmat4.rs
+++ b/src/f64/dmat4.rs
@@ -245,26 +245,24 @@ impl DMat4 {
     /// expected to be a 3D affine transformation matrix otherwise the output will be invalid.
     ///
     /// # Panics
-    ///
-    /// Will panic if the determinant of `self` is zero or if the resulting scale vector
-    /// contains any zero elements when `glam_assert` is enabled.
+    /// Will panic if `self` is not a valid affine transformation matrix, if the determinant of the
+    /// 3x3 linear part (the rotation and scale part of the transform) is zero, when `glam_assert`
+    /// is enabled.
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> (DVec3, DQuat, DVec3) {
-        // The full matrix can be singular even when its linear part is not.
-        glam_assert!(self.determinant() != 0.0);
+        glam_assert!(self.row(3).abs_diff_eq(DVec4::W, 1e-6));
 
-        // The determinant of an affine matrix is the determinant of its linear part.
-        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
-        let det = self
-            .x_axis
-            .xyz()
-            .dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
+        let r = DMat3::from_mat4(*self);
+
+        let det = r.determinant();
+
+        glam_assert!(det != 0.0);
 
         let scale = DVec3::new(
-            self.x_axis.length() * math::signum(det),
-            self.y_axis.length(),
-            self.z_axis.length(),
+            r.x_axis.length() * math::signum(det),
+            r.y_axis.length(),
+            r.z_axis.length(),
         );
 
         glam_assert!(scale.cmpne(DVec3::ZERO).all());
@@ -272,9 +270,9 @@ impl DMat4 {
         let inv_scale = scale.recip();
 
         let rotation = DQuat::from_rotation_axes(
-            self.x_axis.mul(inv_scale.x).xyz(),
-            self.y_axis.mul(inv_scale.y).xyz(),
-            self.z_axis.mul(inv_scale.z).xyz(),
+            r.x_axis.mul(inv_scale.x),
+            r.y_axis.mul(inv_scale.y),
+            r.z_axis.mul(inv_scale.z),
         );
 
         let translation = self.w_axis.xyz();

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -37,7 +37,6 @@
 
 {% if self_t == "Mat2" %}
     {% if not is_scalar %}
-        {% set is_simd = true %}
         {% if is_sse2 %}
             {% set simd_t = "__m128" %}
         {% elif is_wasm %}
@@ -49,6 +48,8 @@
         {% endif %}
     {% endif %}
 {% endif %}
+
+{% set is_simd = not is_scalar %}
 
 {% set size = dim * dim %}
 {% set nxn = dim ~ "x" ~ dim %}
@@ -719,34 +720,49 @@ impl {{ self_t }} {
     /// expected to be a 3D affine transformation matrix otherwise the output will be invalid.
     ///
     /// # Panics
-    ///
-    /// Will panic if the determinant of `self` is zero or if the resulting scale vector
-    /// contains any zero elements when `glam_assert` is enabled.
+    /// Will panic if `self` is not a valid affine transformation matrix, if the determinant of the
+    /// 3x3 linear part (the rotation and scale part of the transform) is zero, when `glam_assert`
+    /// is enabled.
     #[inline]
     #[must_use]
     pub fn to_scale_rotation_translation(&self) -> ({{ vec3_t }}, {{ quat_t }}, {{ vec3_t }}) {
-        // The full matrix can be singular even when its linear part is not.
-        glam_assert!(self.determinant() != 0.0);
+        glam_assert!(self.row(3).abs_diff_eq({{ vec4_t }}::W, 1e-6));
 
-        // The determinant of an affine matrix is the determinant of its linear part.
-        // Expand along the first column, like `determinant()`, to preserve underflow behavior.
-        let det = self.x_axis.xyz().dot(self.y_axis.xyz().cross(self.z_axis.xyz()));
+        {% if self_t == "Mat4" and is_simd %}
+        let r = Mat3A::from_mat4(*self);
+        {% else %}
+        let r = {{ mat3_t }}::from_mat4(*self);
+        {% endif %}
+
+        let det = r.determinant();
+
+        glam_assert!(det != 0.0);
 
         let scale = {{ vec3_t }}::new(
-            self.x_axis.length() * math::signum(det),
-            self.y_axis.length(),
-            self.z_axis.length(),
+            r.x_axis.length() * math::signum(det),
+            r.y_axis.length(),
+            r.z_axis.length(),
         );
 
         glam_assert!(scale.cmpne({{ vec3_t }}::ZERO).all());
 
         let inv_scale = scale.recip();
 
-        let rotation = {{ quat_t }}::from_rotation_axes(
-            self.x_axis.mul(inv_scale.x).xyz(),
-            self.y_axis.mul(inv_scale.y).xyz(),
-            self.z_axis.mul(inv_scale.z).xyz(),
+        {% if self_t == "Mat4" and is_simd %}
+        let rotation = {{ quat_t }}::from_mat3a(
+            &Mat3A::from_cols(
+                r.x_axis.mul(inv_scale.x),
+                r.y_axis.mul(inv_scale.y),
+                r.z_axis.mul(inv_scale.z),
+            )
         );
+        {% else %}
+        let rotation = {{ quat_t }}::from_rotation_axes(
+            r.x_axis.mul(inv_scale.x),
+            r.y_axis.mul(inv_scale.y),
+            r.z_axis.mul(inv_scale.z),
+        );
+        {% endif %}
 
         let translation = self.w_axis.xyz();
 

--- a/tests/mat4.rs
+++ b/tests/mat4.rs
@@ -426,8 +426,8 @@ macro_rules! impl_mat4_tests {
                     i as $t * 0.37,
                 );
                 let matrix = $mat4::from_scale_rotation_translation(scale, rotation, $vec3::ZERO);
-                // Check inputs accepted by the full 4x4 determinant, even near underflow.
-                if matrix.determinant() != 0.0 {
+                // Check inputs accepted by the 3x3 submatrix determinant, even near underflow.
+                if $mat3::from_mat4(matrix).determinant() != 0.0 {
                     let (s, r, t) = matrix.to_scale_rotation_translation();
                     assert!(s.abs_diff_eq(scale, 32.0 * $t::EPSILON * small));
                     assert!(r.is_normalized());
@@ -444,7 +444,6 @@ macro_rules! impl_mat4_tests {
             any(feature = "glam-assert", feature = "debug-glam-assert")
         ))]
         glam_test!(test_mat4_decompose_singular, {
-            // A zero fourth column makes the full matrix singular even when its linear part is not.
             for column in 0..4 {
                 let mut matrix = $mat4::IDENTITY;
                 *matrix.col_mut(column) = $vec4::ZERO;


### PR DESCRIPTION
Use Mat3A or a 3x3 matrix to calculate determinant and scale values when available.
