### PR TITLE
perf: add neon float32x4_t sin implementation.

### DIFF
--- a/src/f32/neon/quat.rs
+++ b/src/f32/neon/quat.rs
@@ -740,10 +740,20 @@ impl Quat {
     fn slerp_impl(self, end: Self, dot: f32, s: f32) -> Self {
         let theta = math::acos_approx(dot);
 
-        let scale1 = math::sin(theta * (1.0 - s));
-        let scale2 = math::sin(theta * s);
-        let theta_sin = math::sin(theta);
-        ((self * scale1) + (end * scale2)) * (1.0 / theta_sin)
+        let coefs = [1.0 - s, s, 1.0, 0.0];
+        unsafe {
+            let tmp = vmulq_f32(vdupq_n_f32(theta), vld1q_f32(coefs.as_ptr()));
+            let tmp = f32x4_sin(tmp);
+
+            let scale1 = vdupq_n_f32(vgetq_lane_f32(tmp, 0));
+            let scale2 = vdupq_n_f32(vgetq_lane_f32(tmp, 1));
+            let theta_sin = vdupq_n_f32(vgetq_lane_f32(tmp, 2));
+
+            Self(vdivq_f32(
+                vaddq_f32(vmulq_f32(self.0, scale1), vmulq_f32(end.0, scale2)),
+                theta_sin,
+            ))
+        }
     }
 
     /// Performs a spherical linear interpolation between `self` and `end`

--- a/src/f32/neon/vec3a.rs
+++ b/src/f32/neon/vec3a.rs
@@ -1326,9 +1326,16 @@ impl Vec3A {
             // Angle between the vectors [0, +π]
             let theta = math::acos_approx(dot);
             // Sine of the angle between vectors [0, 1]
-            let sin_theta = math::sin(theta);
-            let t1 = math::sin(theta * (1.0 - s));
-            let t2 = math::sin(theta * s);
+            let coefs = [1.0 - s, s, 1.0, 0.0];
+            let (sin_theta, t1, t2) = unsafe {
+                let tmp = vmulq_f32(vdupq_n_f32(theta), vld1q_f32(coefs.as_ptr()));
+                let tmp = f32x4_sin(tmp);
+                (
+                    vgetq_lane_f32(tmp, 2), // sin(theta)
+                    vgetq_lane_f32(tmp, 0), // sin(theta * (1.0 - s))
+                    vgetq_lane_f32(tmp, 1), // sin(theta * s)
+                )
+            };
 
             // Interpolate vector lengths
             let result_length = self_length.lerp(rhs_length, s);

--- a/src/neon.rs
+++ b/src/neon.rs
@@ -17,9 +17,9 @@ pub(crate) const fn u32x4_from_array(u32x4: [u32; 4]) -> uint32x4_t {
     unsafe { UnionCast { u32x4 }.u }
 }
 
-const U64X4_NEGATIVE_ZERO: uint32x4_t = u32x4_from_array([0x8000_0000; 4]);
-const U64X4_PI: uint32x4_t = u32x4_from_array([core::f32::consts::PI.to_bits(); 4]);
-const F32X4_HALF_PI: float32x4_t = f32x4_from_array([core::f32::consts::FRAC_PI_2; 4]);
+const U32X4_NEG_ZERO: uint32x4_t = u32x4_from_array([0x8000_0000; 4]);
+const F32X4_PI: float32x4_t = f32x4_from_array([core::f32::consts::PI; 4]);
+const F32X4_FRAC_PI_2: float32x4_t = f32x4_from_array([core::f32::consts::FRAC_PI_2; 4]);
 const F32X4_SIN_COEFFICIENTS0: float32x4_t =
     f32x4_from_array([-0.16666667, 0.008_333_331, -0.00019840874, 2.752_556_2e-6]);
 const F32X4_SIN_COEFFICIENTS1: float32x4_t = f32x4_from_array([
@@ -30,7 +30,7 @@ const F32X4_SIN_COEFFICIENTS1: float32x4_t = f32x4_from_array([
 ]);
 const F32X4_ONE: float32x4_t = f32x4_from_array([1.0; 4]);
 const F32X4_TAU: float32x4_t = f32x4_from_array([core::f32::consts::TAU; 4]);
-const F32X4_RECIPROCAL_TWO_PI: float32x4_t = f32x4_from_array([0.159_154_94; 4]);
+const F32X4_FRAC_1_TAU: float32x4_t = f32x4_from_array([0.159_154_94; 4]);
 
 // #[inline]
 // pub(crate) unsafe fn dot3_in_x(lhs: float32x4_t, rhs: float32x4_t) -> float32x4_t {
@@ -76,7 +76,7 @@ pub(crate) unsafe fn dot4_into_f32x4(lhs: float32x4_t, rhs: float32x4_t) -> floa
 pub(crate) unsafe fn f32x4_mod_angles(angles: float32x4_t) -> float32x4_t {
     // Based on https://github.com/microsoft/DirectXMath `XMVectorModAngles`
     // Modulo the range of the given angles such that -XM_PI <= Angles < XM_PI
-    let mut v = vmulq_f32(angles, F32X4_RECIPROCAL_TWO_PI);
+    let mut v = vmulq_f32(angles, F32X4_FRAC_1_TAU);
     v = vrndnq_f32(v);
     vmlsq_f32(angles, v, F32X4_TAU)
 }
@@ -94,11 +94,11 @@ pub(crate) unsafe fn f32x4_sin(v: float32x4_t) -> float32x4_t {
     let mut x = f32x4_mod_angles(v);
 
     // Map in [-pi/2,pi/2] with sin(y) = sin(x).
-    let sign = vandq_u32(vreinterpretq_u32_f32(x), U64X4_NEGATIVE_ZERO);
-    let c = vorrq_u32(U64X4_PI, sign); // pi when x >= 0, -pi when x < 0
+    let sign = vandq_u32(vreinterpretq_u32_f32(x), U32X4_NEG_ZERO);
+    let c = vorrq_u32(vreinterpretq_u32_f32(F32X4_PI), sign); // pi when x >= 0, -pi when x < 0
     let absx = vabsq_f32(x);
     let rflx = vsubq_f32(vreinterpretq_f32_u32(c), x);
-    let comp = vcleq_f32(absx, F32X4_HALF_PI);
+    let comp = vcleq_f32(absx, F32X4_FRAC_PI_2);
     x = vbslq_f32(comp, x, rflx);
 
     let x2 = vmulq_f32(x, x);

--- a/src/neon.rs
+++ b/src/neon.rs
@@ -1,15 +1,36 @@
 use core::arch::aarch64::*;
 
 union UnionCast {
-    // u32x4: [u32; 4],
+    u32x4: [u32; 4],
     f32x4: [f32; 4],
     v: float32x4_t,
+    u: uint32x4_t,
 }
 
 #[inline]
 pub const fn f32x4_from_array(f32x4: [f32; 4]) -> float32x4_t {
     unsafe { UnionCast { f32x4 }.v }
 }
+
+#[inline]
+pub(crate) const fn u32x4_from_array(u32x4: [u32; 4]) -> uint32x4_t {
+    unsafe { UnionCast { u32x4 }.u }
+}
+
+const U64X4_NEGATIVE_ZERO: uint32x4_t = u32x4_from_array([0x8000_0000; 4]);
+const U64X4_PI: uint32x4_t = u32x4_from_array([core::f32::consts::PI.to_bits(); 4]);
+const F32X4_HALF_PI: float32x4_t = f32x4_from_array([core::f32::consts::FRAC_PI_2; 4]);
+const F32X4_SIN_COEFFICIENTS0: float32x4_t =
+    f32x4_from_array([-0.16666667, 0.008_333_331, -0.00019840874, 2.752_556_2e-6]);
+const F32X4_SIN_COEFFICIENTS1: float32x4_t = f32x4_from_array([
+    -2.388_985_9e-8,
+    -0.16665852,      /*Est1*/
+    0.008_313_95,     /*Est2*/
+    -0.000_185_246_7, /*Est3*/
+]);
+const F32X4_ONE: float32x4_t = f32x4_from_array([1.0; 4]);
+const F32X4_TAU: float32x4_t = f32x4_from_array([core::f32::consts::TAU; 4]);
+const F32X4_RECIPROCAL_TWO_PI: float32x4_t = f32x4_from_array([0.159_154_94; 4]);
 
 // #[inline]
 // pub(crate) unsafe fn dot3_in_x(lhs: float32x4_t, rhs: float32x4_t) -> float32x4_t {
@@ -48,4 +69,80 @@ pub(crate) unsafe fn dot4(lhs: float32x4_t, rhs: float32x4_t) -> f32 {
 pub(crate) unsafe fn dot4_into_f32x4(lhs: float32x4_t, rhs: float32x4_t) -> float32x4_t {
     let dot = dot4(lhs, rhs);
     vld1q_dup_f32(&dot as *const f32)
+}
+
+/// Returns a vector whose components are the corresponding components of Angles modulo 2PI.
+#[inline]
+pub(crate) unsafe fn f32x4_mod_angles(angles: float32x4_t) -> float32x4_t {
+    // Based on https://github.com/microsoft/DirectXMath `XMVectorModAngles`
+    // Modulo the range of the given angles such that -XM_PI <= Angles < XM_PI
+    let mut v = vmulq_f32(angles, F32X4_RECIPROCAL_TWO_PI);
+    v = vrndnq_f32(v);
+    vmlsq_f32(angles, v, F32X4_TAU)
+}
+
+/// Computes the sine of the angle in each lane of `v`. Values outside
+/// the bounds of PI may produce an increasing error as the input angle
+/// drifts from `[-PI, PI]`.
+#[inline]
+pub(crate) unsafe fn f32x4_sin(v: float32x4_t) -> float32x4_t {
+    // Based on https://github.com/microsoft/DirectXMath `XMVectorSin`
+
+    // 11-degree minimax approximation
+
+    // Force the value within the bounds of pi
+    let mut x = f32x4_mod_angles(v);
+
+    // Map in [-pi/2,pi/2] with sin(y) = sin(x).
+    let sign = vandq_u32(vreinterpretq_u32_f32(x), U64X4_NEGATIVE_ZERO);
+    let c = vorrq_u32(U64X4_PI, sign); // pi when x >= 0, -pi when x < 0
+    let absx = vabsq_f32(x);
+    let rflx = vsubq_f32(vreinterpretq_f32_u32(c), x);
+    let comp = vcleq_f32(absx, F32X4_HALF_PI);
+    x = vbslq_f32(comp, x, rflx);
+
+    let x2 = vmulq_f32(x, x);
+
+    // Compute polynomial approximation
+    const SC1: float32x4_t = F32X4_SIN_COEFFICIENTS1;
+    const SC0: float32x4_t = F32X4_SIN_COEFFICIENTS0;
+    let mut v_constants = vdupq_lane_f32(vget_high_f32(SC0), 1);
+    let mut result = vmlaq_lane_f32(v_constants, x2, vget_low_f32(SC1), 0);
+
+    v_constants = vdupq_lane_f32(vget_high_f32(SC0), 0);
+    result = vmlaq_f32(v_constants, result, x2);
+
+    v_constants = vdupq_lane_f32(vget_low_f32(SC0), 1);
+    result = vmlaq_f32(v_constants, result, x2);
+
+    v_constants = vdupq_lane_f32(vget_low_f32(SC0), 0);
+    result = vmlaq_f32(v_constants, result, x2);
+
+    result = vmlaq_f32(F32X4_ONE, result, x2);
+    result = vmulq_f32(result, x);
+
+    result
+}
+
+#[test]
+fn test_neon_f32x4_sin() {
+    use crate::Vec4;
+    use core::f32::consts::PI;
+
+    fn test_neon_f32x4_sin_angle(a: f32) {
+        let v = unsafe { f32x4_sin(vdupq_n_f32(a)) };
+        let v = Vec4(v);
+        let a_sin = a.sin();
+        // dbg!((a, a_sin, v));
+        assert!(v.abs_diff_eq(Vec4::splat(a_sin), 1e-6));
+    }
+
+    let mut a = -PI;
+    let end = PI;
+    let step = PI / 8192.0;
+
+    while a <= end {
+        test_neon_f32x4_sin_angle(a);
+        a += step;
+    }
 }

--- a/templates/quat.rs.tera
+++ b/templates/quat.rs.tera
@@ -924,6 +924,21 @@ impl {{ self_t }} {
                     theta_sin,
                 ))
             }
+        {% elif is_neon %}
+            let coefs = [1.0 - s, s, 1.0, 0.0];
+            unsafe {
+                let tmp = vmulq_f32(vdupq_n_f32(theta), vld1q_f32(coefs.as_ptr()));
+                let tmp = f32x4_sin(tmp);
+
+                let scale1 = vdupq_n_f32(vgetq_lane_f32(tmp, 0));
+                let scale2 = vdupq_n_f32(vgetq_lane_f32(tmp, 1));
+                let theta_sin = vdupq_n_f32(vgetq_lane_f32(tmp, 2));
+
+                Self(vdivq_f32(
+                    vaddq_f32(vmulq_f32(self.0, scale1), vmulq_f32(end.0, scale2)),
+                    theta_sin,
+                ))
+            }
         {% else %}
             let scale1 = math::sin(theta * (1.0 - s));
             let scale2 = math::sin(theta * s);

--- a/templates/vec.rs.tera
+++ b/templates/vec.rs.tera
@@ -2706,6 +2706,17 @@ impl {{ self_t }} {
                     _mm_cvtss_f32(_mm_shuffle_ps(tmp, tmp, 0b01_01_01_01)), // sin(theta * s)
                 )
             };
+            {%- elif is_neon %}
+            let coefs = [1.0 - s, s, 1.0, 0.0];
+            let (sin_theta, t1, t2) = unsafe {
+                let tmp = vmulq_f32(vdupq_n_f32(theta), vld1q_f32(coefs.as_ptr()));
+                let tmp = f32x4_sin(tmp);
+                (
+                    vgetq_lane_f32(tmp, 2), // sin(theta)
+                    vgetq_lane_f32(tmp, 0), // sin(theta * (1.0 - s))
+                    vgetq_lane_f32(tmp, 1), // sin(theta * s)
+                )
+            };
             {%- else %}
             let sin_theta = math::sin(theta);
             let t1 = math::sin(theta * (1.0 - s));


### PR DESCRIPTION
Matches the sse2 version. Only used in Quat and Vec4 slerp.
