### PR TITLE
ci: run release-plz semver check on nightly

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -46,8 +46,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
           submodules: true # tools/codegen is a workspace member submodule
-      - run: rustup update --no-self-update stable
-      - run: rustup default stable
+      - run: rustup update --no-self-update nightly
+      - run: rustup default nightly
       - uses: release-plz/action@v0.5
         with:
           command: release-pr


### PR DESCRIPTION
## Summary

Fixes the Release-plz workflow failing since rustc 1.98 (`#837` CI reds).

cargo-semver-checks (invoked by release-plz) builds the crate with all
features, including `core-simd`, which enables bytemuck's nightly-only
`nightly_portable_simd` feature. Those bytemuck impls are
rustversion-date-gated, and on stable rustversion always selects the
pre-2026 impl referencing `core::simd::LaneCount`/`SupportedLaneCount`,
which rustc 1.98 removed from `core::simd`. Result: semver check fails
with `E0425`/`E0405` and release-plz aborts ("failed to determine next
versions").

## Change

Run the `release-plz-pr` job on nightly, matching glam's own core-simd
CI (ci.yml already tests `core-simd` on nightly). The `release-plz
release` job stays on stable.

## Notes

Long-term fix upstream: release-plz has no way to exclude features from
its semver check (`cargo-semver-checks` supports `--default-features`,
but release-plz doesn't expose it); bytemuck's rustversion date-gate is
also broken on stable. Neither is fixable from glam.