### PR TITLE
perf(mat3a): avoid intermediate Mat2 in transform_vector2

### DIFF
--- a/benches/mat3a.rs
+++ b/benches/mat3a.rs
@@ -3,8 +3,9 @@
 mod macros;
 mod support;
 
-use criterion::{criterion_group, criterion_main, Criterion};
-use glam::Mat3A;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use glam::{Mat3A, Vec2};
+use std::hint::black_box;
 use std::ops::Mul;
 use support::*;
 
@@ -56,13 +57,26 @@ bench_binop!(
     from2 => random_vec2
 );
 
-bench_binop!(
-    mat3a_transform_vector2,
-    "mat3a transform vector2",
-    op => transform_vector2,
-    from1 => random_srt_mat3a,
-    from2 => random_vec2
-);
+fn mat3a_transform_vector2(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mat3a transform vector2");
+    let mut rng = PCG32::default();
+    for size in [1, 256] {
+        let inputs: Vec<_> = (0..size)
+            .map(|_| (random_srt_mat3a(&mut rng), random_vec2(&mut rng)))
+            .collect();
+        let mut outputs = vec![Vec2::ZERO; size];
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
+            b.iter(|| {
+                for ((matrix, vector), output) in black_box(&inputs).iter().zip(&mut outputs) {
+                    *output = matrix.transform_vector2(*vector);
+                }
+                black_box(&outputs);
+            });
+        });
+    }
+    group.finish();
+}
 
 criterion_group!(
     benches,

--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -675,7 +675,7 @@ impl Mat3A {
     #[must_use]
     pub fn transform_vector2(&self, rhs: Vec2) -> Vec2 {
         glam_assert!(self.row(2).abs_diff_eq(Vec3A::Z, 1e-6));
-        Mat2::from_cols(self.x_axis.xy(), self.y_axis.xy()) * rhs
+        self.x_axis.xy() * rhs.x + self.y_axis.xy() * rhs.y
     }
 
     /// Creates a left-handed view matrix using a facing direction and an up direction.

--- a/src/f32/neon/mat3a.rs
+++ b/src/f32/neon/mat3a.rs
@@ -693,7 +693,7 @@ impl Mat3A {
     #[must_use]
     pub fn transform_vector2(&self, rhs: Vec2) -> Vec2 {
         glam_assert!(self.row(2).abs_diff_eq(Vec3A::Z, 1e-6));
-        Mat2::from_cols(self.x_axis.xy(), self.y_axis.xy()) * rhs
+        self.x_axis.xy() * rhs.x + self.y_axis.xy() * rhs.y
     }
 
     /// Creates a left-handed view matrix using a facing direction and an up direction.

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -676,7 +676,7 @@ impl Mat3A {
     #[must_use]
     pub fn transform_vector2(&self, rhs: Vec2) -> Vec2 {
         glam_assert!(self.row(2).abs_diff_eq(Vec3A::Z, 1e-6));
-        Mat2::from_cols(self.x_axis.xy(), self.y_axis.xy()) * rhs
+        self.x_axis.xy() * rhs.x + self.y_axis.xy() * rhs.y
     }
 
     /// Creates a left-handed view matrix using a facing direction and an up direction.

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -687,7 +687,7 @@ impl Mat3A {
     #[must_use]
     pub fn transform_vector2(&self, rhs: Vec2) -> Vec2 {
         glam_assert!(self.row(2).abs_diff_eq(Vec3A::Z, 1e-6));
-        Mat2::from_cols(self.x_axis.xy(), self.y_axis.xy()) * rhs
+        self.x_axis.xy() * rhs.x + self.y_axis.xy() * rhs.y
     }
 
     /// Creates a left-handed view matrix using a facing direction and an up direction.

--- a/src/f32/wasm/mat3a.rs
+++ b/src/f32/wasm/mat3a.rs
@@ -685,7 +685,7 @@ impl Mat3A {
     #[must_use]
     pub fn transform_vector2(&self, rhs: Vec2) -> Vec2 {
         glam_assert!(self.row(2).abs_diff_eq(Vec3A::Z, 1e-6));
-        Mat2::from_cols(self.x_axis.xy(), self.y_axis.xy()) * rhs
+        self.x_axis.xy() * rhs.x + self.y_axis.xy() * rhs.y
     }
 
     /// Creates a left-handed view matrix using a facing direction and an up direction.

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -1773,7 +1773,11 @@ impl {{ self_t }} {
     #[must_use]
     pub fn transform_vector2(&self, rhs: {{ vec2_t }}) -> {{ vec2_t }} {
         glam_assert!(self.row(2).abs_diff_eq({{ col_t }}::Z, 1e-6));
+        {%- if self_t == "Mat3A" %}
+        self.x_axis.xy() * rhs.x + self.y_axis.xy() * rhs.y
+        {% else %}
         {{ mat2_t }}::from_cols(self.x_axis.xy(), self.y_axis.xy()) * rhs
+        {% endif %}
     }
 
     /// Creates a left-handed view matrix using a facing direction and an up direction.

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -193,6 +193,57 @@ macro_rules! impl_mat3_tests {
             assert_approx_eq!(result2, (m * $vec2::Y.extend(1.0)).truncate());
         });
 
+        glam_test!(test_transform_vector2_edge_cases, {
+            let tiny = $t::from_bits(1);
+            // Each case specifies the two linear columns, input, and expected output.
+            let cases = [
+                ([2.0, -3.0, 4.0, 5.0], [7.0, -2.0], [6.0, -31.0]),
+                ([-0.0, 0.0, -0.0, -0.0], [1.0, 1.0], [-0.0, 0.0]),
+                ([tiny, tiny, tiny, tiny], [0.5, 0.5], [0.0, 0.0]),
+                ([tiny, tiny, tiny, tiny], [1.0, 1.0], [tiny * 2.0; 2]),
+                ([$t::MAX, 1.0, -$t::MAX, 1.0], [2.0, 2.0], [$t::NAN, 4.0]),
+                (
+                    [1.0, 0.0, 0.0, 1.0],
+                    [$t::INFINITY, 1.0],
+                    [$t::INFINITY, $t::NAN],
+                ),
+                ([$t::NAN, 2.0, 3.0, 4.0], [1.0, 1.0], [$t::NAN, 6.0]),
+            ];
+            for (columns, input, expected) in cases {
+                let matrix = $mat3::from_cols_array(&[
+                    columns[0],
+                    columns[1],
+                    0.0,
+                    columns[2],
+                    columns[3],
+                    0.0,
+                    // Translation must not contribute, even when it is non-finite.
+                    $t::NAN,
+                    $t::INFINITY,
+                    1.0,
+                ]);
+                let result = matrix.transform_vector2($vec2::from_array(input));
+                for (actual, expected) in result.to_array().into_iter().zip(expected) {
+                    if expected.is_nan() {
+                        assert!(actual.is_nan());
+                    } else {
+                        assert_eq!(actual.to_bits(), expected.to_bits());
+                    }
+                }
+            }
+        });
+
+        glam_test!(test_transform_vector2_affine_row, {
+            let vector = $vec2::new(2.0, -3.0);
+            for column in 0..3 {
+                let mut matrix = $mat3::IDENTITY;
+                matrix.col_mut(column).z += 0.5e-6;
+                assert_eq!(matrix.transform_vector2(vector), vector);
+                matrix.col_mut(column).z += 1.0e-3;
+                should_glam_assert!({ matrix.transform_vector2(vector) });
+            }
+        });
+
         glam_test!(test_from_ypr, {
             use glam::EulerRot;
             let zero = deg(0.0);


### PR DESCRIPTION
`Mat3A::transform_vector2` can skip the intermediate `Mat2` and multiply the two linear columns directly.

## Solution

This keeps the existing arithmetic order and affine-row assertion. Templates, generated code, tests, and benchmarks are updated.

Kept this to `Mat3A`: the same change made single-transform `Mat3` timing 4% slower.

## Benchmarks

On my Xeon E5-2696 v4:

| Measurement | Before | After | Change |
|---|---:|---:|---:|
| Single transform | 2.864 ns | 2.611 ns | -8.8% |
| 256-transform batch | 289.829 ns | 252.050 ns | -13.0% |
| Throughput | 883.28 M/s | 1015.67 M/s | +15.0% |
| Cycles/transform | 3.160 | 2.744 | -13.2% |
| Instructions/transform | 12.080 | 10.104 | -16.4% |
| Allocations | 0 | 0 | Unchanged |

Timing: Criterion on Windows. Counters: five alternating, core-pinned runs under WSL. The new loop performs one extra memory read per transform, but total bytes read and written stay unchanged.

## Testing and linting

- Six million comparisons passed: non-NaN outputs matched bit for bit; NaNs matched by classification.
- Regression tests cover signed zero, underflow, overflow, non-finite values, ignored translation, and the affine-row assertion.
- All nine feature configurations, release assertion tests, MSRV, and portable SIMD checks passed.
- Glam-specific Clippy, formatting, and matrix code-generation checks passed.
- Full workspace Clippy wasn't rerun due to the existing Windows CI-tool lint.

🤖 AI disclosure: I used Codex with GPT-6 Astra at xhigh reasoning effort to help identify the optimization and construct the benchmark. I have reviewed and understand the resulting implementation.