### PR TITLE
fix: Align determinant and inverse across backends (#828)

### DIFF
--- a/src/f32/coresimd/mat3a.rs
+++ b/src/f32/coresimd/mat3a.rs
@@ -579,7 +579,7 @@ impl Mat3A {
     #[inline]
     #[must_use]
     pub fn determinant(&self) -> f32 {
-        self.z_axis.dot(self.x_axis.cross(self.y_axis))
+        self.x_axis.dot(self.y_axis.cross(self.z_axis))
     }
 
     /// If `CHECKED` is true then if the determinant is zero this function will return a tuple
@@ -599,7 +599,7 @@ impl Mat3A {
         let tmp0 = self.y_axis.cross(self.z_axis);
         let tmp1 = self.z_axis.cross(self.x_axis);
         let tmp2 = self.x_axis.cross(self.y_axis);
-        let det = self.z_axis.dot(tmp2);
+        let det = self.x_axis.dot(tmp0);
         if CHECKED {
             if det == 0.0 {
                 return (Self::ZERO, false);

--- a/src/f32/coresimd/mat4.rs
+++ b/src/f32/coresimd/mat4.rs
@@ -4,7 +4,6 @@
 use crate::DMat4;
 
 use crate::{
-    coresimd::*,
     euler::{FromEuler, ToEuler},
     f32::math,
     swizzles::*,
@@ -662,7 +661,10 @@ impl Mat4 {
         let addres = subres + mulfacc;
         let detcof = addres * f32x4::from_array([1.0, -1.0, 1.0, -1.0]);
 
-        dot4(self.x_axis.0, detcof)
+        let prod = self.x_axis.0 * detcof;
+        let sub0 = prod + simd_swizzle!(prod, [1, 0, 0, 0]);
+        let add1 = sub0 + simd_swizzle!(prod, [2, 0, 0, 0]);
+        (add1 + simd_swizzle!(prod, [3, 0, 0, 0]))[0]
     }
 
     /// If `CHECKED` is true then if the determinant is zero this function will return a tuple
@@ -805,7 +807,11 @@ impl Mat4 {
         let row1 = simd_swizzle!(inv2, inv3, [0, 0, 4, 4]);
         let row2 = simd_swizzle!(row0, row1, [0, 2, 4, 6]);
 
-        let dot0 = dot4(self.x_axis.0, row2);
+        let prod = self.x_axis.0 * row2;
+        let dot0 = (prod
+            + simd_swizzle!(prod, [1, 0, 0, 0])
+            + simd_swizzle!(prod, [2, 0, 0, 0])
+            + simd_swizzle!(prod, [3, 0, 0, 0]))[0];
 
         if CHECKED {
             if dot0 == 0.0 {

--- a/src/f32/mat3.rs
+++ b/src/f32/mat3.rs
@@ -512,7 +512,7 @@ impl Mat3 {
     #[inline]
     #[must_use]
     pub fn determinant(&self) -> f32 {
-        self.z_axis.dot(self.x_axis.cross(self.y_axis))
+        self.x_axis.dot(self.y_axis.cross(self.z_axis))
     }
 
     /// If `CHECKED` is true then if the determinant is zero this function will return a tuple
@@ -532,7 +532,7 @@ impl Mat3 {
         let tmp0 = self.y_axis.cross(self.z_axis);
         let tmp1 = self.z_axis.cross(self.x_axis);
         let tmp2 = self.x_axis.cross(self.y_axis);
-        let det = self.z_axis.dot(tmp2);
+        let det = self.x_axis.dot(tmp0);
         if CHECKED {
             if det == 0.0 {
                 return (Self::ZERO, false);

--- a/src/f32/neon/mat3a.rs
+++ b/src/f32/neon/mat3a.rs
@@ -597,7 +597,7 @@ impl Mat3A {
     #[inline]
     #[must_use]
     pub fn determinant(&self) -> f32 {
-        self.z_axis.dot(self.x_axis.cross(self.y_axis))
+        self.x_axis.dot(self.y_axis.cross(self.z_axis))
     }
 
     /// If `CHECKED` is true then if the determinant is zero this function will return a tuple
@@ -617,7 +617,7 @@ impl Mat3A {
         let tmp0 = self.y_axis.cross(self.z_axis);
         let tmp1 = self.z_axis.cross(self.x_axis);
         let tmp2 = self.x_axis.cross(self.y_axis);
-        let det = self.z_axis.dot(tmp2);
+        let det = self.x_axis.dot(tmp0);
         if CHECKED {
             if det == 0.0 {
                 return (Self::ZERO, false);

--- a/src/f32/neon/mat4.rs
+++ b/src/f32/neon/mat4.rs
@@ -816,7 +816,17 @@ impl Mat4 {
             let row1 = swizzle0044(inv2, inv3);
             let row2 = swizzle0246(row0, row1);
 
-            let dot0 = dot4(self.x_axis.0, row2);
+            let prod = vmulq_f32(self.x_axis.0, row2);
+            let dot0 = vgetq_lane_f32(
+                vaddq_f32(
+                    vaddq_f32(
+                        vaddq_f32(prod, vdupq_laneq_f32(prod, 1)),
+                        vdupq_laneq_f32(prod, 2),
+                    ),
+                    vdupq_laneq_f32(prod, 3),
+                ),
+                0,
+            );
 
             if CHECKED {
                 if dot0 == 0.0 {

--- a/src/f32/scalar/mat3a.rs
+++ b/src/f32/scalar/mat3a.rs
@@ -580,7 +580,7 @@ impl Mat3A {
     #[inline]
     #[must_use]
     pub fn determinant(&self) -> f32 {
-        self.z_axis.dot(self.x_axis.cross(self.y_axis))
+        self.x_axis.dot(self.y_axis.cross(self.z_axis))
     }
 
     /// If `CHECKED` is true then if the determinant is zero this function will return a tuple
@@ -600,7 +600,7 @@ impl Mat3A {
         let tmp0 = self.y_axis.cross(self.z_axis);
         let tmp1 = self.z_axis.cross(self.x_axis);
         let tmp2 = self.x_axis.cross(self.y_axis);
-        let det = self.z_axis.dot(tmp2);
+        let det = self.x_axis.dot(tmp0);
         if CHECKED {
             if det == 0.0 {
                 return (Self::ZERO, false);

--- a/src/f32/sse2/mat3a.rs
+++ b/src/f32/sse2/mat3a.rs
@@ -591,7 +591,7 @@ impl Mat3A {
     #[inline]
     #[must_use]
     pub fn determinant(&self) -> f32 {
-        self.z_axis.dot(self.x_axis.cross(self.y_axis))
+        self.x_axis.dot(self.y_axis.cross(self.z_axis))
     }
 
     /// If `CHECKED` is true then if the determinant is zero this function will return a tuple
@@ -611,7 +611,7 @@ impl Mat3A {
         let tmp0 = self.y_axis.cross(self.z_axis);
         let tmp1 = self.z_axis.cross(self.x_axis);
         let tmp2 = self.x_axis.cross(self.y_axis);
-        let det = self.z_axis.dot(tmp2);
+        let det = self.x_axis.dot(tmp0);
         if CHECKED {
             if det == 0.0 {
                 return (Self::ZERO, false);

--- a/src/f32/sse2/mat4.rs
+++ b/src/f32/sse2/mat4.rs
@@ -6,7 +6,6 @@ use crate::DMat4;
 use crate::{
     euler::{FromEuler, ToEuler},
     f32::math,
-    sse2::*,
     swizzles::*,
     EulerRot, Mat3, Mat3A, Quat, Vec3, Vec3A, Vec4,
 };
@@ -675,7 +674,10 @@ impl Mat4 {
             let addres = _mm_add_ps(subres, mulfacc);
             let detcof = _mm_mul_ps(addres, _mm_setr_ps(1.0, -1.0, 1.0, -1.0));
 
-            dot4(self.x_axis.0, detcof)
+            let prod = _mm_mul_ps(self.x_axis.0, detcof);
+            let sub0 = _mm_add_ps(prod, _mm_shuffle_ps(prod, prod, 0b00_00_00_01));
+            let add1 = _mm_add_ps(sub0, _mm_shuffle_ps(prod, prod, 0b00_00_00_10));
+            _mm_cvtss_f32(_mm_add_ps(add1, _mm_shuffle_ps(prod, prod, 0b00_00_00_11)))
         }
     }
 
@@ -820,7 +822,14 @@ impl Mat4 {
             let row1 = _mm_shuffle_ps(inv2, inv3, 0b00_00_00_00);
             let row2 = _mm_shuffle_ps(row0, row1, 0b10_00_10_00);
 
-            let dot0 = dot4(self.x_axis.0, row2);
+            let prod = _mm_mul_ps(self.x_axis.0, row2);
+            let dot0 = _mm_cvtss_f32(_mm_add_ps(
+                _mm_add_ps(
+                    _mm_add_ps(prod, _mm_shuffle_ps(prod, prod, 0b00_00_00_01)),
+                    _mm_shuffle_ps(prod, prod, 0b00_00_00_10),
+                ),
+                _mm_shuffle_ps(prod, prod, 0b00_00_00_11),
+            ));
 
             if CHECKED {
                 if dot0 == 0.0 {

--- a/src/f32/wasm/mat3a.rs
+++ b/src/f32/wasm/mat3a.rs
@@ -589,7 +589,7 @@ impl Mat3A {
     #[inline]
     #[must_use]
     pub fn determinant(&self) -> f32 {
-        self.z_axis.dot(self.x_axis.cross(self.y_axis))
+        self.x_axis.dot(self.y_axis.cross(self.z_axis))
     }
 
     /// If `CHECKED` is true then if the determinant is zero this function will return a tuple
@@ -609,7 +609,7 @@ impl Mat3A {
         let tmp0 = self.y_axis.cross(self.z_axis);
         let tmp1 = self.z_axis.cross(self.x_axis);
         let tmp2 = self.x_axis.cross(self.y_axis);
-        let det = self.z_axis.dot(tmp2);
+        let det = self.x_axis.dot(tmp0);
         if CHECKED {
             if det == 0.0 {
                 return (Self::ZERO, false);

--- a/src/f32/wasm/mat4.rs
+++ b/src/f32/wasm/mat4.rs
@@ -672,7 +672,10 @@ impl Mat4 {
         let addres = f32x4_add(subres, mulfacc);
         let detcof = f32x4_mul(addres, f32x4(1.0, -1.0, 1.0, -1.0));
 
-        dot4(self.x_axis.0, detcof)
+        let prod = f32x4_mul(self.x_axis.0, detcof);
+        let sub0 = f32x4_add(prod, i32x4_shuffle::<1, 0, 0, 0>(prod, prod));
+        let add1 = f32x4_add(sub0, i32x4_shuffle::<2, 0, 0, 0>(prod, prod));
+        f32x4_extract_lane::<0>(f32x4_add(add1, i32x4_shuffle::<3, 0, 0, 0>(prod, prod)))
     }
 
     /// If `CHECKED` is true then if the determinant is zero this function will return a tuple
@@ -815,7 +818,14 @@ impl Mat4 {
         let row1 = i32x4_shuffle::<0, 0, 4, 4>(inv2, inv3);
         let row2 = i32x4_shuffle::<0, 2, 4, 6>(row0, row1);
 
-        let dot0 = dot4(self.x_axis.0, row2);
+        let prod = f32x4_mul(self.x_axis.0, row2);
+        let dot0 = f32x4_extract_lane::<0>(f32x4_add(
+            f32x4_add(
+                f32x4_add(prod, i32x4_shuffle::<1, 0, 0, 0>(prod, prod)),
+                i32x4_shuffle::<2, 0, 0, 0>(prod, prod),
+            ),
+            i32x4_shuffle::<3, 0, 0, 0>(prod, prod),
+        ));
 
         if CHECKED {
             if dot0 == 0.0 {

--- a/src/f64/dmat3.rs
+++ b/src/f64/dmat3.rs
@@ -513,7 +513,7 @@ impl DMat3 {
     #[inline]
     #[must_use]
     pub fn determinant(&self) -> f64 {
-        self.z_axis.dot(self.x_axis.cross(self.y_axis))
+        self.x_axis.dot(self.y_axis.cross(self.z_axis))
     }
 
     /// If `CHECKED` is true then if the determinant is zero this function will return a tuple
@@ -533,7 +533,7 @@ impl DMat3 {
         let tmp0 = self.y_axis.cross(self.z_axis);
         let tmp1 = self.z_axis.cross(self.x_axis);
         let tmp2 = self.x_axis.cross(self.y_axis);
-        let det = self.z_axis.dot(tmp2);
+        let det = self.x_axis.dot(tmp0);
         if CHECKED {
             if det == 0.0 {
                 return (Self::ZERO, false);

--- a/templates/coresimd.rs.tera
+++ b/templates/coresimd.rs.tera
@@ -237,7 +237,9 @@
     let row1 = simd_swizzle!(inv2, inv3, [0, 0, 4, 4]);
     let row2 = simd_swizzle!(row0, row1, [0, 2, 4, 6]);
 
-    let dot0 = dot4(self.x_axis.0, row2);
+    let prod = self.x_axis.0 * row2;
+    let dot0 = (prod + simd_swizzle!(prod, [1, 0, 0, 0]) + simd_swizzle!(prod, [2, 0, 0, 0])
+        + simd_swizzle!(prod, [3, 0, 0, 0]))[0];
 
     if CHECKED {
         if dot0 == 0.0 {

--- a/templates/mat.rs.tera
+++ b/templates/mat.rs.tera
@@ -87,12 +87,8 @@ use crate::{
     Mat{{ dim }},
 {% endif %}
 {% if self_t == "Mat4" %}
-    {% if is_sse2 %}
-        sse2::*,
-    {% elif is_wasm %}
+    {% if is_wasm %}
         wasm::*,
-    {% elif is_coresimd %}
-        coresimd::*,
     {% elif is_neon %}
         neon::*,
     {% endif %}
@@ -1332,7 +1328,10 @@ impl {{ self_t }} {
                 let addres = _mm_add_ps(subres, mulfacc);
                 let detcof = _mm_mul_ps(addres, _mm_setr_ps(1.0, -1.0, 1.0, -1.0));
 
-                dot4(self.x_axis.0, detcof)
+                let prod = _mm_mul_ps(self.x_axis.0, detcof);
+                let sub0 = _mm_add_ps(prod, _mm_shuffle_ps(prod, prod, 0b00_00_00_01));
+                let add1 = _mm_add_ps(sub0, _mm_shuffle_ps(prod, prod, 0b00_00_00_10));
+                _mm_cvtss_f32(_mm_add_ps(add1, _mm_shuffle_ps(prod, prod, 0b00_00_00_11)))
             }
         {% elif self_t == "Mat4" and is_wasm %}
             // Based on https://github.com/g-truc/glm `glm_mat4_determinant`
@@ -1367,7 +1366,10 @@ impl {{ self_t }} {
             let addres = f32x4_add(subres, mulfacc);
             let detcof = f32x4_mul(addres, f32x4(1.0, -1.0, 1.0, -1.0));
 
-            dot4(self.x_axis.0, detcof)
+            let prod = f32x4_mul(self.x_axis.0, detcof);
+            let sub0 = f32x4_add(prod, i32x4_shuffle::<1, 0, 0, 0>(prod, prod));
+            let add1 = f32x4_add(sub0, i32x4_shuffle::<2, 0, 0, 0>(prod, prod));
+            f32x4_extract_lane::<0>(f32x4_add(add1, i32x4_shuffle::<3, 0, 0, 0>(prod, prod)))
         {% elif self_t == "Mat4" and is_coresimd %}
             // Based on https://github.com/g-truc/glm `glm_mat4_determinant`
             let swp2a = simd_swizzle!(self.z_axis.0, [2, 1, 1, 0]);
@@ -1401,7 +1403,10 @@ impl {{ self_t }} {
             let addres = subres + mulfacc;
             let detcof = addres * f32x4::from_array([1.0, -1.0, 1.0, -1.0]);
 
-            dot4(self.x_axis.0, detcof)
+            let prod = self.x_axis.0 * detcof;
+            let sub0 = prod + simd_swizzle!(prod, [1, 0, 0, 0]);
+            let add1 = sub0 + simd_swizzle!(prod, [2, 0, 0, 0]);
+            (add1 + simd_swizzle!(prod, [3, 0, 0, 0]))[0]
         {#
         // neon implementation is slower than scalar
         // {% elif self_t == "Mat4" and is_neon %}
@@ -1474,7 +1479,7 @@ impl {{ self_t }} {
         {% elif dim == 2 %}
             self.x_axis.x * self.y_axis.y - self.x_axis.y * self.y_axis.x
         {% elif dim == 3 %}
-            self.z_axis.dot(self.x_axis.cross(self.y_axis))
+            self.x_axis.dot(self.y_axis.cross(self.z_axis))
         {% elif dim == 4 %}
             let (m00, m01, m02, m03) = self.x_axis.into();
             let (m10, m11, m12, m13) = self.y_axis.into();
@@ -1611,7 +1616,7 @@ impl {{ self_t }} {
             let tmp0 = self.y_axis.cross(self.z_axis);
             let tmp1 = self.z_axis.cross(self.x_axis);
             let tmp2 = self.x_axis.cross(self.y_axis);
-            let det = self.z_axis.dot(tmp2);
+            let det = self.x_axis.dot(tmp0);
             if CHECKED {
                 if det == 0.0 {
                     return (Self::ZERO, false);

--- a/templates/neon.rs.tera
+++ b/templates/neon.rs.tera
@@ -154,7 +154,14 @@
         let row1 = swizzle0044(inv2, inv3);
         let row2 = swizzle0246(row0, row1);
 
-        let dot0 = dot4(self.x_axis.0, row2);
+        let prod = vmulq_f32(self.x_axis.0, row2);
+        let dot0 = vgetq_lane_f32(
+            vaddq_f32(
+                vaddq_f32(vaddq_f32(prod, vdupq_laneq_f32(prod, 1)), vdupq_laneq_f32(prod, 2)),
+                vdupq_laneq_f32(prod, 3),
+            ),
+            0,
+        );
 
         if CHECKED {
             if dot0 == 0.0 {

--- a/templates/sse2.rs.tera
+++ b/templates/sse2.rs.tera
@@ -126,7 +126,14 @@
         let row1 = _mm_shuffle_ps(inv2, inv3, 0b00_00_00_00);
         let row2 = _mm_shuffle_ps(row0, row1, 0b10_00_10_00);
 
-        let dot0 = dot4(self.x_axis.0, row2);
+        let prod = _mm_mul_ps(self.x_axis.0, row2);
+        let dot0 = _mm_cvtss_f32(_mm_add_ps(
+            _mm_add_ps(
+                _mm_add_ps(prod, _mm_shuffle_ps(prod, prod, 0b00_00_00_01)),
+                _mm_shuffle_ps(prod, prod, 0b00_00_00_10),
+            ),
+            _mm_shuffle_ps(prod, prod, 0b00_00_00_11),
+        ));
 
         if CHECKED {
             if dot0 == 0.0 {

--- a/templates/wasm.rs.tera
+++ b/templates/wasm.rs.tera
@@ -125,7 +125,14 @@
     let row1 = i32x4_shuffle::<0, 0, 4, 4>(inv2, inv3);
     let row2 = i32x4_shuffle::<0, 2, 4, 6>(row0, row1);
 
-    let dot0 = dot4(self.x_axis.0, row2);
+    let prod = f32x4_mul(self.x_axis.0, row2);
+    let dot0 = f32x4_extract_lane::<0>(f32x4_add(
+        f32x4_add(
+            f32x4_add(prod, i32x4_shuffle::<1, 0, 0, 0>(prod, prod)),
+            i32x4_shuffle::<2, 0, 0, 0>(prod, prod),
+        ),
+        i32x4_shuffle::<3, 0, 0, 0>(prod, prod),
+    ));
 
     if CHECKED {
         if dot0 == 0.0 {

--- a/tests/mat3.rs
+++ b/tests/mat3.rs
@@ -282,6 +282,67 @@ macro_rules! impl_mat3_tests {
             );
         });
 
+        glam_test!(test_affine_determinant_and_inverse_consistency, {
+            // For an affine transform M = [A t; 0 1], det(M) = det(A), and the
+            // 3x3 block of M^-1 is A^-1. The 3x3 family and all Mat4 backends
+            // must agree bit-exactly on both.
+            let mut checked = 0;
+            for i in 0..64 {
+                let rotation = $quat::from_euler(
+                    glam::EulerRot::XYZ,
+                    i as $t * 0.13,
+                    i as $t * 0.29,
+                    i as $t * 0.37,
+                );
+                let scale = $vec3::new(1.0, 1.5, 3.0);
+                let translation = $vec3::new(-0.0, i as $t, -1.0e10);
+                let matrix = $mat4::from_scale_rotation_translation(scale, rotation, translation);
+                let linear = $mat3::from_mat4(matrix);
+                let det = linear.determinant();
+                assert_eq!(
+                    det.to_bits(),
+                    matrix.determinant().to_bits(),
+                    "Mat3/Mat4 determinant mismatch"
+                );
+                assert_eq!(
+                    linear.inverse(),
+                    $mat3::from_mat4(matrix.inverse()),
+                    "Mat3/Mat4 inverse mismatch"
+                );
+                if det != 0.0 {
+                    checked += 1;
+                }
+            }
+            assert!(checked > 0);
+
+            // Embedded 2D affine (z_axis = (0, 0, 1)): its Mat3 determinant
+            // collapses to the 2x2 determinant, so Mat2 must agree bit-exactly
+            // (Mat2 has its own SIMD implementation on some backends).
+            for i in 0..64 {
+                let angle = i as $t * 0.13;
+                let (sin, cos) = angle.sin_cos();
+                // Rotation-style and general (non-rotation) 2D linear parts,
+                // including a negative-determinant case.
+                let (x0, x1, y0, y1) = match i % 4 {
+                    0 => (cos, sin, -sin * 4.0, cos * 4.0),
+                    1 => (1.3, 0.7, -2.7, 0.9),
+                    2 => (0.6, -1.1, 2.4, 0.5),
+                    _ => (1.0, 0.0, 0.0, -1.0),
+                };
+                let m2 = $mat2::from_cols($vec2::new(x0, x1), $vec2::new(y0, y1));
+                let m3 = $mat3::from_cols(
+                    $newvec3(x0, x1, 0.0),
+                    $newvec3(y0, y1, 0.0),
+                    $newvec3(0.0, 0.0, 1.0),
+                );
+                assert_eq!(
+                    m2.determinant().to_bits(),
+                    m3.determinant().to_bits(),
+                    "Mat2/Mat3 determinant mismatch"
+                );
+            }
+        });
+
         glam_test!(test_mat3_inverse, {
             assert_eq!(None, $mat3::ZERO.try_inverse());
             assert_eq!($mat3::ZERO, $mat3::ZERO.inverse_or_zero());


### PR DESCRIPTION
Fixes #828.

For an affine transform M = [A t; 0 1], det(M) = det(A) and the 3x3 block of M^-1 is A^-1. Before this, the 3x3 determinant used z_axis dot (x_axis cross y_axis) while scalar Mat4 cofactor-expands along the first column, so the two disagreed at the ulp level and could contradict each other near underflow (nonzero vs zero).

The SIMD Mat4 determinant and inverse summed their cofactor expansion pairwise, `(p0 + p2) + (p1 + p3)` via dot4, while the scalar backend accumulates serially, `((p0 + p1) + p2) + p3`. Both now use the serial order, which costs 1 or 2 extra instructions per call but makes scalar and SIMD results identical. Exact-zero components can still differ in the sign of zero, which compares equal under `==`.

Adds a regression test covering Mat2/Mat3/Mat3A/DMat3 against Mat4 for affine determinant and inverse consistency.