### PR TITLE
fix(vec): round half-way cases away from zero in the SIMD backends

### DIFF
--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -814,7 +814,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn round(self) -> Self {
-        Self(unsafe { vrndnq_f32(self.0) })
+        Self(unsafe { vrndaq_f32(self.0) })
     }
 
     /// Returns a vector containing the largest integer less than or equal to a number for each

--- a/src/f32/neon/vec4.rs
+++ b/src/f32/neon/vec4.rs
@@ -782,7 +782,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn round(self) -> Self {
-        Self(unsafe { vrndnq_f32(self.0) })
+        Self(unsafe { vrndaq_f32(self.0) })
     }
 
     /// Returns a vector containing the largest integer less than or equal to a number for each

--- a/src/f32/wasm/vec3a.rs
+++ b/src/f32/wasm/vec3a.rs
@@ -784,7 +784,7 @@ impl Vec3A {
     #[inline]
     #[must_use]
     pub fn round(self) -> Self {
-        Self(f32x4_nearest(self.0))
+        Self(crate::wasm::f32x4_round(self.0))
     }
 
     /// Returns a vector containing the largest integer less than or equal to a number for each

--- a/src/f32/wasm/vec4.rs
+++ b/src/f32/wasm/vec4.rs
@@ -765,7 +765,7 @@ impl Vec4 {
     #[inline]
     #[must_use]
     pub fn round(self) -> Self {
-        Self(f32x4_nearest(self.0))
+        Self(crate::wasm::f32x4_round(self.0))
     }
 
     /// Returns a vector containing the largest integer less than or equal to a number for each

--- a/src/sse2.rs
+++ b/src/sse2.rs
@@ -34,6 +34,7 @@ const PS_SIN_COEFFICIENTS1: __m128 = m128_from_f32x4([
     -0.000_185_246_7, /*Est3*/
 ]);
 const PS_ONE: __m128 = m128_from_f32x4([1.0; 4]);
+const PS_HALF: __m128 = m128_from_f32x4([0.5; 4]);
 const PS_TWO_PI: __m128 = m128_from_f32x4([core::f32::consts::TAU; 4]);
 const PS_RECIPROCAL_TWO_PI: __m128 = m128_from_f32x4([0.159_154_94; 4]);
 
@@ -144,8 +145,10 @@ pub(crate) unsafe fn m128_neg_mul_sub(a: __m128, b: __m128, c: __m128) -> __m128
     _mm_sub_ps(c, _mm_mul_ps(a, b))
 }
 
+/// Rounds each lane to the nearest integer, rounding half-way cases to the
+/// nearest even integer.
 #[inline]
-pub(crate) unsafe fn m128_round(v: __m128) -> __m128 {
+pub(crate) unsafe fn m128_round_ties_even(v: __m128) -> __m128 {
     // Based on https://github.com/microsoft/DirectXMath `XMVectorRound`
     let sign = _mm_and_ps(v, PS_SIGN_MASK);
     let s_magic = _mm_or_ps(PS_NO_FRACTION, sign);
@@ -156,6 +159,20 @@ pub(crate) unsafe fn m128_round(v: __m128) -> __m128 {
     let r2 = _mm_andnot_ps(mask, v);
     let r1 = _mm_and_ps(r1, mask);
     _mm_xor_ps(r1, r2)
+}
+
+/// Rounds each lane to the nearest integer, rounding half-way cases away from
+/// zero, matching `f32::round`.
+#[inline]
+pub(crate) unsafe fn m128_round(v: __m128) -> __m128 {
+    // The two roundings only differ on half-way cases that `m128_round_ties_even`
+    // rounded towards zero, and those are exactly the lanes where the difference
+    // between the input and the result is `0.5` with the sign of the input, so
+    // move those one further away from zero.
+    let rounded = m128_round_ties_even(v);
+    let sign = _mm_and_ps(v, PS_SIGN_MASK);
+    let ties_down = _mm_cmpeq_ps(_mm_sub_ps(v, rounded), _mm_or_ps(PS_HALF, sign));
+    _mm_add_ps(rounded, _mm_and_ps(ties_down, _mm_or_ps(PS_ONE, sign)))
 }
 
 #[inline]
@@ -182,7 +199,7 @@ pub(crate) unsafe fn m128_trunc(v: __m128) -> __m128 {
 pub(crate) unsafe fn m128_mod_angles(angles: __m128) -> __m128 {
     // Based on https://github.com/microsoft/DirectXMath `XMVectorModAngles`
     let v = _mm_mul_ps(angles, PS_RECIPROCAL_TWO_PI);
-    let v = m128_round(v);
+    let v = m128_round_ties_even(v);
     m128_neg_mul_sub(PS_TWO_PI, v, angles)
 }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -7,6 +7,27 @@ pub const fn v128_from_f32x4(a: [f32; 4]) -> v128 {
     f32x4(a[0], a[1], a[2], a[3])
 }
 
+const PS_SIGN_MASK: v128 = v128_from_f32x4([-0.0; 4]);
+
+/// Rounds each lane to the nearest integer, rounding half-way cases away from
+/// zero, matching `f32::round`.
+#[inline]
+pub(crate) fn f32x4_round(v: v128) -> v128 {
+    // `f32x4_nearest` rounds half-way cases to the nearest even integer. The two
+    // roundings only differ on half-way cases that it rounded towards zero, and
+    // those are exactly the lanes where the difference between the input and the
+    // result is `0.5` with the sign of the input, so move those one further away
+    // from zero.
+    let rounded = f32x4_nearest(v);
+    let sign = v128_and(v, PS_SIGN_MASK);
+    let ties_down = f32x4_eq(f32x4_sub(v, rounded), v128_or(f32x4_splat(0.5), sign));
+    v128_bitselect(
+        f32x4_add(rounded, v128_or(f32x4_splat(1.0), sign)),
+        rounded,
+        ties_down,
+    )
+}
+
 /// Calculates the vector 3 dot product and returns answer in x lane of v128.
 #[inline(always)]
 pub(crate) fn dot3_in_x(lhs: v128, rhs: v128) -> v128 {

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -2013,11 +2013,11 @@ impl {{ self_t }} {
         {% elif is_sse2 %}
             Self(unsafe { m128_round(self.0) })
         {% elif is_wasm %}
-            Self(f32x4_nearest(self.0))
+            Self(crate::wasm::f32x4_round(self.0))
         {% elif is_coresimd %}
             Self(coresimd::round{{dim}}(self.0))
         {% elif is_neon %}
-            Self(unsafe { vrndnq_f32(self.0) })
+            Self(unsafe { vrndaq_f32(self.0) })
         {% else %}
             unimplemented!()
         {% endif %}

--- a/tests/vec2.rs
+++ b/tests/vec2.rs
@@ -1346,6 +1346,9 @@ macro_rules! impl_vec2_float_tests {
             assert_eq!($vec2::new(0.0, 21.1).round().y, 21.0);
             assert_eq!($vec2::new(0.0, 11.123).round().y, 11.0);
             assert_eq!($vec2::new(0.0, 11.499).round().y, 11.0);
+            // half-way cases round away from zero, not to the nearest even integer
+            assert_eq!($vec2::new(0.5, -0.5).round(), $vec2::new(1.0, -1.0));
+            assert_eq!($vec2::new(2.5, -2.5).round(), $vec2::new(3.0, -3.0));
             assert_eq!(
                 $vec2::new($t::NEG_INFINITY, $t::INFINITY).round(),
                 $vec2::new($t::NEG_INFINITY, $t::INFINITY)

--- a/tests/vec3.rs
+++ b/tests/vec3.rs
@@ -1547,6 +1547,15 @@ macro_rules! impl_vec3_float_tests {
             assert_eq!($vec3::new(0.0, 21.1, 0.0).round().y, 21.0);
             assert_eq!($vec3::new(0.0, 11.123, 0.0).round().y, 11.0);
             assert_eq!($vec3::new(0.0, 11.499, 0.0).round().y, 11.0);
+            // half-way cases round away from zero, not to the nearest even integer
+            assert_eq!(
+                $vec3::new(0.5, -0.5, 2.5).round(),
+                $vec3::new(1.0, -1.0, 3.0)
+            );
+            assert_eq!(
+                $vec3::new(-2.5, 3.5, -3.5).round(),
+                $vec3::new(-3.0, 4.0, -4.0)
+            );
             assert_eq!(
                 $vec3::new($t::NEG_INFINITY, $t::INFINITY, 0.0).round(),
                 $vec3::new($t::NEG_INFINITY, $t::INFINITY, 0.0)

--- a/tests/vec4.rs
+++ b/tests/vec4.rs
@@ -1728,6 +1728,15 @@ macro_rules! impl_vec4_float_tests {
             assert_eq!($vec4::new(0.0, 21.1, 0.0, 0.0).round().y, 21.0);
             assert_eq!($vec4::new(0.0, 0.0, 0.0, 11.123).round().w, 11.0);
             assert_eq!($vec4::new(0.0, 0.0, 11.501, 0.0).round().z, 12.0);
+            // half-way cases round away from zero, not to the nearest even integer
+            assert_eq!(
+                $vec4::new(0.5, -0.5, 2.5, -2.5).round(),
+                $vec4::new(1.0, -1.0, 3.0, -3.0)
+            );
+            assert_eq!(
+                $vec4::new(3.5, -3.5, 4.5, -4.5).round(),
+                $vec4::new(4.0, -4.0, 5.0, -5.0)
+            );
             assert_eq!(
                 $vec4::new($t::NEG_INFINITY, $t::INFINITY, 1.0, -1.0).round(),
                 $vec4::new($t::NEG_INFINITY, $t::INFINITY, 1.0, -1.0)


### PR DESCRIPTION
# Objective

- `Vec3A::round` and `Vec4::round` are documented to round half-way cases away from zero, which is what `f32::round` and the scalar backend do, but the SSE2, NEON and wasm backends round them to the nearest even integer. On aarch64 `Vec3A::new(0.5, -0.5, 2.5).round()` is `(0.0, -0.0, 2.0)` while the scalar `Vec3::new(0.5, -0.5, 2.5).round()` is `(1.0, -1.0, 3.0)`, so the answer depends on the target.

- One line per backend causes it. `templates/vec.rs.tera` line 2020 emits `vrndnq_f32` for NEON, which is FRINTN, round to nearest with ties to even, and line 2016 emits `f32x4_nearest` for wasm, which is ties to even as well. On SSE2, `m128_round` in `src/sse2.rs` line 148 is DirectXMath's `XMVectorRound`, which rounds by adding and subtracting 8388608.0 and therefore follows the current rounding mode, ties to even again. The existing `test_round` cases miss it because 1.5 and -15.5 round the same way under both rules.

## Solution

- NEON uses `vrndaq_f32` (FRINTA), the single instruction that has exactly the documented behaviour, so it is not slower.

- SSE2 keeps the DirectXMath helper under the name `m128_round_ties_even`, which is still what `m128_mod_angles` wants, and `m128_round` corrects it. The two rules differ only on half-way cases that were rounded towards zero, and those are exactly the lanes where the input minus the rounded value is 0.5 with the sign of the input, so those lanes get one more in the direction of the input. That is a compare and two bitwise ops on top of the existing sequence.

- wasm gets the same correction on top of `f32x4_nearest` in a new `f32x4_round` in `src/wasm.rs`. It selects with `v128_bitselect` rather than adding zero to the untouched lanes, so `-0.0` still rounds to `-0.0`.

- The core-simd backend already rounds half-way cases away from zero, so it is unchanged.

## Code generation

- Yes. `templates/vec.rs.tera` was edited and `cargo run --release -p codegen` was run. The generated part of the diff is one line in each of `src/f32/neon/vec3a.rs`, `src/f32/neon/vec4.rs`, `src/f32/wasm/vec3a.rs` and `src/f32/wasm/vec4.rs`. `src/sse2.rs` and `src/wasm.rs` are hand written. `cargo run -p ci -- codegen` passes.

## Testing and linting

- The half-way cases are added to the existing `test_round` in `tests/vec2.rs`, `tests/vec3.rs` and `tests/vec4.rs`. Without the fix, `vec3a::test_round` fails on aarch64 with `left: Vec3A(0.0, -0.0, 2.0)` against `right: Vec3A(1.0, -1.0, 3.0)` and `vec4::test_round` fails on both aarch64 and x86_64. With the fix all three test files pass on aarch64, on x86_64 and with `scalar-math`.

- I also ran a throwaway test comparing `Vec4::splat(v).round()` and `Vec3A::splat(v).round()` against `v.round()` for every 65536th `f32` bit pattern from 0 up to 2^24 in both signs, plus the largest float below 0.5, 2^23, the infinities and NaN. With the change it passes on the scalar, SSE2, NEON, core-simd and wasm backends, and without it the wasm one aborts.

- `cargo run -p ci -- test-features` passes all nine feature sets, and `cargo fmt --all -- --check` and `cargo clippy -p glam --all-targets` are clean. I checked wasm by building the tests for `wasm32-wasip1` with `-C target-feature=+simd128` and running them under node, because the `wasm_bindgen_test` harness in `tests/` needs a browser.
